### PR TITLE
[patch] Support manual certificate management

### DIFF
--- a/src/mas/devops/tekton.py
+++ b/src/mas/devops/tekton.py
@@ -134,7 +134,7 @@ def preparePipelinesNamespace(dynClient: DynamicClient, instanceId: str=None, st
                 logger.debug(configPVC)
                 sleep(15)
 
-def prepareInstallSecrets(dynClient: DynamicClient, instanceId: str, slsLicenseFile: str, additionalConfigs: dict=None, podTemplates: str=None) -> None:
+def prepareInstallSecrets(dynClient: DynamicClient, instanceId: str, slsLicenseFile: str, additionalConfigs: dict=None, certs: str=None, podTemplates: str=None) -> None:
     namespace=f"mas-{instanceId}-pipelines"
     secretsAPI = dynClient.resources.get(api_version="v1", kind="Secret")
 
@@ -177,14 +177,15 @@ def prepareInstallSecrets(dynClient: DynamicClient, instanceId: str, slsLicenseF
     except NotFoundError:
         pass
 
-    certs={
-        "apiVersion": "v1",
-        "kind": "Secret",
-        "type": "Opaque",
-        "metadata": {
-            "name": "pipeline-certificates"
+    if certs is None:
+        certs={
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "type": "Opaque",
+            "metadata": {
+                "name": "pipeline-certificates"
+            }
         }
-    }
     secretsAPI.create(body=certs, namespace=namespace)
 
     # 4. Secret/pipeline-pod-templates

--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -435,6 +435,10 @@ spec:
     - name: mas_trust_default_cas
       value: "{{ mas_trust_default_cas }}"
 {%- endif %}
+{%- if mas_config_dir is defined %}
+    - name: mas_config_dir
+      value: "{{ mas_config_dir }}"
+{%- endif %}
 {%- if mas_manual_cert_mgmt is defined %}
     - name: mas_manual_cert_mgmt
       value: "{{ mas_manual_cert_mgmt }}"

--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -435,6 +435,10 @@ spec:
     - name: mas_trust_default_cas
       value: "{{ mas_trust_default_cas }}"
 {%- endif %}
+{%- if mas_manual_cert_mgmt is defined %}
+    - name: mas_manual_cert_mgmt
+      value: "{{ mas_manual_cert_mgmt }}"
+{%- endif %}
 {%- if enable_ipv6 is defined %}
     - name: enable_ipv6
       value: "{{ enable_ipv6 }}"

--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -435,10 +435,6 @@ spec:
     - name: mas_trust_default_cas
       value: "{{ mas_trust_default_cas }}"
 {%- endif %}
-{%- if mas_config_dir is defined %}
-    - name: mas_config_dir
-      value: "{{ mas_config_dir }}"
-{%- endif %}
 {%- if mas_manual_cert_mgmt is defined %}
     - name: mas_manual_cert_mgmt
       value: "{{ mas_manual_cert_mgmt }}"


### PR DESCRIPTION
This python-devops change will be used by the changes in mas/cli PR: https://github.com/ibm-mas/cli/pull/1112

1. Modify the function to take one more parameter - this parameter provides the manual certificate provided by the customer 
2. Add if condition to allow dummy certificate to be used when manual certificates are not provided. 
3. Update pipeline to allow mas_manual_cert_mgmt - manual certificates path to be passed on from cli

https://jsw.ibm.com/browse/MASCORE-3152
https://jsw.ibm.com/browse/MASCORE-3153
https://jsw.ibm.com/browse/MASCORE-2795