### PR TITLE
[minor] Support insecure_skip_tls_verify for connect

### DIFF
--- a/src/mas/devops/ocp.py
+++ b/src/mas/devops/ocp.py
@@ -19,7 +19,7 @@ from openshift.dynamic.exceptions import NotFoundError
 logger = logging.getLogger(__name__)
 
 
-def connect(server: str, token: str) -> bool:
+def connect(server: str, token: str, skipVerify: bool=False) -> bool:
     """
     Connect to target OCP
     """
@@ -40,7 +40,8 @@ def connect(server: str, token: str) -> bool:
     )
     conf.set_cluster(
         name='my-cluster',
-        server=server
+        server=server,
+        insecure_skip_tls_verify=skipVerify
     )
     conf.set_context(
         name='my-context',


### PR DESCRIPTION
Adds the ability to disable TLS certification verification when connecting to a cluster, e.g. without this we can not use the CLI on FYRE because it uses self-signed certificates.

![image](https://github.com/user-attachments/assets/98712203-a149-4253-a3e6-274a233a244b)

Part of the resolution for:
- https://github.com/ibm-mas/cli/issues/1133
