### PR TITLE
[patch] Align base language variable names in PipelineRun template

### DIFF
--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -589,11 +589,11 @@ spec:
     - name: mas_app_settings_server_bundles_size
       value: "{{ mas_app_settings_server_bundles_size }}"
   {%- endif %}
-  {%- if mas_app_settings_base_language is defined and mas_app_settings_base_language != "" %}
-    - name: mas_app_settings_base_language
-      value: "{{ mas_app_settings_base_language }}"
-    - name: mas_app_settings_secondary_languages
-      value: "{{ mas_app_settings_secondary_languages }}"
+  {%- if mas_app_settings_base_lang is defined and mas_app_settings_base_lang != "" %}
+    - name: mas_app_settings_base_lang
+      value: "{{ mas_app_settings_base_lang }}"
+    - name: mas_app_settings_secondary_langs
+      value: "{{ mas_app_settings_secondary_langs }}"
   {%- endif %}
   {%- if mas_app_settings_server_timezone is defined and mas_app_settings_server_timezone != "" %}
     - name: mas_app_settings_server_timezone


### PR DESCRIPTION
For ibm-mas/cli#1216

Corresponding issues:
- https://github.com/ibm-mas/ansible-devops/pull/1439
- https://github.com/ibm-mas/cli/pull/1217

Aligning variable name usage across our devops tools:
- Any instance of `mas_app_settings_base_language` has been changed to `mas_app_settings_base_lang`
- Any instance of `mas_app_settings_secondary_languages` has been changed to `mas_app_settings_secondary_langs`