### PR TITLE
[minor] Add catalog data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include src/mas/devops/templates/*.yml.j2
+include src/mas/devops/data/catalogs/*.yaml

--- a/src/mas/devops/data/__init__.py
+++ b/src/mas/devops/data/__init__.py
@@ -1,0 +1,19 @@
+# *****************************************************************************
+# Copyright (c) 2024 IBM Corporation and other Contributors.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# *****************************************************************************
+import yaml
+from os import path
+
+
+def getCatalog(name: str) -> dict:
+    moduleFile = path.abspath(__file__)
+    modulePath = path.dirname(moduleFile)
+    catalogFileName = f"{name}.yaml"
+    with open(path.join(modulePath, "catalogs", catalogFileName)) as stream:
+        return yaml.safe_load(stream)

--- a/src/mas/devops/data/catalogs/v8-230414-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v8-230414-amd64.yaml
@@ -1,0 +1,68 @@
+---
+# IBM Maximo Operator Catalog v230411
+# -----------------------------------------------------------------------------
+catalog_digest: sha256:4e7a81ee11bd0667f1cadc1ea1da44865e412fb0597186cfc8baa9ceb3015592
+
+# Dependencies
+# -----------------------------------------------------------------------------
+common_svcs_version: 1.19.0   # Operator version 3.23.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+db2u_version: 5.1.1           # Operator version 110508.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+events_version: 4.4.0         # Operator version 4.4.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
+uds_version: 2.0.9            # Operator version 2.0.9
+sls_version: 3.6.0            # Operator version 3.6.0
+tsm_version: 1.5.0            # Operator version 1.5.0
+dd_version: 1.1.3             # Operator version 1.1.3
+appconnect_version: 6.2.0     # Operator version 6.2.0
+cp4d_platform_version: 2.7.0  # Operator version 3.6.0
+wsl_version: 6.3.0            # Operator version 6.3.0
+wml_version: 6.3.0            # Operator version 3.3.0
+spark_version: 6.3.0          # Operator version 3.3.0
+wd_version: 5.3.0             # Operator version 4.6.3
+cognos_version: 23.3.0        # Operator version 23.3.0
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  8.9.x: 8.9.4    # Updated
+  8.10.x: 8.10.0  # No Update
+mas_assist_version:
+  8.9.x: 8.6.3    # Updated
+  8.10.x: 8.7.0   # No Update
+mas_hputilities_version:
+  8.9.x: 8.5.1    # Updated
+  8.10.x: 8.6.0   # Updated
+mas_iot_version:
+  8.9.x: 8.6.5    # Updated
+  8.10.x: 8.7.0   # No Update
+mas_manage_version:
+  8.9.x: 8.5.4    # Updated
+  8.10.x: 8.6.0   # No Update
+mas_monitor_version:
+  8.9.x: 8.9.4    # No Update
+  8.10.x: 8.10.0  # No Update
+mas_optimizer_version:
+  8.9.x: 8.3.3    # Updated
+  8.10.x: 8.4.0   # No Update
+mas_predict_version:
+  8.9.x: 8.7.2    # Updated
+  8.10.x: 8.8.0   # No Update
+mas_visualinspection_version:
+  8.9.x: 8.7.0    # No Update
+  8.10.x: 8.8.0   # No Update
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.2.0
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version: 4.4.21
+
+# Extra Images for Db2u
+# ------------------------------------------------------------------------------
+db2u_extras_version: 1.0.1
+
+# Default Cloud Pak for Data version
+# ------------------------------------------------------------------------------
+cpd_product_version_default: 4.6.3
+cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default(cpd_product_version_default, true) }}"

--- a/src/mas/devops/data/catalogs/v8-230518-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v8-230518-amd64.yaml
@@ -1,0 +1,68 @@
+---
+# IBM Maximo Operator Catalog v230518
+# -----------------------------------------------------------------------------
+catalog_digest: sha256:14cba8ea86a045901cc506f260e4f7aaa5d7a60a1922b927c30353f55e1c5cec
+
+# Dependencies
+# -----------------------------------------------------------------------------
+common_svcs_version: 1.19.0   # Operator version 3.23.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+db2u_version: 5.1.1           # Operator version 110508.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+events_version: 4.4.0         # Operator version 4.4.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
+uds_version: 2.0.9            # Operator version 2.0.9
+sls_version: 3.7.0            # Operator version 3.7.0
+tsm_version: 1.5.0            # Operator version 1.5.0
+dd_version: 1.1.4             # Operator version 1.1.4
+appconnect_version: 6.2.0     # Operator version 6.2.0
+cp4d_platform_version: 2.7.0  # Operator version 3.6.0
+wsl_version: 6.3.0            # Operator version 6.3.0
+wml_version: 6.3.0            # Operator version 3.3.0
+spark_version: 6.3.0          # Operator version 3.3.0
+wd_version: 5.3.0             # Operator version 4.6.3
+cognos_version: 23.3.0        # Operator version 23.3.0
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  8.9.x: 8.9.5    # Updated
+  8.10.x: 8.10.1  # Updated
+mas_assist_version:
+  8.9.x: 8.6.3    # No Update
+  8.10.x: 8.7.0   # No Update
+mas_hputilities_version:
+  8.9.x: 8.5.1    # No Update
+  8.10.x: 8.6.1   # Updated
+mas_iot_version:
+  8.9.x: 8.6.6    # Updated
+  8.10.x: 8.7.1   # Updated
+mas_manage_version:
+  8.9.x: 8.5.5    # Updated
+  8.10.x: 8.6.1   # Updated
+mas_monitor_version:
+  8.9.x: 8.9.5    # Updated
+  8.10.x: 8.10.1  # Updated
+mas_optimizer_version:
+  8.9.x: 8.3.3    # No Update
+  8.10.x: 8.4.1   # Updated
+mas_predict_version:
+  8.9.x: 8.7.2    # No Update
+  8.10.x: 8.8.0   # No Update
+mas_visualinspection_version:
+  8.9.x: 8.7.1    # Updated
+  8.10.x: 8.8.0   # No Update
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.2.0
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version: 4.4.21
+
+# Extra Images for Db2u
+# ------------------------------------------------------------------------------
+db2u_extras_version: 1.0.1
+
+# Default Cloud Pak for Data version
+# ------------------------------------------------------------------------------
+cpd_product_version_default: 4.6.3
+cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default(cpd_product_version_default, true) }}"

--- a/src/mas/devops/data/catalogs/v8-230526-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v8-230526-amd64.yaml
@@ -1,0 +1,68 @@
+---
+# IBM Maximo Operator Catalog v230518
+# -----------------------------------------------------------------------------
+catalog_digest: sha256:bdae03cfd469399d29a962448dcf790dcf81d309c4bc233637c3acecf228aa1f
+
+# Dependencies
+# -----------------------------------------------------------------------------
+common_svcs_version: 1.19.0   # Operator version 3.23.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+db2u_version: 5.1.1           # Operator version 110508.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+events_version: 4.4.0         # Operator version 4.4.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
+uds_version: 2.0.9            # Operator version 2.0.9
+sls_version: 3.7.0            # Operator version 3.7.0
+tsm_version: 1.5.0            # Operator version 1.5.0
+dd_version: 1.1.4             # Operator version 1.1.4
+appconnect_version: 6.2.0     # Operator version 6.2.0
+cp4d_platform_version: 2.7.0  # Operator version 3.6.0
+wsl_version: 6.3.0            # Operator version 6.3.0
+wml_version: 6.3.0            # Operator version 3.3.0
+spark_version: 6.3.0          # Operator version 3.3.0
+wd_version: 5.3.0             # Operator version 4.6.3
+cognos_version: 23.3.0        # Operator version 23.3.0
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  8.9.x: 8.9.5    # Updated
+  8.10.x: 8.10.1  # Updated
+mas_assist_version:
+  8.9.x: 8.6.3    # No Update
+  8.10.x: 8.7.0   # No Update
+mas_hputilities_version:
+  8.9.x: 8.5.1    # No Update
+  8.10.x: 8.6.1   # Updated
+mas_iot_version:
+  8.9.x: 8.6.6    # Updated
+  8.10.x: 8.7.1   # Updated
+mas_manage_version:
+  8.9.x: 8.5.5    # Updated
+  8.10.x: 8.6.1   # Updated
+mas_monitor_version:
+  8.9.x: 8.9.5    # Updated
+  8.10.x: 8.10.2  # Updated
+mas_optimizer_version:
+  8.9.x: 8.3.3    # No Update
+  8.10.x: 8.4.1   # Updated
+mas_predict_version:
+  8.9.x: 8.7.2    # No Update
+  8.10.x: 8.8.1   # Updated
+mas_visualinspection_version:
+  8.9.x: 8.7.1    # Updated
+  8.10.x: 8.8.0   # No Update
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.2.0
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version: 4.4.21
+
+# Extra Images for Db2u
+# ------------------------------------------------------------------------------
+db2u_extras_version: 1.0.1
+
+# Default Cloud Pak for Data version
+# ------------------------------------------------------------------------------
+cpd_product_version_default: 4.6.3
+cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default(cpd_product_version_default, true) }}"

--- a/src/mas/devops/data/catalogs/v8-230616-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v8-230616-amd64.yaml
@@ -1,0 +1,68 @@
+---
+# IBM Maximo Operator Catalog v230616
+# -----------------------------------------------------------------------------
+catalog_digest: sha256:cb0a38132a1e16964d9aa9b7eb5d247543df5feea218bb1100757290a07bc042
+
+# Dependencies
+# -----------------------------------------------------------------------------
+common_svcs_version: 1.19.2   # Operator version 3.23.2 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+db2u_version: 5.1.1           # Operator version 110508.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+events_version: 4.6.0         # Operator version 4.6.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
+uds_version: 2.0.10           # Operator version 2.0.10
+sls_version: 3.7.0            # Operator version 3.7.0
+tsm_version: 1.5.0            # Operator version 1.5.0
+dd_version: 1.1.4             # Operator version 1.1.4
+appconnect_version: 6.2.0     # Operator version 6.2.0
+cp4d_platform_version: 2.8.0+20230417.110116  # Operator version 3.7.0
+wsl_version: 6.4.0            # Operator version 6.4.0
+wml_version: 6.4.0            # Operator version 3.4.0
+spark_version: 6.4.0          # Operator version 3.4.0
+wd_version: 5.3.0             # Operator version 4.6.3
+cognos_version: 23.4.0        # Operator version 23.4.0
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  8.9.x: 8.9.6    # Updated
+  8.10.x: 8.10.2  # Updated
+mas_assist_version:
+  8.9.x: 8.6.4    # Updated
+  8.10.x: 8.7.1   # Updated
+mas_hputilities_version:
+  8.9.x: 8.5.1    # No Update
+  8.10.x: 8.6.1   # No Update
+mas_iot_version:
+  8.9.x: 8.6.7    # Updated
+  8.10.x: 8.7.2   # Updated
+mas_manage_version:
+  8.9.x: 8.5.6    # Updated
+  8.10.x: 8.6.2   # Updated
+mas_monitor_version:
+  8.9.x: 8.9.5    # No Update
+  8.10.x: 8.10.3  # Updated
+mas_optimizer_version:
+  8.9.x: 8.3.3    # No Update
+  8.10.x: 8.4.1   # No Update
+mas_predict_version:
+  8.9.x: 8.7.2    # No Update
+  8.10.x: 8.8.1   # No Update
+mas_visualinspection_version:
+  8.9.x: 8.7.1    # No Update
+  8.10.x: 8.8.1   # Updated
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.3.0
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version: 4.4.21
+
+# Extra Images for Db2u
+# ------------------------------------------------------------------------------
+db2u_extras_version: 1.0.1
+
+# Default Cloud Pak for Data version
+# ------------------------------------------------------------------------------
+cpd_product_version_default: 4.6.4
+cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default(cpd_product_version_default, true) }}"

--- a/src/mas/devops/data/catalogs/v8-230627-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v8-230627-amd64.yaml
@@ -1,0 +1,80 @@
+---
+# IBM Maximo Operator Catalog v230627
+# -----------------------------------------------------------------------------
+catalog_digest: sha256:42891d978163c24737f799ed870ad340f5b3e6cd9b14644eaf1c5810ed5ef7cf
+
+# Dependencies
+# -----------------------------------------------------------------------------
+common_svcs_version: 1.19.2                  # Operator version 3.23.2 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+db2u_version: 5.1.1                          # Operator version 110508.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+events_version: 4.6.0                        # Operator version 4.6.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
+uds_version: 2.0.10                          # Operator version 2.0.10
+sls_version: 3.7.0                           # Operator version 3.7.0
+tsm_version: 1.5.0                           # Operator version 1.5.0
+dd_version: 1.1.4                            # Operator version 1.1.4
+appconnect_version: 6.2.0                    # Operator version 6.2.0
+cp4d_platform_version: 2.8.0+20230417.110116 # Operator version 3.7.0
+wsl_version: 6.4.0                           # Operator version 6.4.0
+wml_version: 6.4.0                           # Operator version 3.4.0
+spark_version: 6.4.0                         # Operator version 3.4.0
+cognos_version: 23.4.0                       # Operator version 23.4.0
+
+# Watson discovery and its dependencies
+# Match corresponding case version for default versions in the catalog source
+# -----------------------------------------------------------------------------
+wd_version: 5.3.0                            # Operator version 4.6.3
+model_train_version: 1.2.5                   # Operator version 1.1.7
+elasticsearch_version: 1.1.1336              # Operator version 1.1.1336
+couchdb_version: 1.0.13                      # Operator version 2.2.1
+
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  8.9.x: 8.9.7    # Updated
+  8.10.x: 8.10.2  # No Update
+mas_assist_version:
+  8.9.x: 8.6.4    # No Update
+  8.10.x: 8.7.1   # No Update
+mas_hputilities_version:
+  8.9.x: 8.5.1    # No Update
+  8.10.x: 8.6.1   # No Update
+mas_iot_version:
+  8.9.x: 8.6.7    # No Update
+  8.10.x: 8.7.2   # No Update
+mas_manage_version:
+  8.9.x: 8.5.6    # No Update
+  8.10.x: 8.6.2   # No Update
+mas_monitor_version:
+  8.9.x: 8.9.5    # No Update
+  8.10.x: 8.10.3  # No Update
+mas_optimizer_version:
+  8.9.x: 8.3.3    # No Update
+  8.10.x: 8.4.1   # No Update
+mas_predict_version:
+  8.9.x: 8.7.2    # No Update
+  8.10.x: 8.8.1   # No Update
+mas_visualinspection_version:
+  8.9.x: 8.7.1    # No Update
+  8.10.x: 8.8.1   # No Update
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.3.0
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version: 4.4.21
+
+# Extra Images for Db2u
+# ------------------------------------------------------------------------------
+db2u_extras_version: 1.0.1
+
+# Extra Images for IBM Watson Discovery
+# ------------------------------------------------------------------------------
+wd_extras_version: 1.0.0
+
+# Default Cloud Pak for Data version
+# ------------------------------------------------------------------------------
+cpd_product_version_default: 4.6.4
+cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default(cpd_product_version_default, true) }}"

--- a/src/mas/devops/data/catalogs/v8-230721-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v8-230721-amd64.yaml
@@ -1,0 +1,80 @@
+---
+# IBM Maximo Operator Catalog v230721
+# -----------------------------------------------------------------------------
+catalog_digest: sha256:200df0fe4723d2ec40433be5793ee3afe341f966f66b7acaa1fb43b412c90848
+
+# Dependencies
+# -----------------------------------------------------------------------------
+common_svcs_version: 1.19.2                  # Operator version 3.23.2 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+db2u_version: 5.1.1                          # Operator version 110508.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+events_version: 4.6.0                        # Operator version 4.6.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
+uds_version: 2.0.11                          # Operator version 2.0.11
+sls_version: 3.7.0                           # Operator version 3.7.0
+tsm_version: 1.5.0                           # Operator version 1.5.0
+dd_version: 1.1.4                            # Operator version 1.1.4
+appconnect_version: 6.2.0                    # Operator version 6.2.0
+cp4d_platform_version: 2.8.0+20230417.110116 # Operator version 3.7.0
+wsl_version: 6.4.0                           # Operator version 6.4.0
+wml_version: 6.4.0                           # Operator version 3.4.0
+spark_version: 6.4.0                         # Operator version 3.4.0
+cognos_version: 23.4.0                       # Operator version 23.4.0
+
+# Watson discovery and its dependencies
+# Match corresponding case version for default versions in the catalog source
+# -----------------------------------------------------------------------------
+wd_version: 5.3.0                            # Operator version 4.6.3
+model_train_version: 1.2.5                   # Operator version 1.1.7
+elasticsearch_version: 1.1.1336              # Operator version 1.1.1336
+couchdb_version: 1.0.13                      # Operator version 2.2.1
+
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  8.9.x: 8.9.7    # No Update
+  8.10.x: 8.10.2  # No Update
+mas_assist_version:
+  8.9.x: 8.6.4    # No Update
+  8.10.x: 8.7.1   # No Update
+mas_hputilities_version:
+  8.9.x: 8.5.1    # No Update
+  8.10.x: 8.6.1   # No Update
+mas_iot_version:
+  8.9.x: 8.6.7    # No Update
+  8.10.x: 8.7.2   # No Update
+mas_manage_version:
+  8.9.x: 8.5.6    # No Update
+  8.10.x: 8.6.2   # No Update
+mas_monitor_version:
+  8.9.x: 8.9.5    # No Update
+  8.10.x: 8.10.3  # No Update
+mas_optimizer_version:
+  8.9.x: 8.3.3    # No Update
+  8.10.x: 8.4.1   # No Update
+mas_predict_version:
+  8.9.x: 8.7.2    # No Update
+  8.10.x: 8.8.1   # No Update
+mas_visualinspection_version:
+  8.9.x: 8.7.1    # No Update
+  8.10.x: 8.8.1   # No Update
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.3.0
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version: 4.4.21
+
+# Extra Images for Db2u
+# ------------------------------------------------------------------------------
+db2u_extras_version: 1.0.1
+
+# Extra Images for IBM Watson Discovery
+# ------------------------------------------------------------------------------
+wd_extras_version: 1.0.0
+
+# Default Cloud Pak for Data version
+# ------------------------------------------------------------------------------
+cpd_product_version_default: 4.6.4
+cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default(cpd_product_version_default, true) }}"

--- a/src/mas/devops/data/catalogs/v8-230725-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v8-230725-amd64.yaml
@@ -1,0 +1,85 @@
+---
+# IBM Maximo Operator Catalog v230725
+# -----------------------------------------------------------------------------
+
+catalog_digest: sha256:f0776894d5b584bfdd10c3de2f5e586ddafdaca9b247d13ef05dc23fe98cfe2a
+
+# Dependencies
+# -----------------------------------------------------------------------------
+common_svcs_version: 1.19.2                  # Operator version 3.23.2 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+db2u_version: 5.1.1                          # Operator version 110508.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+events_version: 4.6.0                        # Operator version 4.6.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
+uds_version: 2.0.11                          # Operator version 2.0.11
+sls_version: 3.7.0                           # Operator version 3.7.0
+tsm_version: 1.5.0                           # Operator version 1.5.0
+dd_version: 1.1.4                            # Operator version 1.1.4
+appconnect_version: 6.2.0                    # Operator version 6.2.0
+cp4d_platform_version: 2.8.0+20230417.110116 # Operator version 3.7.0
+wsl_version: 6.4.0                           # Operator version 6.4.0
+wml_version: 6.4.0                           # Operator version 3.4.0
+spark_version: 6.4.0                         # Operator version 3.4.0
+cognos_version: 23.4.0                       # Operator version 23.4.0
+
+# Watson discovery and its dependencies
+# Match corresponding case version for default versions in the catalog source
+# -----------------------------------------------------------------------------
+wd_version: 5.3.0                            # Operator version 4.6.3
+model_train_version: 1.2.5                   # Operator version 1.1.7
+elasticsearch_version: 1.1.1336              # Operator version 1.1.1336
+couchdb_version: 1.0.13                      # Operator version 2.2.1
+
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  8.9.x: 8.9.8    # Updated
+  8.10.x: 8.10.3  # Updated
+mas_assist_version:
+  8.9.x: 8.6.4    # No Update
+  8.10.x: 8.7.1   # No Update
+mas_hputilities_version:
+  8.9.x: 8.5.1    # No Update
+  8.10.x: 8.6.1   # No Update
+mas_iot_version:
+  8.9.x: 8.6.8    # Updated
+  8.10.x: 8.7.3   # Updated
+mas_manage_version:
+  8.9.x: 8.5.7    # Updated
+  8.10.x: 8.6.3   # Updated
+mas_monitor_version:
+  8.9.x: 8.9.6    # Updated
+  8.10.x: 8.10.4  # Updated
+mas_optimizer_version:
+  8.9.x: 8.3.3    # No Update
+  8.10.x: 8.4.1   # No Update
+mas_predict_version:
+  8.9.x: 8.7.2    # No Update
+  8.10.x: 8.8.2   # Updated
+mas_visualinspection_version:
+  8.9.x: 8.7.1    # No Update
+  8.10.x: 8.8.1   # No Update
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.3.0
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version: 4.4.21
+
+# Extra Images for Db2u
+# ------------------------------------------------------------------------------
+db2u_extras_version: 1.0.1
+
+# Extra Images for IBM Watson Discovery
+# ------------------------------------------------------------------------------
+wd_extras_version: 1.0.0
+
+# Extra Images for Amlen
+# ------------------------------------------------------------------------------
+amlen_extras_version: 1.0.1
+
+# Default Cloud Pak for Data version
+# ------------------------------------------------------------------------------
+cpd_product_version_default: 4.6.4
+cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default(cpd_product_version_default, true) }}"

--- a/src/mas/devops/data/catalogs/v8-230829-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v8-230829-amd64.yaml
@@ -1,0 +1,84 @@
+---
+# IBM Maximo Operator Catalog v230829
+# -----------------------------------------------------------------------------
+catalog_digest: sha256:ecc076b3219db96ed78faac32c815282515d830bc5c6025268be96ca15618f7e
+
+# Dependencies
+# -----------------------------------------------------------------------------
+common_svcs_version: 1.19.4                  # Operator version 3.23.4 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+db2u_version: 5.1.4                          # Operator version 110508.0.2 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+events_version: 4.6.1                        # Operator version 4.6.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
+uds_version: 2.0.11                          # Operator version 2.0.11
+sls_version: 3.7.0                           # Operator version 3.7.0
+tsm_version: 1.5.0                           # Operator version 1.5.0
+dd_version: 1.1.4                            # Operator version 1.1.4
+appconnect_version: 6.2.0                    # Operator version 6.2.0
+cp4d_platform_version: 2.8.0+20230417.110116 # Operator version 3.7.0
+wsl_version: 6.4.0                           # Operator version 6.4.0
+wml_version: 6.4.0                           # Operator version 3.4.0
+spark_version: 6.4.0                         # Operator version 3.4.0
+cognos_version: 23.4.0                       # Operator version 23.4.0
+
+# Watson discovery and its dependencies
+# Match corresponding case version for default versions in the catalog source
+# -----------------------------------------------------------------------------
+wd_version: 5.3.0                            # Operator version 4.6.3
+model_train_version: 1.2.7                   # Operator version 1.1.9
+elasticsearch_version: 1.1.1541              # Operator version 1.1.1541
+couchdb_version: 1.0.13                      # Operator version 2.2.1
+
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  8.9.x: 8.9.9    # Updated
+  8.10.x: 8.10.4  # Updated
+mas_assist_version:
+  8.9.x: 8.6.5    # Updated
+  8.10.x: 8.7.2   # Updated
+mas_hputilities_version:
+  8.9.x: 8.5.3    # Updated
+  8.10.x: 8.6.2   # Updated
+mas_iot_version:
+  8.9.x: 8.6.9    # Updated
+  8.10.x: 8.7.4   # Updated
+mas_manage_version:
+  8.9.x: 8.5.8    # Updated
+  8.10.x: 8.6.4   # Updated
+mas_monitor_version:
+  8.9.x: 8.9.6    # No Update
+  8.10.x: 8.10.4  # No Update
+mas_optimizer_version:
+  8.9.x: 8.3.3    # No Update
+  8.10.x: 8.4.1   # No Update
+mas_predict_version:
+  8.9.x: 8.7.2    # No Update
+  8.10.x: 8.8.2   # No Update
+mas_visualinspection_version:
+  8.9.x: 8.7.1    # No Update
+  8.10.x: 8.8.1   # No Update
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.4.0
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version: 4.4.21
+
+# Extra Images for Db2u
+# ------------------------------------------------------------------------------
+db2u_extras_version: 1.0.2
+
+# Extra Images for IBM Watson Discovery
+# ------------------------------------------------------------------------------
+wd_extras_version: 1.0.1
+
+# Extra Images for Amlen
+# ------------------------------------------------------------------------------
+amlen_extras_version: 1.0.1
+
+# Default Cloud Pak for Data version
+# ------------------------------------------------------------------------------
+cpd_product_version_default: 4.6.4
+cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default(cpd_product_version_default, true) }}"

--- a/src/mas/devops/data/catalogs/v8-230926-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v8-230926-amd64.yaml
@@ -1,0 +1,84 @@
+---
+# IBM Maximo Operator Catalog v230926
+# -----------------------------------------------------------------------------
+catalog_digest: sha256:b3ad0d8d20eee9c7e48ba93b956a4f452e48ba0a648e76c39100c352f2cb6537
+
+# Dependencies
+# -----------------------------------------------------------------------------
+common_svcs_version: 1.19.4                  # Operator version 3.23.4 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+db2u_version: 5.1.4                          # Operator version 110508.0.2 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+events_version: 4.6.1                        # Operator version 4.6.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
+uds_version: 2.0.11                          # Operator version 2.0.11
+sls_version: 3.8.0                           # Operator version 3.8.0
+tsm_version: 1.5.1                           # Operator version 1.5.1
+dd_version: 1.1.5                            # Operator version 1.1.5
+appconnect_version: 6.2.0                    # Operator version 6.2.0
+cp4d_platform_version: 2.9.0+20230524.165553 # Operator version 3.8.0
+wsl_version: 6.5.0                           # Operator version 6.5.0
+wml_version: 6.5.0                           # Operator version 3.5.0
+spark_version: 6.5.0                         # Operator version 3.5.0
+cognos_version: 23.5.0                       # Operator version 23.5.0
+
+# Watson discovery and its dependencies
+# Match corresponding case version for default versions in the catalog source
+# -----------------------------------------------------------------------------
+wd_version: 5.5.0                            # Operator version 4.6.5
+model_train_version: 1.2.7                   # Operator version 1.1.9
+elasticsearch_version: 1.1.1541              # Operator version 1.1.1541
+couchdb_version: 1.0.13                      # Operator version 2.2.1
+
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  8.10.x: 8.10.5  # Updated
+  8.11.x: 8.11.0  # Updated
+mas_assist_version:
+  8.10.x: 8.7.2   # No Update
+  8.11.x: 8.8.0   # Updated
+mas_hputilities_version:
+  8.10.x: 8.6.2   # No Update
+  8.11.x: ""      # Not Supported
+mas_iot_version:
+  8.10.x: 8.7.4   # No Update
+  8.11.x: 8.8.0   # Updated
+mas_manage_version:
+  8.10.x: 8.6.5   # Updated
+  8.11.x: 8.7.0   # Updated
+mas_monitor_version:
+  8.10.x: 8.10.5  # Updated
+  8.11.x: 8.11.0  # Updated
+mas_optimizer_version:
+  8.10.x: 8.4.1   # No Update
+  8.11.x: 8.5.0   # Updated
+mas_predict_version:
+  8.10.x: 8.8.2   # No Update
+  8.11.x: 8.9.0   # Updated
+mas_visualinspection_version:
+  8.10.x: 8.8.1   # No Update
+  8.11.x: 8.9.0   # Updated
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.4.0
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version: 4.4.21
+
+# Extra Images for Db2u
+# ------------------------------------------------------------------------------
+db2u_extras_version: 1.0.2
+
+# Extra Images for IBM Watson Discovery
+# ------------------------------------------------------------------------------
+wd_extras_version: 1.0.1
+
+# Extra Images for Amlen
+# ------------------------------------------------------------------------------
+amlen_extras_version: 1.0.1
+
+# Default Cloud Pak for Data version
+# ------------------------------------------------------------------------------
+cpd_product_version_default: 4.6.6
+cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default(cpd_product_version_default, true) }}"

--- a/src/mas/devops/data/catalogs/v8-231004-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v8-231004-amd64.yaml
@@ -1,0 +1,94 @@
+---
+# IBM Maximo Operator Catalog v231004
+# -----------------------------------------------------------------------------
+catalog_digest: sha256:32b28d56327215dcab58664f10987b3e961c0ee9630744b9f66b710e9d879dca
+
+# Dependencies
+# -----------------------------------------------------------------------------
+common_svcs_version: 1.19.4                  # Operator version 3.23.4 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+db2u_version: 5.1.4                          # Operator version 110508.0.2 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+events_version: 4.6.1                        # Operator version 4.6.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
+uds_version: 2.0.11                          # Operator version 2.0.11
+sls_version: 3.8.1                           # Operator version 3.8.1
+tsm_version: 1.5.1                           # Operator version 1.5.1
+dd_version: 1.1.5                            # Operator version 1.1.5
+appconnect_version: 6.2.0                    # Operator version 6.2.0
+cp4d_platform_version: 2.9.0+20230524.165553 # Operator version 3.8.0
+wsl_version: 6.5.0                           # Operator version 6.5.0
+wml_version: 6.5.0                           # Operator version 3.5.0
+spark_version: 6.5.0                         # Operator version 3.5.0
+cognos_version: 23.5.0                       # Operator version 23.5.0
+
+# Watson discovery and its dependencies
+# Match corresponding case version for default versions in the catalog source
+# -----------------------------------------------------------------------------
+wd_version: 5.5.0                            # Operator version 4.6.5
+model_train_version: 1.2.7                   # Operator version 1.1.9
+elasticsearch_version: 1.1.1541              # Operator version 1.1.1541
+couchdb_version: 1.0.13                      # Operator version 2.2.1
+
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  8.10.x: 8.10.5  # No Update
+  8.11.x: 8.11.1  # Updated
+  8.9.x: 8.9.10   # Updated
+mas_assist_version:
+  8.10.x: 8.7.2   # No Update
+  8.11.x: 8.8.0   # No Update
+  8.9.x: 8.6.5    # No Update
+mas_hputilities_version:
+  8.10.x: 8.6.2   # No Update
+  8.11.x: ""      # Not Supported
+  8.9.x: 8.5.3    # No Update
+mas_iot_version:
+  8.10.x: 8.7.4   # No Update
+  8.11.x: 8.8.0   # No Update
+  8.9.x: 8.6.9    # No Update
+mas_manage_version:
+  8.10.x: 8.6.5   # No Update
+  8.11.x: 8.7.0   # No Update
+  8.9.x: 8.5.9    # Updated
+mas_monitor_version:
+  8.10.x: 8.10.5  # No Update
+  8.11.x: 8.11.0  # No Update
+  8.9.x: 8.9.6    # No Update
+mas_optimizer_version:
+  8.10.x: 8.4.1   # No Update
+  8.11.x: 8.5.0   # No Update
+  8.9.x: 8.3.3    # No Update
+mas_predict_version:
+  8.10.x: 8.8.2   # No Update
+  8.11.x: 8.9.0   # No Update
+  8.9.x: 8.7.2    # No Update
+mas_visualinspection_version:
+  8.10.x: 8.8.1   # No Update
+  8.11.x: 8.9.0   # No Update
+  8.9.x: 8.7.1    # No Update
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.4.0
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version_default: 4.4.21
+mongo_extras_version: "{{ lookup('env', 'MONGODB_VERSION') | default(mongo_extras_version_default, True) }}"
+
+# Extra Images for Db2u
+# ------------------------------------------------------------------------------
+db2u_extras_version: 1.0.2
+
+# Extra Images for IBM Watson Discovery
+# ------------------------------------------------------------------------------
+wd_extras_version: 1.0.1
+
+# Extra Images for Amlen
+# ------------------------------------------------------------------------------
+amlen_extras_version: 1.0.1
+
+# Default Cloud Pak for Data version
+# ------------------------------------------------------------------------------
+cpd_product_version_default: 4.6.6
+cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default(cpd_product_version_default, true) }}"

--- a/src/mas/devops/data/catalogs/v8-231031-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v8-231031-amd64.yaml
@@ -1,0 +1,99 @@
+---
+# IBM Maximo Operator Catalog v231031
+# -----------------------------------------------------------------------------
+catalog_digest: sha256:31f0f52a55cc97e7d6c80b844c1d13791efa303eeca87b41954dd2ab67d75378
+
+# Dependencies
+# -----------------------------------------------------------------------------
+common_svcs_version: 1.19.4                  # Operator version 3.23.4 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+db2u_version: 5.1.4                          # Operator version 110508.0.2 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+events_version: 4.6.1                        # Operator version 4.6.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
+uds_version: 2.0.12                          # Operator version 2.0.12
+sls_version: 3.8.1                           # Operator version 3.8.1
+tsm_version: 1.5.1                           # Operator version 1.5.1
+dd_version: 1.1.5                            # Operator version 1.1.5
+appconnect_version: 6.2.0                    # Operator version 6.2.0
+cp4d_platform_version: 2.9.0+20230524.165553 # Operator version 3.8.0
+wsl_version: 6.5.0                           # Operator version 6.5.0
+wml_version: 6.5.0                           # Operator version 3.5.0
+spark_version: 6.5.0                         # Operator version 3.5.0
+cognos_version: 23.5.0                       # Operator version 23.5.0
+
+# Watson discovery and its dependencies
+# Match corresponding case version for default versions in the catalog source
+# -----------------------------------------------------------------------------
+wd_version: 5.5.0                            # Operator version 4.6.5
+model_train_version: 1.2.7                   # Operator version 1.1.9
+elasticsearch_version: 1.1.1541              # Operator version 1.1.1541
+couchdb_version: 1.0.13                      # Operator version 2.2.1
+
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  8.10.x: 8.10.6  # Updated
+  8.11.x: 8.11.2  # Updated
+  8.9.x: 8.9.10   # No Update
+mas_assist_version:
+  8.10.x: 8.7.2   # No Update
+  8.11.x: 8.8.1   # Updated
+  8.9.x: 8.6.5    # No Update
+mas_hputilities_version:
+  8.10.x: 8.6.2   # No Update
+  8.11.x: ""      # Not Supported
+  8.9.x: 8.5.3    # No Update
+mas_iot_version:
+  8.10.x: 8.7.5   # Updated
+  8.11.x: 8.8.1   # Updated
+  8.9.x: 8.6.9    # No Update
+mas_manage_version:
+  8.10.x: 8.6.6   # Updated
+  8.11.x: 8.7.1   # Updated
+  8.9.x: 8.5.9    # No Update
+mas_monitor_version:
+  8.10.x: 8.10.5  # No Update
+  8.11.x: 8.11.1  # Updated
+  8.9.x: 8.9.6    # No Update
+mas_optimizer_version:
+  8.10.x: 8.4.1   # No Update
+  8.11.x: 8.5.0   # No Update
+  8.9.x: 8.3.3    # No Update
+mas_predict_version:
+  8.10.x: 8.8.2   # No Update
+  8.11.x: 8.9.0   # No Update
+  8.9.x: 8.7.2    # No Update
+mas_visualinspection_version:
+  8.10.x: 8.8.1   # No Update
+  8.11.x: 8.9.0   # No Update
+  8.9.x: 8.7.1    # No Update
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.4.0
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version_default: 4.4.21
+mongo_extras_version: "{{ lookup('env', 'MONGODB_VERSION') | default(mongo_extras_version_default, True) }}"
+
+# Variables used to mirror extra mongo versions
+mongo_extras_version_4: 4.4.21
+mongo_extras_version_5: 5.0.21
+mongo_extras_version_6: 6.0.10
+
+# Extra Images for Db2u
+# ------------------------------------------------------------------------------
+db2u_extras_version: 1.0.2
+
+# Extra Images for IBM Watson Discovery
+# ------------------------------------------------------------------------------
+wd_extras_version: 1.0.1
+
+# Extra Images for Amlen
+# ------------------------------------------------------------------------------
+amlen_extras_version: 1.0.1
+
+# Default Cloud Pak for Data version
+# ------------------------------------------------------------------------------
+cpd_product_version_default: 4.6.6
+cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default(cpd_product_version_default, true) }}"

--- a/src/mas/devops/data/catalogs/v8-231128-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v8-231128-amd64.yaml
@@ -1,0 +1,99 @@
+---
+# IBM Maximo Operator Catalog v231128
+# -----------------------------------------------------------------------------
+catalog_digest: sha256:e9f2439166ee18b540b8fc4484e3df5235bfaf7293dadd181b5755c3c79c602a
+
+# Dependencies
+# -----------------------------------------------------------------------------
+common_svcs_version: 1.19.4                  # Operator version 3.23.4 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+db2u_version: 5.1.4                          # Operator version 110508.0.2 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+events_version: 4.6.1                        # Operator version 4.6.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
+uds_version: 2.0.12                          # Operator version 2.0.12
+sls_version: 3.8.1                           # Operator version 3.8.1
+tsm_version: 1.5.1                           # Operator version 1.5.1
+dd_version: 1.1.5                            # Operator version 1.1.5
+appconnect_version: 6.2.0                    # Operator version 6.2.0
+cp4d_platform_version: 2.9.0+20230524.165553 # Operator version 3.8.0
+wsl_version: 6.5.0                           # Operator version 6.5.0
+wml_version: 6.5.0                           # Operator version 3.5.0
+spark_version: 6.5.0                         # Operator version 3.5.0
+cognos_version: 23.5.0                       # Operator version 23.5.0
+
+# Watson discovery and its dependencies
+# Match corresponding case version for default versions in the catalog source
+# -----------------------------------------------------------------------------
+wd_version: 5.5.0                            # Operator version 4.6.5
+model_train_version: 1.2.7                   # Operator version 1.1.9
+elasticsearch_version: 1.1.1541              # Operator version 1.1.1541
+couchdb_version: 1.0.13                      # Operator version 2.2.1
+
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  8.10.x: 8.10.7  # Updated
+  8.11.x: 8.11.3  # Updated
+  8.9.x: 8.9.10   # No Update
+mas_assist_version:
+  8.10.x: 8.7.2   # No Update
+  8.11.x: 8.8.1   # No Update
+  8.9.x: 8.6.5    # No Update
+mas_hputilities_version:
+  8.10.x: 8.6.2   # No Update
+  8.11.x: ""      # Not Supported
+  8.9.x: 8.5.3    # No Update
+mas_iot_version:
+  8.10.x: 8.7.6   # Updated
+  8.11.x: 8.8.2   # Updated
+  8.9.x: 8.6.9    # No Update
+mas_manage_version:
+  8.10.x: 8.6.7   # Updated
+  8.11.x: 8.7.2   # Updated
+  8.9.x: 8.5.9    # No Update
+mas_monitor_version:
+  8.10.x: 8.10.6  # Updated
+  8.11.x: 8.11.2  # Updated
+  8.9.x: 8.9.6    # No Update
+mas_optimizer_version:
+  8.10.x: 8.4.1   # No Update
+  8.11.x: 8.5.0   # No Update
+  8.9.x: 8.3.3    # No Update
+mas_predict_version:
+  8.10.x: 8.8.2   # No Update
+  8.11.x: 8.9.0   # No Update
+  8.9.x: 8.7.2    # No Update
+mas_visualinspection_version:
+  8.10.x: 8.8.1   # No Update
+  8.11.x: 8.9.0   # No Update
+  8.9.x: 8.7.1    # No Update
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.4.0
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version_default: 5.0.21
+mongo_extras_version: "{{ lookup('env', 'MONGODB_VERSION') | default(mongo_extras_version_default, True) }}"
+
+# Variables used to mirror additional mongo image versions
+mongo_extras_version_4: 4.4.21
+mongo_extras_version_5: 5.0.21
+mongo_extras_version_6: 6.0.10
+
+# Extra Images for Db2u
+# ------------------------------------------------------------------------------
+db2u_extras_version: 1.0.2
+
+# Extra Images for IBM Watson Discovery
+# ------------------------------------------------------------------------------
+wd_extras_version: 1.0.1
+
+# Extra Images for Amlen
+# ------------------------------------------------------------------------------
+amlen_extras_version: 1.0.2
+
+# Default Cloud Pak for Data version
+# ------------------------------------------------------------------------------
+cpd_product_version_default: 4.6.6
+cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default(cpd_product_version_default, true) }}"

--- a/src/mas/devops/data/catalogs/v8-231228-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v8-231228-amd64.yaml
@@ -1,0 +1,99 @@
+---
+# IBM Maximo Operator Catalog v231228
+# -----------------------------------------------------------------------------
+catalog_digest: sha256:431656fe80e0d565d9b130bb53e6ef12ec0370e3422975f6f4ddbfe95f728cda
+
+# Dependencies
+# -----------------------------------------------------------------------------
+common_svcs_version: 1.19.10                  # Operator version 3.23.10 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+db2u_version: 5.4.2                          # Operator version 110508.0.3 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+events_version: 4.9.0                        # Operator version 4.9.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
+uds_version: 2.0.12                          # Operator version 2.0.12
+sls_version: 3.8.1                           # Operator version 3.8.1
+tsm_version: 1.5.1                           # Operator version 1.5.1
+dd_version: 1.1.5                            # Operator version 1.1.5
+appconnect_version: 6.2.0                    # Operator version 6.2.0
+cp4d_platform_version: 2.9.0+20230524.165553 # Operator version 3.8.0
+wsl_version: 6.5.0                           # Operator version 6.5.0
+wml_version: 6.5.0                           # Operator version 3.5.0
+spark_version: 6.5.0                         # Operator version 3.5.0
+cognos_version: 23.5.0                       # Operator version 23.5.0
+
+# Watson discovery and its dependencies
+# Match corresponding case version for default versions in the catalog source
+# -----------------------------------------------------------------------------
+wd_version: 5.5.0                            # Operator version 4.6.5
+model_train_version: 1.2.10                  # Operator version 1.1.12
+elasticsearch_version: 1.1.1807              # Operator version 1.1.1807
+couchdb_version: 1.0.13                      # Operator version 2.2.1
+
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  8.10.x: 8.10.8  # Updated
+  8.11.x: 8.11.5  # Updated
+  8.9.x: 8.9.10   # No Update
+mas_assist_version:
+  8.10.x: 8.7.2   # No Update
+  8.11.x: 8.8.1   # No Update
+  8.9.x: 8.6.5    # No Update
+mas_hputilities_version:
+  8.10.x: 8.6.2   # No Update
+  8.11.x: ""      # Not Supported
+  8.9.x: 8.5.3    # No Update
+mas_iot_version:
+  8.10.x: 8.7.7   # Updated
+  8.11.x: 8.8.3   # Updated
+  8.9.x: 8.6.9    # No Update
+mas_manage_version:
+  8.10.x: 8.6.8   # Updated
+  8.11.x: 8.7.3   # Updated
+  8.9.x: 8.5.9    # No Update
+mas_monitor_version:
+  8.10.x: 8.10.6  # No Update
+  8.11.x: 8.11.2  # No Update
+  8.9.x: 8.9.6    # No Update
+mas_optimizer_version:
+  8.10.x: 8.4.2   # Updated
+  8.11.x: 8.5.1   # Updated
+  8.9.x: 8.3.3    # No Update
+mas_predict_version:
+  8.10.x: 8.8.2   # No Update
+  8.11.x: 8.9.0   # No Update
+  8.9.x: 8.7.2    # No Update
+mas_visualinspection_version:
+  8.10.x: 8.8.1   # No Update
+  8.11.x: 8.9.0   # No Update
+  8.9.x: 8.7.1    # No Update
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.5.0
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version_default: 5.0.23
+mongo_extras_version: "{{ lookup('env', 'MONGODB_VERSION') | default(mongo_extras_version_default, True) }}"
+
+# Variables used to mirror additional mongo image versions
+mongo_extras_version_4: 4.4.21
+mongo_extras_version_5: 5.0.23
+mongo_extras_version_6: 6.0.12
+
+# Extra Images for Db2u
+# ------------------------------------------------------------------------------
+db2u_extras_version: 1.0.3
+
+# Extra Images for IBM Watson Discovery
+# ------------------------------------------------------------------------------
+wd_extras_version: 1.0.2
+
+# Extra Images for Amlen
+# ------------------------------------------------------------------------------
+amlen_extras_version: 1.0.2
+
+# Default Cloud Pak for Data version
+# ------------------------------------------------------------------------------
+cpd_product_version_default: 4.6.6
+cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default(cpd_product_version_default, true) }}"

--- a/src/mas/devops/data/catalogs/v8-240130-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v8-240130-amd64.yaml
@@ -1,0 +1,99 @@
+---
+# IBM Maximo Operator Catalog v240130
+# -----------------------------------------------------------------------------
+catalog_digest: sha256:7944a630ce47776338238717cb04ff98e1faf90087fd339708a0785c683326ca
+
+# Dependencies
+# -----------------------------------------------------------------------------
+common_svcs_version: 1.19.11                  # Operator version 3.23.11 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+db2u_version: 5.6.0                          # Operator version 110509.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+events_version: 4.9.0                        # Operator version 4.9.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
+uds_version: 2.0.12                          # Operator version 2.0.12
+sls_version: 3.8.1                           # Operator version 3.8.1
+tsm_version: 1.5.1                           # Operator version 1.5.1
+dd_version: 1.1.6                            # Operator version 1.1.6
+appconnect_version: 6.2.0                    # Operator version 6.2.0
+cp4d_platform_version: 2.9.0+20230524.165553 # Operator version 3.8.0
+wsl_version: 6.5.0                           # Operator version 6.5.0
+wml_version: 6.5.0                           # Operator version 3.5.0
+spark_version: 6.5.0                         # Operator version 3.5.0
+cognos_version: 23.5.0                       # Operator version 23.5.0
+
+# Watson discovery and its dependencies
+# Match corresponding case version for default versions in the catalog source
+# -----------------------------------------------------------------------------
+wd_version: 5.5.0                            # Operator version 4.6.5
+model_train_version: 1.2.11                  # Operator version 1.1.13
+elasticsearch_version: 1.1.1845              # Operator version 1.1.1845
+couchdb_version: 1.0.13                      # Operator version 2.2.1
+
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  8.10.x: 8.10.9  # Updated
+  8.11.x: 8.11.6  # Updated
+  8.9.x: 8.9.10   # No Update
+mas_assist_version:
+  8.10.x: 8.7.2   # No Update
+  8.11.x: 8.8.1   # No Update
+  8.9.x: 8.6.5    # No Update
+mas_hputilities_version:
+  8.10.x: 8.6.3   # Updated
+  8.11.x: ""      # Not Supported
+  8.9.x: 8.5.3    # No Update
+mas_iot_version:
+  8.10.x: 8.7.8   # Updated
+  8.11.x: 8.8.4   # Updated
+  8.9.x: 8.6.9    # No Update
+mas_manage_version:
+  8.10.x: 8.6.9   # Updated
+  8.11.x: 8.7.4   # Updated
+  8.9.x: 8.5.9    # No Update
+mas_monitor_version:
+  8.10.x: 8.10.6  # No Update
+  8.11.x: 8.11.3  # Updated
+  8.9.x: 8.9.6    # No Update
+mas_optimizer_version:
+  8.10.x: 8.4.2   # No Update
+  8.11.x: 8.5.1   # No Update
+  8.9.x: 8.3.3    # No Update
+mas_predict_version:
+  8.10.x: 8.8.2   # No Update
+  8.11.x: 8.9.1   # Updated
+  8.9.x: 8.7.2    # No Update
+mas_visualinspection_version:
+  8.10.x: 8.8.1   # No Update
+  8.11.x: 8.9.0   # No Update
+  8.9.x: 8.7.1    # No Update
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.5.0
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version_default: 5.0.23
+mongo_extras_version: "{{ lookup('env', 'MONGODB_VERSION') | default(mongo_extras_version_default, True) }}"
+
+# Variables used to mirror additional mongo image versions
+mongo_extras_version_4: 4.4.21
+mongo_extras_version_5: 5.0.23
+mongo_extras_version_6: 6.0.12
+
+# Extra Images for Db2u
+# ------------------------------------------------------------------------------
+db2u_extras_version: 1.0.4
+
+# Extra Images for IBM Watson Discovery
+# ------------------------------------------------------------------------------
+wd_extras_version: 1.0.3
+
+# Extra Images for Amlen
+# ------------------------------------------------------------------------------
+amlen_extras_version: 1.0.2
+
+# Default Cloud Pak for Data version
+# ------------------------------------------------------------------------------
+cpd_product_version_default: 4.6.6
+cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default(cpd_product_version_default, true) }}"

--- a/src/mas/devops/data/catalogs/v8-240227-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v8-240227-amd64.yaml
@@ -1,0 +1,99 @@
+---
+# IBM Maximo Operator Catalog v240227
+# -----------------------------------------------------------------------------
+catalog_digest: sha256:8a2f2226b4aa47d42ccb564083d2a6e365fc4b116fb9a82ea83e269383a1efa1
+
+# Dependencies
+# -----------------------------------------------------------------------------
+common_svcs_version: 1.19.11                  # Operator version 3.23.11 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+db2u_version: 5.6.0                          # Operator version 110509.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+events_version: 4.9.0                        # Operator version 4.9.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
+uds_version: 2.0.12                          # Operator version 2.0.12
+sls_version: 3.8.1                           # Operator version 3.8.1
+tsm_version: 1.5.1                           # Operator version 1.5.1
+dd_version: 1.1.6                            # Operator version 1.1.6
+appconnect_version: 6.2.0                    # Operator version 6.2.0
+cp4d_platform_version: 2.9.0+20230524.165553 # Operator version 3.8.0
+wsl_version: 6.5.0                           # Operator version 6.5.0
+wml_version: 6.5.0                           # Operator version 3.5.0
+spark_version: 6.5.0                         # Operator version 3.5.0
+cognos_version: 23.5.0                       # Operator version 23.5.0
+
+# Watson discovery and its dependencies
+# Match corresponding case version for default versions in the catalog source
+# -----------------------------------------------------------------------------
+wd_version: 5.5.0                            # Operator version 4.6.5
+model_train_version: 1.2.11                  # Operator version 1.1.13
+elasticsearch_version: 1.1.1845              # Operator version 1.1.1845
+couchdb_version: 1.0.13                      # Operator version 2.2.1
+
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  8.10.x: 8.10.10 # Updated
+  8.11.x: 8.11.7  # Updated
+  8.9.x: 8.9.10   # No Update
+mas_assist_version:
+  8.10.x: 8.7.3   # Updated
+  8.11.x: 8.8.2   # Updated
+  8.9.x: 8.6.5    # No Update
+mas_hputilities_version:
+  8.10.x: 8.6.4   # Updated
+  8.11.x: ""      # Not Supported
+  8.9.x: 8.5.3    # No Update
+mas_iot_version:
+  8.10.x: 8.7.9   # Updated
+  8.11.x: 8.8.5   # Updated
+  8.9.x: 8.6.9    # No Update
+mas_manage_version:
+  8.10.x: 8.6.10  # Updated
+  8.11.x: 8.7.5   # Updated
+  8.9.x: 8.5.9    # No Update
+mas_monitor_version:
+  8.10.x: 8.10.7  # Updated
+  8.11.x: 8.11.4  # Updated
+  8.9.x: 8.9.6    # No Update
+mas_optimizer_version:
+  8.10.x: 8.4.3   # Updated
+  8.11.x: 8.5.2   # Updated
+  8.9.x: 8.3.3    # No Update
+mas_predict_version:
+  8.10.x: 8.8.2   # No Update
+  8.11.x: 8.9.2   # Updated
+  8.9.x: 8.7.2    # No Update
+mas_visualinspection_version:
+  8.10.x: 8.8.2   # Updated
+  8.11.x: 8.9.1   # Updated
+  8.9.x: 8.7.1    # No Update
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.5.0
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version_default: 5.0.23
+mongo_extras_version: "{{ lookup('env', 'MONGODB_VERSION') | default(mongo_extras_version_default, True) }}"
+
+# Variables used to mirror additional mongo image versions
+mongo_extras_version_4: 4.4.21
+mongo_extras_version_5: 5.0.23
+mongo_extras_version_6: 6.0.12
+
+# Extra Images for Db2u
+# ------------------------------------------------------------------------------
+db2u_extras_version: 1.0.4
+
+# Extra Images for IBM Watson Discovery
+# ------------------------------------------------------------------------------
+wd_extras_version: 1.0.3
+
+# Extra Images for Amlen
+# ------------------------------------------------------------------------------
+amlen_extras_version: 1.0.3
+
+# Default Cloud Pak for Data version
+# ------------------------------------------------------------------------------
+cpd_product_version_default: 4.6.6
+cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default(cpd_product_version_default, true) }}"

--- a/src/mas/devops/data/catalogs/v8-240326-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v8-240326-amd64.yaml
@@ -1,0 +1,99 @@
+---
+# IBM Maximo Operator Catalog v240326
+# -----------------------------------------------------------------------------
+catalog_digest: sha256:9c891bb6fa8496e1ef514d29b253bf5b1e817fe95963f6e536170688aa95f1d2
+
+# Dependencies
+# -----------------------------------------------------------------------------
+common_svcs_version: 1.19.12                  # Operator version 3.23.12 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+db2u_version: 5.6.2                          # Operator version 110509.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+events_version: 4.9.0                        # Operator version 4.9.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
+uds_version: 2.0.12                          # Operator version 2.0.12
+sls_version: 3.8.1                           # Operator version 3.8.1
+tsm_version: 1.5.3                           # Operator version 1.5.3
+dd_version: 1.1.7                            # Operator version 1.1.7
+appconnect_version: 6.2.0                    # Operator version 6.2.0
+cp4d_platform_version: 2.9.0+20230524.165553 # Operator version 3.8.0
+wsl_version: 6.5.0                           # Operator version 6.5.0
+wml_version: 6.5.0                           # Operator version 3.5.0
+spark_version: 6.5.0                         # Operator version 3.5.0
+cognos_version: 23.5.0                       # Operator version 23.5.0
+
+# Watson discovery and its dependencies
+# Match corresponding case version for default versions in the catalog source
+# -----------------------------------------------------------------------------
+wd_version: 5.5.0                            # Operator version 4.6.5
+model_train_version: 1.2.13                  # Operator version 1.1.15
+elasticsearch_version: 1.1.1960              # Operator version 1.1.1960
+couchdb_version: 1.0.13                      # Operator version 2.2.1
+
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  8.10.x: 8.10.11 # Updated
+  8.11.x: 8.11.8  # Updated
+  8.9.x: 8.9.10   # No Update
+mas_assist_version:
+  8.10.x: 8.7.3   # No Update
+  8.11.x: 8.8.2   # No Update
+  8.9.x: 8.6.5    # No Update
+mas_hputilities_version:
+  8.10.x: 8.6.4   # No Update
+  8.11.x: ""      # Not Supported
+  8.9.x: 8.5.3    # No Update
+mas_iot_version:
+  8.10.x: 8.7.10  # Updated
+  8.11.x: 8.8.6   # Updated
+  8.9.x: 8.6.9    # No Update
+mas_manage_version:
+  8.10.x: 8.6.11  # Updated
+  8.11.x: 8.7.6   # Updated
+  8.9.x: 8.5.9    # No Update
+mas_monitor_version:
+  8.10.x: 8.10.8  # Updated
+  8.11.x: 8.11.5  # Updated
+  8.9.x: 8.9.6    # No Update
+mas_optimizer_version:
+  8.10.x: 8.4.4   # Updated
+  8.11.x: 8.5.3   # Updated
+  8.9.x: 8.3.3    # No Update
+mas_predict_version:
+  8.10.x: 8.8.2   # No Update
+  8.11.x: 8.9.2   # No Update
+  8.9.x: 8.7.2    # No Update
+mas_visualinspection_version:
+  8.10.x: 8.8.2   # No Update
+  8.11.x: 8.9.1   # No Update
+  8.9.x: 8.7.1    # No Update
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.5.0
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version_default: 5.0.23
+mongo_extras_version: "{{ lookup('env', 'MONGODB_VERSION') | default(mongo_extras_version_default, True) }}"
+
+# Variables used to mirror additional mongo image versions
+mongo_extras_version_4: 4.4.21
+mongo_extras_version_5: 5.0.23
+mongo_extras_version_6: 6.0.12
+
+# Extra Images for Db2u
+# ------------------------------------------------------------------------------
+db2u_extras_version: 1.0.5
+
+# Extra Images for IBM Watson Discovery
+# ------------------------------------------------------------------------------
+wd_extras_version: 1.0.4
+
+# Extra Images for Amlen
+# ------------------------------------------------------------------------------
+amlen_extras_version: 1.0.3
+
+# Default Cloud Pak for Data version
+# ------------------------------------------------------------------------------
+cpd_product_version_default: 4.6.6
+cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default(cpd_product_version_default, true) }}"

--- a/src/mas/devops/data/catalogs/v8-240405-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v8-240405-amd64.yaml
@@ -1,0 +1,99 @@
+---
+# IBM Maximo Operator Catalog 240405
+# -----------------------------------------------------------------------------
+catalog_digest: sha256:8f03470e84cad81cd5e7aaaf4bce3a08b6575d48b2d27de07c25872f73ecc59c
+
+# Dependencies
+# -----------------------------------------------------------------------------
+common_svcs_version: 1.19.12                  # Operator version 3.23.12 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+db2u_version: 5.6.2                          # Operator version 110509.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+events_version: 4.9.0                        # Operator version 4.9.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
+uds_version: 2.0.12                          # Operator version 2.0.12
+sls_version: 3.8.1                           # Operator version 3.8.1
+tsm_version: 1.5.3                           # Operator version 1.5.3
+dd_version: 1.1.7                            # Operator version 1.1.7
+appconnect_version: 6.2.0                    # Operator version 6.2.0
+cp4d_platform_version: 2.9.0+20230524.165553 # Operator version 3.8.0
+wsl_version: 6.5.0                           # Operator version 6.5.0
+wml_version: 6.5.0                           # Operator version 3.5.0
+spark_version: 6.5.0                         # Operator version 3.5.0
+cognos_version: 23.5.0                       # Operator version 23.5.0
+
+# Watson discovery and its dependencies
+# Match corresponding case version for default versions in the catalog source
+# -----------------------------------------------------------------------------
+wd_version: 5.5.0                            # Operator version 4.6.5
+model_train_version: 1.2.13                  # Operator version 1.1.15
+elasticsearch_version: 1.1.1960              # Operator version 1.1.1960
+couchdb_version: 1.0.13                      # Operator version 2.2.1
+
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  8.10.x: 8.10.11 # No Update
+  8.11.x: 8.11.9  # Updated
+  8.9.x: 8.9.10   # No Update
+mas_assist_version:
+  8.10.x: 8.7.3   # No Update
+  8.11.x: 8.8.2   # No Update
+  8.9.x: 8.6.5    # No Update
+mas_hputilities_version:
+  8.10.x: 8.6.4   # No Update
+  8.11.x: ""      # Not Supported
+  8.9.x: 8.5.3    # No Update
+mas_iot_version:
+  8.10.x: 8.7.10  # No Update
+  8.11.x: 8.8.6   # No Update
+  8.9.x: 8.6.9    # No Update
+mas_manage_version:
+  8.10.x: 8.6.11  # No Update
+  8.11.x: 8.7.6   # No Update
+  8.9.x: 8.5.9    # No Update
+mas_monitor_version:
+  8.10.x: 8.10.8  # No Update
+  8.11.x: 8.11.5  # No Update
+  8.9.x: 8.9.6    # No Update
+mas_optimizer_version:
+  8.10.x: 8.4.4   # No Update
+  8.11.x: 8.5.3   # No Update
+  8.9.x: 8.3.3    # No Update
+mas_predict_version:
+  8.10.x: 8.8.2   # No Update
+  8.11.x: 8.9.2   # No Update
+  8.9.x: 8.7.2    # No Update
+mas_visualinspection_version:
+  8.10.x: 8.8.2   # No Update
+  8.11.x: 8.9.1   # No Update
+  8.9.x: 8.7.1    # No Update
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.5.0
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version_default: 5.0.23
+mongo_extras_version: "{{ lookup('env', 'MONGODB_VERSION') | default(mongo_extras_version_default, True) }}"
+
+# Variables used to mirror additional mongo image versions
+mongo_extras_version_4: 4.4.21
+mongo_extras_version_5: 5.0.23
+mongo_extras_version_6: 6.0.12
+
+# Extra Images for Db2u
+# ------------------------------------------------------------------------------
+db2u_extras_version: 1.0.5
+
+# Extra Images for IBM Watson Discovery
+# ------------------------------------------------------------------------------
+wd_extras_version: 1.0.4
+
+# Extra Images for Amlen
+# ------------------------------------------------------------------------------
+amlen_extras_version: 1.0.3
+
+# Default Cloud Pak for Data version
+# ------------------------------------------------------------------------------
+cpd_product_version_default: 4.6.6
+cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default(cpd_product_version_default, true) }}"

--- a/src/mas/devops/data/catalogs/v8-240430-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v8-240430-amd64.yaml
@@ -1,0 +1,100 @@
+---
+# IBM Maximo Operator Catalog 240430
+# -----------------------------------------------------------------------------
+catalog_digest: sha256:ce8e623505fbfca7fa207b341a442448b99ff44eeb527df5f3a4c687a47e47e4
+
+# Dependencies
+# -----------------------------------------------------------------------------
+common_svcs_version: 1.19.12                  # Operator version 3.23.12 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+db2u_version: 5.6.2                          # Operator version 110509.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+events_version: 4.9.0                        # Operator version 4.9.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
+uds_version: 2.0.12                          # Operator version 2.0.12
+sls_version: 3.9.0                           # Operator version 3.9.0
+tsm_version: 1.5.3                           # Operator version 1.5.3
+dd_version: 1.1.7                            # Operator version 1.1.7
+appconnect_version: 6.2.0                    # Operator version 6.2.0
+cp4d_platform_version: 2.9.0+20230524.165553 # Operator version 3.8.0
+wsl_version: 6.5.0                           # Operator version 6.5.0
+wml_version: 6.5.0                           # Operator version 3.5.0
+spark_version: 6.5.0                         # Operator version 3.5.0
+cognos_version: 23.5.0                       # Operator version 23.5.0
+
+
+# Watson discovery and its dependencies
+# Match corresponding case version for default versions in the catalog source
+# -----------------------------------------------------------------------------
+wd_version: 5.5.0                            # Operator version 4.6.5
+model_train_version: 1.2.13                  # Operator version 1.1.15
+elasticsearch_version: 1.1.1960              # Operator version 1.1.1960
+couchdb_version: 1.0.13                      # Operator version 2.2.1
+
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  8.10.x: 8.10.13 # Updated
+  8.11.x: 8.11.10 # Updated
+  8.9.x: 8.9.10   # No Update
+mas_assist_version:
+  8.10.x: 8.7.4   # Updated
+  8.11.x: 8.8.3   # Updated
+  8.9.x: 8.6.5    # No Update
+mas_hputilities_version:
+  8.10.x: 8.6.5   # Updated
+  8.11.x: ""      # Not Supported
+  8.9.x: 8.5.3    # No Update
+mas_iot_version:
+  8.10.x: 8.7.11  # Updated
+  8.11.x: 8.8.7   # Updated
+  8.9.x: 8.6.9    # No Update
+mas_manage_version:
+  8.10.x: 8.6.13  # Updated
+  8.11.x: 8.7.7   # Updated
+  8.9.x: 8.5.9    # No Update
+mas_monitor_version:
+  8.10.x: 8.10.9  # Updated
+  8.11.x: 8.11.6  # Updated
+  8.9.x: 8.9.6    # No Update
+mas_optimizer_version:
+  8.10.x: 8.4.5   # Updated
+  8.11.x: 8.5.4   # Updated
+  8.9.x: 8.3.3    # No Update
+mas_predict_version:
+  8.10.x: 8.8.2   # No Update
+  8.11.x: 8.9.2   # No Update
+  8.9.x: 8.7.2    # No Update
+mas_visualinspection_version:
+  8.10.x: 8.8.3   # Updated
+  8.11.x: 8.9.2   # Updated
+  8.9.x: 8.7.1    # No Update
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.5.0
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version_default: 5.0.23
+mongo_extras_version: "{{ lookup('env', 'MONGODB_VERSION') | default(mongo_extras_version_default, True) }}"
+
+# Variables used to mirror additional mongo image versions
+mongo_extras_version_4: 4.4.21
+mongo_extras_version_5: 5.0.23
+mongo_extras_version_6: 6.0.12
+
+# Extra Images for Db2u
+# ------------------------------------------------------------------------------
+db2u_extras_version: 1.0.5
+
+# Extra Images for IBM Watson Discovery
+# ------------------------------------------------------------------------------
+wd_extras_version: 1.0.4
+
+# Extra Images for Amlen
+# ------------------------------------------------------------------------------
+amlen_extras_version: 1.0.3
+
+# Default Cloud Pak for Data version
+# ------------------------------------------------------------------------------
+cpd_product_version_default: 4.6.6
+cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default(cpd_product_version_default, true) }}"

--- a/src/mas/devops/data/catalogs/v8-240528-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v8-240528-amd64.yaml
@@ -1,0 +1,99 @@
+---
+# IBM Maximo Operator Catalog 240528
+# -----------------------------------------------------------------------------
+catalog_digest: sha256:5ca51934b3aec978e261e6dc9704fd3d46a308010bd6c86252788d69aac3fa9f
+
+# Dependencies
+# -----------------------------------------------------------------------------
+common_svcs_version: 1.19.13                 # Operator version 3.23.13 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+db2u_version: 5.6.2                          # Operator version 110509.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+events_version: 5.0.0                        # Operator version 5.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
+uds_version: 2.0.12                          # Operator version 2.0.12
+sls_version: 3.9.1                           # Operator version 3.9.1 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
+tsm_version: 1.5.3                           # Operator version 1.5.3 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
+dd_version: 1.1.8                            # Operator version 1.1.8 (https://github.ibm.com/maximoappsuite/ibm-data-dictionary/releases)
+appconnect_version: 6.2.0                    # Operator version 6.2.0
+cp4d_platform_version: 2.9.0+20230524.165553 # Operator version 3.8.0
+wsl_version: 6.5.0                           # Operator version 6.5.0
+wml_version: 6.5.0                           # Operator version 3.5.0
+spark_version: 6.5.0                         # Operator version 3.5.0
+cognos_version: 23.5.0                       # Operator version 23.5.0
+
+# Watson discovery and its dependencies
+# Match corresponding case version for default versions in the catalog source
+# -----------------------------------------------------------------------------
+wd_version: 5.5.0                            # Operator version 4.6.5
+model_train_version: 1.2.13                  # Operator version 1.1.15
+elasticsearch_version: 1.1.2071              # Operator version 1.1.2071
+couchdb_version: 1.0.13                      # Operator version 2.2.1
+
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  8.10.x: 8.10.14 # Updated
+  8.11.x: 8.11.11 # Updated
+  8.9.x: 8.9.10   # No Update
+mas_assist_version:
+  8.10.x: 8.7.4   # No Update
+  8.11.x: 8.8.3   # No Update
+  8.9.x: 8.6.5    # No Update
+mas_hputilities_version:
+  8.10.x: 8.6.5   # No Update
+  8.11.x: ""      # Not Supported
+  8.9.x: 8.5.3    # No Update
+mas_iot_version:
+  8.10.x: 8.7.13  # Updated
+  8.11.x: 8.8.9   # Updated
+  8.9.x: 8.6.9    # No Update
+mas_manage_version:
+  8.10.x: 8.6.14  # Updated
+  8.11.x: 8.7.8   # Updated
+  8.9.x: 8.5.9    # No Update
+mas_monitor_version:
+  8.10.x: 8.10.10 # Updated
+  8.11.x: 8.11.7  # Updated
+  8.9.x: 8.9.6    # No Update
+mas_optimizer_version:
+  8.10.x: 8.4.6   # Updated
+  8.11.x: 8.5.5   # Updated
+  8.9.x: 8.3.3    # No Update
+mas_predict_version:
+  8.10.x: 8.8.2   # No Update
+  8.11.x: 8.9.2   # No Update
+  8.9.x: 8.7.2    # No Update
+mas_visualinspection_version:
+  8.10.x: 8.8.4   # Updated
+  8.11.x: 8.9.3   # Updated
+  8.9.x: 8.7.1    # No Update
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.5.0
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version_default: 5.0.23
+mongo_extras_version: "{{ lookup('env', 'MONGODB_VERSION') | default(mongo_extras_version_default, True) }}"
+
+# Variables used to mirror additional mongo image versions
+mongo_extras_version_4: 4.4.21
+mongo_extras_version_5: 5.0.23
+mongo_extras_version_6: 6.0.12
+
+# Extra Images for Db2u
+# ------------------------------------------------------------------------------
+db2u_extras_version: 1.0.5
+
+# Extra Images for IBM Watson Discovery
+# ------------------------------------------------------------------------------
+wd_extras_version: 1.0.4
+
+# Extra Images for Amlen
+# ------------------------------------------------------------------------------
+amlen_extras_version: 1.1.1
+
+# Default Cloud Pak for Data version
+# ------------------------------------------------------------------------------
+cpd_product_version_default: 4.6.6
+cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default(cpd_product_version_default, true) }}"

--- a/src/mas/devops/data/catalogs/v9-240625-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-240625-amd64.yaml
@@ -1,0 +1,95 @@
+---
+# IBM Maximo Operator Catalog 240625
+# -----------------------------------------------------------------------------
+catalog_digest: sha256:e74f646327e728aa523199e9dfb2e95efb67385755c3ac9f0763ab6563e63843
+
+# Dependencies
+# -----------------------------------------------------------------------------
+ibm_licensing_version: 4.2.3                 # Operator version 4.2.3 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-licensing)
+common_svcs_version: 4.3.0                   # Operator version 4.3.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+cp4d_platform_version: 4.0.0+20231213.115030 # Operator version 5.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-datacore/4.0.0%2B20231213.115030)
+
+db2u_version: 5.6.2                          # Operator version 110509.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+events_version: 5.0.0                        # Operator version 5.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
+uds_version: 2.0.12                          # Operator version 2.0.12
+sls_version: 3.9.1                           # Operator version 3.9.1 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
+tsm_version: 1.5.4                           # Operator version 1.5.4 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
+dd_version: 1.1.9                            # Operator version 1.1.9 (https://github.ibm.com/maximoappsuite/ibm-data-dictionary/releases)
+appconnect_version: 6.2.0                    # Operator version 6.2.0
+wsl_version: 8.0.0                           # Operator version 8.0.0
+wml_version: 8.0.0                           # Operator version 5.0.0
+spark_version: 8.0.0                         # Operator version 5.0.0
+cognos_version: 25.0.0                       # Operator version 25.0.0
+couchdb_version: 1.0.13                      # Operator version 2.2.1 (This is required for Assist 9.0, https://github.com/IBM/cloud-pak/blob/master/repo/case/ibm-couchdb/index.yaml)
+elasticsearch_version: 1.1.2071              # Operator version 1.1.2071
+
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  9.0.x: 9.0.0    # Updated
+  8.10.x: 8.10.15 # Updated
+  8.11.x: 8.11.12 # Updated
+mas_assist_version:
+  9.0.x: 9.0.0    # Updated
+  8.10.x: 8.7.5   # Updated
+  8.11.x: 8.8.4   # Updated
+mas_hputilities_version:
+  9.0.x: ""       # Not Supported
+  8.10.x: 8.6.5   # No Update
+  8.11.x: ""      # Not Supported
+mas_iot_version:
+  9.0.x: 9.0.0    # Updated
+  8.10.x: 8.7.14  # Updated
+  8.11.x: 8.8.10  # Updated
+mas_manage_version:
+  9.0.x: 9.0.0    # Updated
+  8.10.x: 8.6.15  # Updated
+  8.11.x: 8.7.9   # Updated
+mas_monitor_version:
+  9.0.x: 9.0.0    # Updated
+  8.10.x: 8.10.11 # Updated
+  8.11.x: 8.11.8  # Updated
+mas_optimizer_version:
+  9.0.x: 9.0.0    # Updated
+  8.10.x: 8.4.7   # Updated
+  8.11.x: 8.5.6   # Updated
+mas_predict_version:
+  9.0.x: 9.0.0    # Updated
+  8.10.x: 8.8.2   # No Update
+  8.11.x: 8.9.3   # Updated
+mas_visualinspection_version:
+  9.0.x: 9.0.0    # Updated
+  8.10.x: 8.8.4   # No update
+  8.11.x: 8.9.3   # No update
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.5.0
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version_default: 6.0.12
+mongo_extras_version: "{{ lookup('env', 'MONGODB_VERSION') | default(mongo_extras_version_default, True) }}"
+
+# Variables used to mirror additional mongo image versions
+mongo_extras_version_4: 4.4.21
+mongo_extras_version_5: 5.0.23
+mongo_extras_version_6: 6.0.12
+
+# Extra Images for Db2u
+# ------------------------------------------------------------------------------
+db2u_extras_version: 1.0.5
+
+# Extra Images for IBM Watson Discovery
+# ------------------------------------------------------------------------------
+#wd_extras_version: 1.0.4
+
+# Extra Images for Amlen
+# ------------------------------------------------------------------------------
+amlen_extras_version: 1.1.1
+
+# Default Cloud Pak for Data version
+# ------------------------------------------------------------------------------
+cpd_product_version_default: 4.8.0
+cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default(cpd_product_version_default, true) }}"

--- a/src/mas/devops/data/catalogs/v9-240730-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-240730-amd64.yaml
@@ -1,0 +1,96 @@
+---
+# IBM Maximo Operator Catalog 240730
+# -----------------------------------------------------------------------------
+catalog_digest: sha256:c38ceab72008bd8ae6ecb4bf8e29453e6a6e6d8ecbdb1e40b465fef401c51d56
+
+# Dependencies
+# -----------------------------------------------------------------------------
+ibm_licensing_version: 4.2.4                 # Operator version 4.2.4 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-licensing)
+common_svcs_version: 4.3.0                   # Operator version 4.3.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+cp4d_platform_version: 4.0.0+20231213.115030 # Operator version 5.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-datacore/4.0.0%2B20231213.115030)
+
+db2u_version: 5.6.2                          # Operator version 110509.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+events_version: 5.0.1                        # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
+uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
+sls_version: 3.9.1                           # Operator version 3.9.1 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
+tsm_version: 1.5.4                           # Operator version 1.5.4 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
+dd_version: 1.1.10 # updated                 # Operator version 1.1.10 (https://github.ibm.com/maximoappsuite/ibm-data-dictionary/releases)
+appconnect_version: 6.2.0                    # Operator version 6.2.0 # sticking to 6.2.0 version # Please do Not Change
+wsl_version: 8.0.0                           # Operator version 8.0.0
+wml_version: 8.0.0                           # Operator version 5.0.0
+spark_version: 8.0.0                         # Operator version 5.0.0
+cognos_version: 25.0.0                       # Operator version 25.0.0
+couchdb_version: 1.0.13                      # Operator version 2.2.1 (This is required for Assist 9.0, https://github.com/IBM/cloud-pak/blob/master/repo/case/ibm-couchdb/index.yaml)
+elasticsearch_version: 1.1.2153              # Operator version 1.1.2153
+
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  9.0.x: 9.0.1    # Updated
+  8.10.x: 8.10.16 # Updated
+  8.11.x: 8.11.13 # Updated
+mas_assist_version:
+  9.0.x: 9.0.1    # Updated
+  8.10.x: 8.7.6   # Updated
+  8.11.x: 8.8.5   # Updated
+mas_hputilities_version:
+  9.0.x: ""       # Not Supported
+  8.10.x: 8.6.6   # Updated
+  8.11.x: ""      # Not Supported
+mas_iot_version:
+  9.0.x: 9.0.1    # Updated
+  8.10.x: 8.7.15  # Updated
+  8.11.x: 8.8.11  # Updated
+mas_manage_version:
+  9.0.x: 9.0.1    # Updated
+  8.10.x: 8.6.16  # Updated
+  8.11.x: 8.7.10  # Updated
+mas_monitor_version:
+  9.0.x: 9.0.1    # Updated
+  8.10.x: 8.10.12 # Updated
+  8.11.x: 8.11.9  # Updated
+mas_optimizer_version:
+  9.0.x: 9.0.1    # Updated
+  8.10.x: 8.4.8   # Updated
+  8.11.x: 8.5.7   # Updated
+mas_predict_version:
+  9.0.x: 9.0.0    # No Update
+  8.10.x: 8.8.3   # Updated
+  8.11.x: 8.9.3   # No Update
+mas_visualinspection_version:
+  9.0.x: 9.0.1    # Updated
+  8.10.x: 8.8.4   # No update
+  8.11.x: 8.9.4   # Updated
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.5.0
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version_default: 6.0.12
+mongo_extras_version: "{{ lookup('env', 'MONGODB_VERSION') | default(mongo_extras_version_default, True) }}"
+
+# Variables used to mirror additional mongo image versions
+mongo_extras_version_4: 4.4.21
+mongo_extras_version_5: 5.0.23
+mongo_extras_version_6: 6.0.12
+mongo_extras_version_7: 7.0.12
+
+# Extra Images for Db2u
+# ------------------------------------------------------------------------------
+db2u_extras_version: 1.0.5
+
+# Extra Images for IBM Watson Discovery
+# ------------------------------------------------------------------------------
+#wd_extras_version: 1.0.4
+
+# Extra Images for Amlen
+# ------------------------------------------------------------------------------
+amlen_extras_version: 1.1.1
+
+# Default Cloud Pak for Data version
+# ------------------------------------------------------------------------------
+cpd_product_version_default: 4.8.0
+cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default(cpd_product_version_default, true) }}"

--- a/src/mas/devops/data/catalogs/v9-240827-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-240827-amd64.yaml
@@ -1,0 +1,95 @@
+---
+# IBM Maximo Operator Catalog 240827
+# -----------------------------------------------------------------------------
+catalog_digest: sha256:bcace8fa41d14ce1b818467243bbc8469f7538ac4bc46198139454626f99f367
+
+# Dependencies
+# -----------------------------------------------------------------------------
+ibm_licensing_version: 4.2.4                 # Operator version 4.2.4 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-licensing)
+common_svcs_version: 4.3.0                   # Operator version 4.3.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+cp4d_platform_version: 4.0.0+20231213.115030 # Operator version 5.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-datacore/4.0.0%2B20231213.115030)
+
+db2u_version: 5.6.2                          # Operator version 110509.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+events_version: 5.0.1                        # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
+uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
+sls_version: 3.10.0 # updated                # Operator version 3.10.0 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
+tsm_version: 1.5.4                           # Operator version 1.5.4 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
+dd_version: 1.1.11 # updated                 # Operator version 1.1.11 (https://github.ibm.com/maximoappsuite/ibm-data-dictionary/releases)
+appconnect_version: 6.2.0                    # Operator version 6.2.0 # sticking to 6.2.0 version # Please do Not Change
+wsl_version: 8.0.0                           # Operator version 8.0.0
+wml_version: 8.0.0                           # Operator version 5.0.0
+spark_version: 8.0.0                         # Operator version 5.0.0
+cognos_version: 25.0.0                       # Operator version 25.0.0
+couchdb_version: 1.0.13                      # Operator version 2.2.1 (This is required for Assist 9.0, https://github.com/IBM/cloud-pak/blob/master/repo/case/ibm-couchdb/index.yaml)
+elasticsearch_version: 1.1.2153              # Operator version 1.1.2153
+
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  9.0.x: 9.0.2    # Updated
+  8.10.x: 8.10.17 # Updated
+  8.11.x: 8.11.14 # Updated
+mas_assist_version:
+  9.0.x: 9.0.2    # Updated
+  8.10.x: 8.7.7   # Updated
+  8.11.x: 8.8.6   # Updated
+mas_hputilities_version:
+  9.0.x: ""       # Not Supported
+  8.10.x: 8.6.7   # Updated
+  8.11.x: ""      # Not Supported
+mas_iot_version:
+  9.0.x: 9.0.2    # Updated
+  8.10.x: 8.7.16  # Updated
+  8.11.x: 8.8.12  # Updated
+mas_manage_version:
+  9.0.x: 9.0.2    # Updated
+  8.10.x: 8.6.17  # Updated
+  8.11.x: 8.7.11  # Updated
+mas_monitor_version:
+  9.0.x: 9.0.2    # Updated
+  8.10.x: 8.10.13 # Updated
+  8.11.x: 8.11.10  # Updated
+mas_optimizer_version:
+  9.0.x: 9.0.2    # Updated
+  8.10.x: 8.4.9   # Updated
+  8.11.x: 8.5.8   # Updated
+mas_predict_version:
+  9.0.x: 9.0.1    # Updated
+  8.10.x: 8.8.3   # No Update
+  8.11.x: 8.9.3   # No Update
+mas_visualinspection_version:
+  9.0.x: 9.0.2    # Updated
+  8.10.x: 8.8.4   # No update
+  8.11.x: 8.9.5   # Updated
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.5.0
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version_default: 6.0.12
+mongo_extras_version: "{{ lookup('env', 'MONGODB_VERSION') | default(mongo_extras_version_default, True) }}"
+
+# Variables used to mirror additional mongo image versions
+mongo_extras_version_4: 4.4.21
+mongo_extras_version_5: 5.0.23
+mongo_extras_version_6: 6.0.12
+
+# Extra Images for Db2u
+# ------------------------------------------------------------------------------
+db2u_extras_version: 1.0.5
+
+# Extra Images for IBM Watson Discovery
+# ------------------------------------------------------------------------------
+#wd_extras_version: 1.0.4
+
+# Extra Images for Amlen
+# ------------------------------------------------------------------------------
+amlen_extras_version: 1.1.1
+
+# Default Cloud Pak for Data version
+# ------------------------------------------------------------------------------
+cpd_product_version_default: 4.8.0
+cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default(cpd_product_version_default, true) }}"

--- a/src/mas/devops/data/catalogs/v9-241003-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-241003-amd64.yaml
@@ -1,0 +1,96 @@
+---
+# IBM Maximo Operator Catalog 241003
+# -----------------------------------------------------------------------------
+catalog_digest: sha256:ba2237481b2ce7407698775a71f44daaecd2db6f74855f20829ac1bceeddb3d9
+
+# Dependencies
+# -----------------------------------------------------------------------------
+ibm_licensing_version: 4.2.7                 # Operator version 4.2.7 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-licensing)
+common_svcs_version: 4.3.0                   # check once why we have 4.3.0 in all previous versions since so long it's 4.3.0   # Operator version 4.3.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+cp4d_platform_version: 4.0.0+20231213.115030 # Operator version 5.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-datacore/4.0.0%2B20231213.115030)
+
+db2u_version: 6.0.1+20240704.142950.9960     # Operator version 110509.0.2 to find the version 6.0.1, search CASE_VERSION in db2u, catalog.yaml into ibm-maximo-operator-catalog (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+events_version: 5.0.1                        # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
+uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
+sls_version: 3.10.0 # No Update              # Operator version 3.10.0 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
+tsm_version: 1.5.4                           # Operator version 1.5.4 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
+dd_version: 1.1.12 # Updated                 # Operator version 1.1.11 (https://github.ibm.com/maximoappsuite/ibm-data-dictionary/releases)
+appconnect_version: 6.2.0                    # Operator version 6.2.0 # sticking to 6.2.0 version # Please do Not Change
+wsl_version: 8.0.0                           # Operator version 8.0.0
+wml_version: 8.0.0                           # Operator version 5.0.0
+spark_version: 8.0.0                         # Operator version 5.0.0
+cognos_version: 25.0.0                       # Operator version 25.0.0
+couchdb_version: 1.0.13                      # Operator version 2.2.1 (This is required for Assist 9.0, https://github.com/IBM/cloud-pak/blob/master/repo/case/ibm-couchdb/index.yaml)
+elasticsearch_version: 1.1.2238              # Operator version 1.1.2238
+
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  9.0.x: 9.0.3    # Updated
+  8.10.x: 8.10.18 # Updated
+  8.11.x: 8.11.15 # Updated
+mas_assist_version:
+  9.0.x: 9.0.2    # No Update
+  8.10.x: 8.7.7   # No Update
+  8.11.x: 8.8.6   # No Update
+mas_hputilities_version:
+  9.0.x: ""       # Not Supported
+  8.10.x: 8.6.7   # No Update
+  8.11.x: ""      # Not Supported
+mas_iot_version:
+  9.0.x: 9.0.3    # Updated
+  8.10.x: 8.7.17  # Updated
+  8.11.x: 8.8.13  # Updated
+mas_manage_version:
+  9.0.x: 9.0.3    # Updated
+  8.10.x: 8.6.18  # Updated
+  8.11.x: 8.7.12  # Updated
+mas_monitor_version:
+  9.0.x: 9.0.3    # Updated
+  8.10.x: 8.10.14 # Updated
+  8.11.x: 8.11.11 # Updated
+mas_optimizer_version:
+  9.0.x: 9.0.3    # Updated
+  8.10.x: 8.4.10  # Updated
+  8.11.x: 8.5.9   # Updated
+mas_predict_version:
+  9.0.x: 9.0.2    # Updated
+  8.10.x: 8.8.3   # No Update
+  8.11.x: 8.9.5   # Updated
+mas_visualinspection_version:
+  9.0.x: 9.0.3    # Updated
+  8.10.x: 8.8.4   # No update
+  8.11.x: 8.9.6   # Updated
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.5.0
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version_default: 7.0.12
+mongo_extras_version: "{{ lookup('env', 'MONGODB_VERSION') | default(mongo_extras_version_default, True) }}"
+
+# Variables used to mirror additional mongo image versions
+mongo_extras_version_4: 4.4.21
+mongo_extras_version_5: 5.0.23
+mongo_extras_version_6: 6.0.12
+mongo_extras_version_7: 7.0.12
+
+# Extra Images for Db2u
+# ------------------------------------------------------------------------------
+db2u_extras_version: 1.0.6
+
+# Extra Images for IBM Watson Discovery
+# ------------------------------------------------------------------------------
+#wd_extras_version: 1.0.4
+
+# Extra Images for Amlen
+# ------------------------------------------------------------------------------
+amlen_extras_version: 1.1.1
+
+# Default Cloud Pak for Data version
+# ------------------------------------------------------------------------------
+cpd_product_version_default: 4.8.0
+cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default(cpd_product_version_default, true) }}"

--- a/src/mas/devops/data/catalogs/v9-241107-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-241107-amd64.yaml
@@ -1,0 +1,96 @@
+---
+# IBM Maximo Operator Catalog 241107
+# -----------------------------------------------------------------------------
+catalog_digest: sha256:2d470131ab6948d5262553547fafa1b472fa25690be5abba8719ad7493cd8911
+
+# Dependencies
+# -----------------------------------------------------------------------------
+ibm_licensing_version: 4.2.7                 # Operator version 4.2.7 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-licensing)
+common_svcs_version: 4.3.0                   # check once why we have 4.3.0 in all previous versions since so long it's 4.3.0   # Operator version 4.3.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+cp4d_platform_version: 4.0.0+20231213.115030 # Operator version 5.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-datacore/4.0.0%2B20231213.115030)
+
+db2u_version: 6.0.1+20240704.142950.9960     # Operator version 110509.0.2 to find the version 6.0.1, search CASE_VERSION in db2u, catalog.yaml into ibm-maximo-operator-catalog (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+events_version: 5.0.1                        # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
+uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
+sls_version: 3.10.1 # Updated                # Operator version 3.10.0 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
+tsm_version: 1.5.4                           # Operator version 1.5.4 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
+dd_version: 1.1.12 # No Update                 # Operator version 1.1.11 (https://github.ibm.com/maximoappsuite/ibm-data-dictionary/releases)
+appconnect_version: 6.2.0                    # Operator version 6.2.0 # sticking to 6.2.0 version # Please do Not Change
+wsl_version: 8.0.0                           # Operator version 8.0.0
+wml_version: 8.0.0                           # Operator version 5.0.0
+spark_version: 8.0.0                         # Operator version 5.0.0
+cognos_version: 25.0.0                       # Operator version 25.0.0
+couchdb_version: 1.0.13                      # Operator version 2.2.1 (This is required for Assist 9.0, https://github.com/IBM/cloud-pak/blob/master/repo/case/ibm-couchdb/index.yaml)
+elasticsearch_version: 1.1.2238              # Operator version 1.1.2238
+
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  9.0.x: 9.0.5    # Updated
+  8.10.x: 8.10.19 # Updated
+  8.11.x: 8.11.16 # Updated
+mas_assist_version:
+  9.0.x: 9.0.2    # No Update
+  8.10.x: 8.7.7   # No Update
+  8.11.x: 8.8.6   # No Update
+mas_hputilities_version:
+  9.0.x: ""       # Not Supported
+  8.10.x: 8.6.7   # No Update
+  8.11.x: ""      # Not Supported
+mas_iot_version:
+  9.0.x: 9.0.4    # Updated
+  8.10.x: 8.7.18  # Updated
+  8.11.x: 8.8.14  # Updated
+mas_manage_version:
+  9.0.x: 9.0.5    # Updated
+  8.10.x: 8.6.19  # Updated
+  8.11.x: 8.7.13  # Updated
+mas_monitor_version:
+  9.0.x: 9.0.4    # Updated
+  8.10.x: 8.10.14 # No Update
+  8.11.x: 8.11.12 # Updated
+mas_optimizer_version:
+  9.0.x: 9.0.4    # Updated
+  8.10.x: 8.4.11  # Updated
+  8.11.x: 8.5.10   # Updated
+mas_predict_version:
+  9.0.x: 9.0.2    # No Update
+  8.10.x: 8.8.4   # Updated
+  8.11.x: 8.9.5   # No Update
+mas_visualinspection_version:
+  9.0.x: 9.0.4    # Updated
+  8.10.x: 8.8.4   # No update
+  8.11.x: 8.9.7   # Updated
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.5.0
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version_default: 7.0.12
+mongo_extras_version: "{{ lookup('env', 'MONGODB_VERSION') | default(mongo_extras_version_default, True) }}"
+
+# Variables used to mirror additional mongo image versions
+mongo_extras_version_4: 4.4.21
+mongo_extras_version_5: 5.0.23
+mongo_extras_version_6: 6.0.12
+mongo_extras_version_7: 7.0.12
+
+# Extra Images for Db2u
+# ------------------------------------------------------------------------------
+db2u_extras_version: 1.0.6
+
+# Extra Images for IBM Watson Discovery
+# ------------------------------------------------------------------------------
+#wd_extras_version: 1.0.4
+
+# Extra Images for Amlen
+# ------------------------------------------------------------------------------
+amlen_extras_version: 1.1.2
+
+# Default Cloud Pak for Data version
+# ------------------------------------------------------------------------------
+cpd_product_version_default: 4.8.0
+cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default(cpd_product_version_default, true) }}"

--- a/src/mas/devops/mas.py
+++ b/src/mas/devops/mas.py
@@ -9,6 +9,7 @@
 # *****************************************************************************
 
 import logging
+import re
 
 from openshift.dynamic import DynamicClient
 from openshift.dynamic.exceptions import NotFoundError, UnauthorizedError
@@ -23,6 +24,32 @@ def isAirgapInstall(dynClient: DynamicClient) -> bool:
         return True
     except NotFoundError:
         return False
+
+
+def getCurrentCatalog(dynClient: DynamicClient) -> dict:
+    catalogsAPI = dynClient.resources.get(api_version="operators.coreos.com/v1alpha1", kind="CatalogSource")
+    try:
+        catalog = catalogsAPI.get(name="ibm-operator-catalog", namespace="openshift-marketplace")
+        catalogDisplayName = catalog.spec.displayName
+        catalogImage = catalog.spec.image
+
+        m = re.match(r".+(?P<catalogId>v[89]-(?P<catalogVersion>[0-9]+)-(amd64|s390x|ppc64le))", catalogDisplayName)
+        if m:
+            # catalogId = v9-yymmdd-amd64
+            # catalogVersion = yymmdd
+            installedCatalogId = m.group("catalogId")
+        elif re.match(r".+v8-amd64", catalogDisplayName):
+            installedCatalogId = "v8-amd64"
+        else:
+            installedCatalogId = None
+
+        return {
+            "displayName": catalogDisplayName,
+            "image": catalogImage,
+            "catalogId": installedCatalogId,
+        }
+    except NotFoundError:
+        return None
 
 
 def listMasInstances(dynClient: DynamicClient) -> list:

--- a/test/src/test_data.py
+++ b/test/src/test_data.py
@@ -1,0 +1,16 @@
+# *****************************************************************************
+# Copyright (c) 2024 IBM Corporation and other Contributors.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# *****************************************************************************
+
+from mas.devops.data import getCatalog
+
+
+def test_catalog():
+    catalogData = getCatalog("v9-241107-amd64")
+    assert catalogData["catalog_digest"] == "sha256:2d470131ab6948d5262553547fafa1b472fa25690be5abba8719ad7493cd8911"


### PR DESCRIPTION
Migrate catalog metadata out of the Ansible collection so that we can use it directly in python code, reducing duplication.