### PR TITLE
[patch] Check for existing OpenShift Pipelines subscription

### DIFF
--- a/src/mas/devops/ocp.py
+++ b/src/mas/devops/ocp.py
@@ -153,3 +153,12 @@ def getStorageClasses(dynClient: DynamicClient) -> list:
 
 def isSNO(dynClient: DynamicClient) -> bool:
     return len(getNodes(dynClient)) == 1
+
+def crdExists(dynClient: DynamicClient, crdName: str) -> bool:
+    crdAPI = dynClient.resources.get(api_version="apiextensions.k8s.io/v1", kind="CustomResourceDefinition")
+    try:
+        crd = crdAPI.get(name=crdName)
+        logger.info(f"Found existing crd: {crd.metadata.name}")
+        return True
+    except NotFoundError:
+        return False

--- a/src/mas/devops/ocp.py
+++ b/src/mas/devops/ocp.py
@@ -158,7 +158,8 @@ def crdExists(dynClient: DynamicClient, crdName: str) -> bool:
     crdAPI = dynClient.resources.get(api_version="apiextensions.k8s.io/v1", kind="CustomResourceDefinition")
     try:
         crd = crdAPI.get(name=crdName)
-        logger.info(f"Found existing crd: {crd.metadata.name}. Hence, skipping the step to create new subscription.")
+        logger.debug(f"CRD does exist: {crdName}")
         return True
     except NotFoundError:
+        logger.debug(f"CRD does not exist: {crdName}")
         return False

--- a/src/mas/devops/ocp.py
+++ b/src/mas/devops/ocp.py
@@ -158,7 +158,7 @@ def crdExists(dynClient: DynamicClient, crdName: str) -> bool:
     crdAPI = dynClient.resources.get(api_version="apiextensions.k8s.io/v1", kind="CustomResourceDefinition")
     try:
         crd = crdAPI.get(name=crdName)
-        logger.info(f"Found existing crd: {crd.metadata.name}")
+        logger.info(f"Found existing crd: {crd.metadata.name}. Hence, skipping the step to create new subscription.")
         return True
     except NotFoundError:
         return False

--- a/src/mas/devops/tekton.py
+++ b/src/mas/devops/tekton.py
@@ -22,7 +22,7 @@ from openshift.dynamic.exceptions import NotFoundError, UnprocessibleEntityError
 
 from jinja2 import Environment, FileSystemLoader
 
-from .ocp import getConsoleURL, waitForCRD, waitForDeployment
+from .ocp import getConsoleURL, waitForCRD, waitForDeployment, crdExists
 
 logger = logging.getLogger(__name__)
 
@@ -36,28 +36,25 @@ def installOpenShiftPipelines(dynClient: DynamicClient) -> bool:
 
     # Create the Operator Subscription
     try:
-        manifest = packagemanifestAPI.get(name="openshift-pipelines-operator-rh", namespace="openshift-marketplace")
-        defaultChannel = manifest.status.defaultChannel
-        catalogSource = manifest.status.catalogSource
-        catalogSourceNamespace = manifest.status.catalogSourceNamespace
+        if not crdExists(dynClient, "pipelines.tekton.dev"):
+            manifest = packagemanifestAPI.get(name="openshift-pipelines-operator-rh", namespace="openshift-marketplace")
+            defaultChannel = manifest.status.defaultChannel
+            catalogSource = manifest.status.catalogSource
+            catalogSourceNamespace = manifest.status.catalogSourceNamespace
 
-        logger.info(f"OpenShift Pipelines Operator Details: {catalogSourceNamespace}/{catalogSource}@{defaultChannel}")
+            logger.info(f"OpenShift Pipelines Operator Details: {catalogSourceNamespace}/{catalogSource}@{defaultChannel}")
 
-        templateDir = path.join(path.abspath(path.dirname(__file__)), "templates")
-        env = Environment(
-            loader=FileSystemLoader(searchpath=templateDir)
-        )
-        template = env.get_template("subscription.yml.j2")
-        renderedTemplate = template.render(
-            pipelines_channel=defaultChannel,
-            pipelines_source=catalogSource,
-            pipelines_source_namespace=catalogSourceNamespace
-        )
-        subscription = yaml.safe_load(renderedTemplate)
-        try:
-            subscriptionsAPI.get(name="openshift-pipelines-operator-rh",namespace="openshift-operators")
-            logger.info(f"Found existing Opendhift Pipelines Operator Subscription: openshift-operators/openshift-pipelines-operator-rh")
-        except NotFoundError:
+            templateDir = path.join(path.abspath(path.dirname(__file__)), "templates")
+            env = Environment(
+                loader=FileSystemLoader(searchpath=templateDir)
+            )
+            template = env.get_template("subscription.yml.j2")
+            renderedTemplate = template.render(
+                pipelines_channel=defaultChannel,
+                pipelines_source=catalogSource,
+                pipelines_source_namespace=catalogSourceNamespace
+            )
+            subscription = yaml.safe_load(renderedTemplate)
             subscriptionsAPI.apply(body=subscription, namespace="openshift-operators")
 
     except NotFoundError:

--- a/src/mas/devops/tekton.py
+++ b/src/mas/devops/tekton.py
@@ -36,25 +36,30 @@ def installOpenShiftPipelines(dynClient: DynamicClient) -> bool:
 
     # Create the Operator Subscription
     try:
-        manifest = packagemanifestAPI.get(name="openshift-pipelines-operator-rh", namespace="openshift-marketplace")
-        defaultChannel = manifest.status.defaultChannel
-        catalogSource = manifest.status.catalogSource
-        catalogSourceNamespace = manifest.status.catalogSourceNamespace
+        existingSubscriptions=subscriptionsAPI.get(name="openshift-pipelines-operator-rh",namespace="openshift-operators")
+        print(len(existingSubscriptions))
+        print(existingSubscriptions)
 
-        logger.info(f"OpenShift Pipelines Operator Details: {catalogSourceNamespace}/{catalogSource}@{defaultChannel}")
+        if len(existingSubscriptions) > 0:
+            manifest = packagemanifestAPI.get(name="openshift-pipelines-operator-rh", namespace="openshift-marketplace")
+            defaultChannel = manifest.status.defaultChannel
+            catalogSource = manifest.status.catalogSource
+            catalogSourceNamespace = manifest.status.catalogSourceNamespace
 
-        templateDir = path.join(path.abspath(path.dirname(__file__)), "templates")
-        env = Environment(
-            loader=FileSystemLoader(searchpath=templateDir)
-        )
-        template = env.get_template("subscription.yml.j2")
-        renderedTemplate = template.render(
-            pipelines_channel=defaultChannel,
-            pipelines_source=catalogSource,
-            pipelines_source_namespace=catalogSourceNamespace
-        )
-        subscription = yaml.safe_load(renderedTemplate)
-        subscriptionsAPI.apply(body=subscription, namespace="openshift-operators")
+            logger.info(f"OpenShift Pipelines Operator Details: {catalogSourceNamespace}/{catalogSource}@{defaultChannel}")
+
+            templateDir = path.join(path.abspath(path.dirname(__file__)), "templates")
+            env = Environment(
+                loader=FileSystemLoader(searchpath=templateDir)
+            )
+            template = env.get_template("subscription.yml.j2")
+            renderedTemplate = template.render(
+                pipelines_channel=defaultChannel,
+                pipelines_source=catalogSource,
+                pipelines_source_namespace=catalogSourceNamespace
+            )
+            subscription = yaml.safe_load(renderedTemplate)
+            subscriptionsAPI.apply(body=subscription, namespace="openshift-operators")
 
     except NotFoundError:
         logger.warning("Error: Couldn't find package manifest for Red Hat Openshift Pipelines Operator")

--- a/src/mas/devops/tekton.py
+++ b/src/mas/devops/tekton.py
@@ -36,11 +36,10 @@ def installOpenShiftPipelines(dynClient: DynamicClient) -> bool:
 
     # Create the Operator Subscription
     try:
-        existingSubscriptions=subscriptionsAPI.get(name="openshift-pipelines-operator-rh",namespace="openshift-operators")
-        print(len(existingSubscriptions))
-        print(existingSubscriptions)
-
-        if len(existingSubscriptions) > 0:
+        try:
+            subscriptionsAPI.get(name="openshift-pipelines-operator-rh",namespace="openshift-operators")
+            logger.info(f"Found existing Opendhift Pipelines Operator Subscription: openshift-operators/openshift-pipelines-operator-rh")
+        except NotFoundError:
             manifest = packagemanifestAPI.get(name="openshift-pipelines-operator-rh", namespace="openshift-marketplace")
             defaultChannel = manifest.status.defaultChannel
             catalogSource = manifest.status.catalogSource


### PR DESCRIPTION
## Description:
Currently, a new subscription is created to openshift pipelines even if it exists and due to that pre-install check fails since, one of the subscriptions fail to become ready. This change adds a check for pipeline CRD and take action based on that.

## Related Links:
https://github.com/ibm-mas/cli/issues/727
https://jsw.ibm.com/browse/MASCORE-3787

## Testing:
Tested in a quickburn with and without an existing openshift pipelines subscription.

**with an existing subscription:**

<img width="998" alt="Screenshot 2024-09-03 at 13 14 10" src="https://github.com/user-attachments/assets/78b1d999-7ec9-4c2a-89d2-9f81ac360d9f">
<img width="1329" alt="Screenshot 2024-09-03 at 13 22 00" src="https://github.com/user-attachments/assets/69e48889-c013-48e8-bfd7-9b879a0b8a05">


**without an existing subscription:**

<img width="849" alt="Screenshot 2024-09-03 at 13 21 36" src="https://github.com/user-attachments/assets/359837b3-0c00-4a35-8eef-7621679065ec">
