### PR TITLE
[patch] Add skipPreCheck to launchUpgradePipeline

### DIFF
--- a/src/mas/devops/tekton.py
+++ b/src/mas/devops/tekton.py
@@ -241,6 +241,7 @@ def testCLI() -> None:
 
 def launchUpgradePipeline(dynClient: DynamicClient,
                           instanceId: str,
+                          skipPreCheck: bool = False,
                           masChannel: str = "") -> str:
     """
     Create a PipelineRun to upgrade the chosen MAS instance
@@ -257,6 +258,7 @@ def launchUpgradePipeline(dynClient: DynamicClient,
     renderedTemplate = template.render(
         timestamp=timestamp,
         mas_instance_id=instanceId,
+        skip_pre_check=skipPreCheck,
         mas_channel=masChannel
     )
     pipelineRun = yaml.safe_load(renderedTemplate)


### PR DESCRIPTION
Adding skipPreCheck to `launchUpgradePipeline` arguments - keeping it false as a default which is the same default set in the cli and this way won't break anyone using the cli before the change proposed at  https://github.com/ibm-mas/cli/pull/1089

The `pipelinerun-upgrade.yml.j2` template already looks for the SkipPreCheck so no change needed there https://github.com/ibm-mas/python-devops/blob/e946b05f0723ca45d728b9456db322f76c607632/src/mas/devops/templates/pipelinerun-install.yml.j2#L26

For https://jsw.ibm.com/browse/MASCORE-3216

See slack thread at https://ibm-watson-iot.slack.com/archives/CNDB5GZ3P/p1720020453530109