### PR TITLE
[patch] Add missing skip-pre-check to upgrade template

### DIFF
--- a/src/mas/devops/templates/pipelinerun-upgrade.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-upgrade.yml.j2
@@ -14,7 +14,16 @@ spec:
     pipeline: "10h"
 
   params:
+    # Target MAS Instance
+    # -------------------------------------------------------------------------
     - name: mas_instance_id
       value: "{{ mas_instance_id }}"
     - name: mas_channel
       value: "{{ mas_channel }}"
+
+{%- if skip_pre_check is defined and skip_pre_check != "" %}
+    # Skip pre-check
+    # -------------------------------------------------------------------------
+    - name: skip_pre_check
+      value: "{{ skip_pre_check }}"
+{%- endif %}


### PR DESCRIPTION
As reported in https://github.com/ibm-mas/cli/issues/1107 we are not passing the `--skip-pre-check` flag right through to the tekton pipelinerun when starting an upgrade from the CLI, the flag is being dropped in `launchUpgradePipeline()`