### PR TITLE
[minor] New functions to support Ansible collection

### DIFF
--- a/src/mas/devops/data/__init__.py
+++ b/src/mas/devops/data/__init__.py
@@ -31,4 +31,8 @@ def listCatalogTags(arch="amd64") -> list:
 
 
 def getNewestCatalogTag(arch="amd64") -> str:
-    return listCatalogTags(arch)[-1]
+    catalogs = listCatalogTags(arch)
+    if len(catalogs) == 0:
+        return None
+    else:
+        return catalogs[-1]

--- a/src/mas/devops/data/__init__.py
+++ b/src/mas/devops/data/__init__.py
@@ -25,7 +25,7 @@ def listCatalogTags(arch="amd64") -> list:
     modulePath = path.dirname(moduleFile)
     yamlFiles = glob(path.join(modulePath, "catalogs", f"*-{arch}.yaml"))
     result = []
-    for yamlFile in yamlFiles:
+    for yamlFile in sorted(yamlFiles):
         result.append(path.basename(yamlFile).replace(".yaml", ""))
     return result
 

--- a/src/mas/devops/data/__init__.py
+++ b/src/mas/devops/data/__init__.py
@@ -8,6 +8,7 @@
 #
 # *****************************************************************************
 import yaml
+from glob import glob
 from os import path
 
 
@@ -17,3 +18,17 @@ def getCatalog(name: str) -> dict:
     catalogFileName = f"{name}.yaml"
     with open(path.join(modulePath, "catalogs", catalogFileName)) as stream:
         return yaml.safe_load(stream)
+
+
+def listCatalogTags(arch="amd64") -> list:
+    moduleFile = path.abspath(__file__)
+    modulePath = path.dirname(moduleFile)
+    yamlFiles = glob(path.join(modulePath, "catalogs", f"*-{arch}.yaml"))
+    result = []
+    for yamlFile in yamlFiles:
+        result.append(path.basename(yamlFile).replace(".yaml", ""))
+    return result
+
+
+def getNewestCatalogTag(arch="amd64") -> str:
+    return listCatalogTags(arch)[-1]

--- a/test/src/test_data.py
+++ b/test/src/test_data.py
@@ -8,9 +8,20 @@
 #
 # *****************************************************************************
 
-from mas.devops.data import getCatalog
+from mas.devops.data import getCatalog, getNewestCatalogTag, listCatalogTags
 
 
 def test_catalog():
     catalogData = getCatalog("v9-241107-amd64")
     assert catalogData["catalog_digest"] == "sha256:2d470131ab6948d5262553547fafa1b472fa25690be5abba8719ad7493cd8911"
+
+
+def test_list_catalogs():
+    catalogList = listCatalogTags("amd64")
+    assert len(catalogList) > 0
+    assert "v9-241107-amd64" in catalogList
+
+
+def test_get_newest_catalog_tag():
+    catalogTag = getNewestCatalogTag("amd64")
+    assert catalogTag == "v9-241107-amd64"

--- a/test/src/test_data.py
+++ b/test/src/test_data.py
@@ -25,3 +25,6 @@ def test_list_catalogs():
 def test_get_newest_catalog_tag():
     catalogTag = getNewestCatalogTag("amd64")
     assert catalogTag == "v9-241107-amd64"
+
+    catalogTag = getNewestCatalogTag("doesntexist")
+    assert catalogTag is None

--- a/test/src/test_data.py
+++ b/test/src/test_data.py
@@ -24,7 +24,10 @@ def test_list_catalogs():
 
 def test_get_newest_catalog_tag():
     catalogTag = getNewestCatalogTag("amd64")
+    # Reminder: update this test when adding a new catalog each month!
     assert catalogTag == "v9-241107-amd64"
 
+
+def test_get_newest_catalog_tag_fail():
     catalogTag = getNewestCatalogTag("doesntexist")
     assert catalogTag is None


### PR DESCRIPTION
Adds two new function:

- `mas.devops.data.listCatalogTags()`
- `mas.devops.data.getNewestCatalogTag()`

These are required for consolidating catalog metadata into this package and removing `common_vars/casebundles` from the Ansible collection.