### PR TITLE
[patch] make sure mongo_v7_ upgrade is added to pipelinerun

### DIFF
--- a/src/mas/devops/templates/pipelinerun-update.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-update.yml.j2
@@ -63,6 +63,10 @@ spec:
     - name: mongodb_v6_upgrade
       value: "{{ mongodb_v6_upgrade }}"
 {%- endif %}
+{%- if mongodb_v7_upgrade is defined and mongodb_v7_upgrade != "" %}
+    - name: mongodb_v7_upgrade
+      value: "{{ mongodb_v7_upgrade }}"
+{%- endif %}
 {%- endif %}
 {%- if kafka_namespace is defined and kafka_namespace != "" %}
 


### PR DESCRIPTION
Even though the option to upgrade to mongo v7 was selected in the cli, the pipeline fails with:
```
TASK [ibm.mas_devops.mongodb : Assert that the Mongo v7 upgrade has been triggered] ***
fatal: [localhost]: FAILED! => changed=false 
  assertion: mongodb_v7_upgrade
  evaluated_to: false
  msg: 'Your current mongo version is 6.0.12, in order to upgrade to version 7.0.12, you must set ''mongodb_v7_upgrade'': true'
```

this is due to the mongodb_v7_upgrade not being set on the pipelinerun