### PR TITLE
[patch] Close timing window when checking deployment status

### DIFF
--- a/src/mas/devops/ocp.py
+++ b/src/mas/devops/ocp.py
@@ -107,7 +107,10 @@ def waitForDeployment(dynClient: DynamicClient, namespace: str, deploymentName: 
         retries += 1
         try:
             deployment = deploymentAPI.get(name=deploymentName, namespace=namespace)
-            if deployment.status.readyReplicas > 0:
+            if deployment.status.readyReplicas is not None and deployment.status.readyReplicas > 0:
+                # Depending on how early we are checking the deployment the status subresource may not
+                # have even been initialized yet, hence the check for "is not None" to avoid a
+                # NoneType and int comparison TypeError
                 foundReadyDeployment = True
             else:
                 logger.debug("Waiting 5s for deployment {deploymentName} to be ready before checking again ...")


### PR DESCRIPTION
It's possible to check the status of the deployment between the deployment existing and the status subresource being initialized, when this happens a `TypeError` is raised due to the NoneType and int comparison being performed.  This update adds a check that the status.readyReplicas has been initialized.