### PR TITLE
[minor] Support IBM entitlement key mgmt

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-10-18T09:38:24Z",
+  "generated_at": "2024-11-24T13:39:40Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -77,12 +77,40 @@
     }
   ],
   "results": {
+    "src/mas/devops/templates/ibm-entitlement-dockerconfig.json.j2": [
+      {
+        "hashed_secret": "d2e2ab0f407e4ee3cf2ab87d61c31b25a74085e5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 28,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "test/src/test_db2.py": [
       {
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_secret": false,
         "is_verified": false,
         "line_number": 263,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "test/src/test_mas.py": [
+      {
+        "hashed_secret": "94f5ed592906089c107208b29e178ddf1f9f5143",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 35,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a9410d9785f49750b9f8672794fc288558c1611c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 48,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
+include src/mas/devops/templates/*.json.j2
 include src/mas/devops/templates/*.yml.j2
 include src/mas/devops/data/catalogs/*.yaml

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,8 @@ setup(
         'openshift',      # Apache Software License
         'kubernetes',     # Apache Software License
         'kubeconfig',     # BSD License
-        'jinja2'          # BSD License
+        'jinja2',         # BSD License
+        'jinja2-base64-filters'  # MIT License
     ],
     extras_require={
         'dev': [

--- a/src/mas/devops/mas.py
+++ b/src/mas/devops/mas.py
@@ -10,9 +10,13 @@
 
 import logging
 import re
+import yaml
+from os import path
 from types import SimpleNamespace
+from kubernetes.dynamic.resource import ResourceInstance
 from openshift.dynamic import DynamicClient
 from openshift.dynamic.exceptions import NotFoundError, UnauthorizedError
+from jinja2 import Environment, FileSystemLoader
 
 from .ocp import getStorageClasses
 
@@ -135,3 +139,36 @@ def verifyMasInstance(dynClient: DynamicClient, instanceId: str) -> bool:
     except UnauthorizedError:
         logger.error("Error: Unable to verify MAS instance due to failed authorization: {e}")
         return False
+
+
+def updateIBMEntitlementKey(dynClient: DynamicClient, namespace: str, icrUsername: str, icrPassword: str, artifactoryUsername: str = None, artifactoryPassword: str = None, secretName: str = "ibm-entitlement") -> ResourceInstance:
+    if artifactoryUsername is not None:
+        logger.info(f"Updating IBM Entitlement ({secretName}) in namespace '{namespace}' (with Artifactory access)")
+    else:
+        logger.info(f"Updating IBM Entitlement ({secretName}) in namespace '{namespace}'")
+
+    templateDir = path.join(path.abspath(path.dirname(__file__)), "templates")
+    env = Environment(
+        loader=FileSystemLoader(searchpath=templateDir),
+        extensions=["jinja2_base64_filters.Base64Filters"]
+    )
+
+    contentTemplate = env.get_template("ibm-entitlement-dockerconfig.json.j2")
+    dockerConfig = contentTemplate.render(
+        artifactory_username=artifactoryUsername,
+        artifactory_token=artifactoryPassword,
+        icr_username=icrUsername,
+        icr_password=icrPassword
+    )
+
+    template = env.get_template("ibm-entitlement-secret.yml.j2")
+    renderedTemplate = template.render(
+        name=secretName,
+        namespace=namespace,
+        docker_config=dockerConfig
+    )
+    secret = yaml.safe_load(renderedTemplate)
+    secretsAPI = dynClient.resources.get(api_version="v1", kind="Secret")
+
+    secret = secretsAPI.apply(body=secret, namespace=namespace)
+    return secret

--- a/src/mas/devops/olm.py
+++ b/src/mas/devops/olm.py
@@ -62,6 +62,9 @@ def applySubscription(dynClient: DynamicClient, namespace: str, packageName: str
     Usage:
       createSubscription(dynClient, "testns1", "sub1", "ibm-sls")  # use default channel, & auto-detect CatalogSource
     """
+    if catalogSourceNamespace is None:
+        catalogSourceNamespace = "openshift-marketplace"
+
     labelSelector = f"operators.coreos.com/{packageName}.{namespace}"
     templateDir = path.join(path.abspath(path.dirname(__file__)), "templates")
     env = Environment(

--- a/src/mas/devops/templates/ibm-entitlement-dockerconfig.json.j2
+++ b/src/mas/devops/templates/ibm-entitlement-dockerconfig.json.j2
@@ -1,0 +1,32 @@
+{
+  "auths": {
+{%- if artifactory_username is defined and artifactory_username != "" %}
+    "docker-na-public.artifactory.swg-devops.com/wiotp-docker-local": {
+      "username": "{{ artifactory_username }}",
+      "password": "{{ artifactory_token }}",
+      "auth": "{{ (artifactory_username ~ ':' ~ artifactory_token) | b64encode }}"
+    },
+    "docker-na-proxy-svl.artifactory.swg-devops.com/wiotp-docker-local": {
+      "username": "{{ artifactory_username }}",
+      "password": "{{ artifactory_token }}",
+      "auth": "{{ (artifactory_username ~ ':' ~ artifactory_token) | b64encode }}"
+    },
+    "docker-na-proxy-rtp.artifactory.swg-devops.com/wiotp-docker-local": {
+      "username": "{{ artifactory_username }}",
+      "password": "{{ artifactory_token }}",
+      "auth": "{{ (artifactory_username ~ ':' ~ artifactory_token) | b64encode }}"
+  {%- if icr_username is defined and icr_username != "" %}
+    },
+  {%- else %}
+    }
+  {%- endif %}
+{%- endif %}
+{%- if icr_username is defined and icr_username != "" %}
+    "cp.icr.io/cp": {
+      "username": "{{ icr_username }}",
+      "password": "{{ icr_password }}",
+      "auth": "{{ (icr_username ~ ':' ~ icr_password) | b64encode }}"
+    }
+{%- endif %}
+  }
+}

--- a/src/mas/devops/templates/ibm-entitlement-secret.yml.j2
+++ b/src/mas/devops/templates/ibm-entitlement-secret.yml.j2
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/dockerconfigjson
+metadata:
+  name: "{{ name }}"
+  namespace: "{{ namespace }}"
+data:
+  .dockerconfigjson: "{{ docker_config | b64encode }}"

--- a/test/src/test_mas.py
+++ b/test/src/test_mas.py
@@ -1,0 +1,53 @@
+# *****************************************************************************
+# Copyright (c) 2024 IBM Corporation and other Contributors.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# *****************************************************************************
+
+from openshift import dynamic
+from kubernetes import config
+from kubernetes.client import api_client
+from kubernetes.dynamic.resource import ResourceInstance
+
+from mas.devops import mas
+
+dynClient = dynamic.DynamicClient(
+    api_client.ApiClient(configuration=config.load_kube_config())
+)
+
+
+def test_entitlement():
+    icrUsername = "testing-i"
+    icrPassword = "not-a-real-password-i"
+
+    secret = mas.updateIBMEntitlementKey(dynClient, "default", icrUsername, icrPassword)
+    assert secret is not None
+    assert isinstance(secret, ResourceInstance)
+    assert secret.metadata.name == "ibm-entitlement"
+
+
+def test_entitlement_with_artifactory():
+    artifactoryUsername = "testing-a"
+    artifactoryPassword = "not-a-real-password-a"
+
+    icrUsername = "testing-i"
+    icrPassword = "not-a-real-password-i"
+
+    secret = mas.updateIBMEntitlementKey(dynClient, "default", icrUsername, icrPassword, artifactoryUsername, artifactoryPassword)
+    assert secret is not None
+    assert isinstance(secret, ResourceInstance)
+    assert secret.metadata.name == "ibm-entitlement"
+
+
+def test_entitlement_alt_name():
+    icrUsername = "testing-i"
+    icrPassword = "not-a-real-password-i"
+
+    secret = mas.updateIBMEntitlementKey(dynClient, "default", icrUsername, icrPassword, secretName="ibm-entitlement-key")
+    assert secret is not None
+    assert isinstance(secret, ResourceInstance)
+    assert secret.metadata.name == "ibm-entitlement-key"


### PR DESCRIPTION
Simple function to easily create/update the ibm entitlement key in a namespace.

```python
from openshift import dynamic
from kubernetes import config
from kubernetes.client import api_client

from mas.devops import mas

dynClient = dynamic.DynamicClient(
    api_client.ApiClient(configuration=config.load_kube_config())
)

icrUsername = "testing-i"
icrPassword = "not-a-real-password-i"

secret = mas.updateIBMEntitlementKey(dynClient, "default", icrUsername, icrPassword)
```