### PR TITLE
[patch] Set secretName to default value when None

### DIFF
--- a/src/mas/devops/mas.py
+++ b/src/mas/devops/mas.py
@@ -142,6 +142,8 @@ def verifyMasInstance(dynClient: DynamicClient, instanceId: str) -> bool:
 
 
 def updateIBMEntitlementKey(dynClient: DynamicClient, namespace: str, icrUsername: str, icrPassword: str, artifactoryUsername: str = None, artifactoryPassword: str = None, secretName: str = "ibm-entitlement") -> ResourceInstance:
+    if secretName is None:
+        secretName = "ibm-entitlement"
     if artifactoryUsername is not None:
         logger.info(f"Updating IBM Entitlement ({secretName}) in namespace '{namespace}' (with Artifactory access)")
     else:


### PR DESCRIPTION
The default when the param is not set is `ibm-entitlement`, but if the param is explicitly set to `None` we also need to set it to the default value.