### PR TITLE
[patch] allow development catalogs in update pipeline

### DIFF
--- a/src/mas/devops/templates/pipelinerun-update.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-update.yml.j2
@@ -24,7 +24,14 @@ spec:
     - name: ibm_entitlement_key
       value: "{{ ibm_entitlement_key }}"
 {%- endif %}
-
+{%- if artifactory_username is defined and artifactory_username != "" %}
+    # Enable development catalogs
+    # -------------------------------------------------------------------------
+    - name: artifactory_username
+      value: "{{ artifactory_username }}"
+    - name: artifactory_token
+      value: "{{ artifactory_token }}"
+{%- endif %}
 {%- if skip_pre_check is defined and skip_pre_check != "" %}
     # Skip pre-check
     # -------------------------------------------------------------------------


### PR DESCRIPTION
**Description**
Add extra parameters so a triggered FVT update flow can install deveopment catalogs (from artifactory)

part of https://jsw.ibm.com/browse/MASCORE-3739

**Testing**
This has been run multiple times in personal FVT clusters