### PR TITLE
[minor] Allow Suite SSO CR settings to be configured at install time - MASCORE-2125

### DIFF
--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -409,6 +409,18 @@ spec:
 
     # MAS Core
     # -------------------------------------------------------------------------
+    - name: idle_timeout
+      value: "{{ idle_timeout }}"
+    - name: idp_session_timeout
+      value: "{{ idp_session_timeout }}"
+    - name: access_token_timeout
+      value: "{{ access_token_timeout }}"
+    - name: refresh_token_timeout
+      value: "{{ refresh_token_timeout }}"
+    - name: default_idp
+      value: "{{ default_idp }}"
+    - name: seamless_login
+      value: "{{ seamless_login }}"
     - name: mas_instance_id
       value: "{{ mas_instance_id }}"
 {%- if mas_wipe_mongo_data is defined and mas_wipe_mongo_data != "" %}


### PR DESCRIPTION
## Description
This PR enables the configuration of the suite SSO CR setting at installation time via CLI, ensuring that the parameters are correctly passed through the pipelines.

## Pull request dependency
https://github.com/ibm-mas/ansible-devops/pull/1389

## Related Issues
- https://jsw.ibm.com/browse/MASCORE-2125

## How Has This Been Tested?
I set up a personal FYRE environment and followed the MAS installation process to configure both default and personal settings. Please refer to the images below for details:
![image](https://github.com/user-attachments/assets/0661fc10-d6f2-41db-a789-0d221c7d97e7)
![image](https://github.com/user-attachments/assets/8e265967-7c40-42ec-bb23-569323b69e07)
![image](https://github.com/user-attachments/assets/1323d007-6827-4a3c-b05d-788dbbded726)
![image](https://github.com/user-attachments/assets/331f220e-adba-4eb9-863a-087844e01489)
![image](https://github.com/user-attachments/assets/5fbeef21-8b54-4f48-ace6-844a42533e4b)

