### PR TITLE
[patch] Pass a new parameter in the install pipeline to control walkme setting

### DIFF
--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -500,6 +500,10 @@ spec:
     - name: mas_superuser_password
       value: "{{ mas_superuser_password }}"
 {%- endif %}
+{%- if mas_enable_walkme is defined and mas_enable_walkme != "" %}
+    - name: mas_enable_walkme
+      value: "{{ mas_enable_walkme }}"
+{%- endif %}
 
     # MAS Workspace
     # -------------------------------------------------------------------------


### PR DESCRIPTION
There is a system setting for "Guided Tours" (spec->settings->walkme) in Suite CR. It is enabled by default and can be configured from the admin UI. Due to the pop of "what's new" some of the UI test cases from Manage are failing, hence, that needs to be turned off for all fvt environments by default. As a fix, an environment variable (MAS_ENABLE_WALKME) has been introduced to control the 'walkme' setting. FVT pipelines need to use this env to disable the setting.

Testing: Changes have been tested locally as well as on the pfvt (fyre-envs) env.

Bug details and snap shots of the FVT run can be found here: MASCORE-3444

Reference to ansible-devops & cli changes: 

> https://github.com/ibm-mas/ansible-devops/pull/1409

> https://github.com/ibm-mas/cli/pull/1168