### PR TITLE
[patch] Fix handling when catalog does not exist

### DIFF
--- a/src/mas/devops/data/__init__.py
+++ b/src/mas/devops/data/__init__.py
@@ -16,7 +16,12 @@ def getCatalog(name: str) -> dict:
     moduleFile = path.abspath(__file__)
     modulePath = path.dirname(moduleFile)
     catalogFileName = f"{name}.yaml"
-    with open(path.join(modulePath, "catalogs", catalogFileName)) as stream:
+
+    pathToCatalog = path.join(modulePath, "catalogs", catalogFileName)
+    if not path.exists(pathToCatalog):
+        return None
+
+    with open(pathToCatalog) as stream:
         return yaml.safe_load(stream)
 
 


### PR DESCRIPTION
In `getCatalog()` return `None` instead of raising an exception if the catalog does not exist.