### PR TITLE
[patch] Handle ResourceNotFoundError in verifyMasInstance

### DIFF
--- a/src/mas/devops/mas.py
+++ b/src/mas/devops/mas.py
@@ -15,7 +15,7 @@ from os import path
 from types import SimpleNamespace
 from kubernetes.dynamic.resource import ResourceInstance
 from openshift.dynamic import DynamicClient
-from openshift.dynamic.exceptions import NotFoundError, UnauthorizedError
+from openshift.dynamic.exceptions import NotFoundError, ResourceNotFoundError, UnauthorizedError
 from jinja2 import Environment, FileSystemLoader
 
 from .ocp import getStorageClasses
@@ -136,6 +136,9 @@ def verifyMasInstance(dynClient: DynamicClient, instanceId: str) -> bool:
         suitesAPI.get(name=instanceId, namespace=f"mas-{instanceId}-core")
         return True
     except NotFoundError:
+        return False
+    except ResourceNotFoundError:
+        # The MAS Suite CRD has not even been installed in the cluster
         return False
     except UnauthorizedError:
         logger.error("Error: Unable to verify MAS instance due to failed authorization: {e}")


### PR DESCRIPTION
Better error handling for the following scenario:

```
IBM Maximo Application Suite Admin CLI v11.13.0-pre.upg
Powered by https://github.com/ibm-mas/ansible-devops/ and https://tekton.dev/
Traceback (most recent call last):
  File "/opt/app-root/bin/mas-cli", line 65, in <module>
    app.upgrade(argv[2:])
  File "/opt/app-root/lib64/python3.9/site-packages/mas/cli/upgrade/app.py", line 72, in upgrade
    if not verifyMasInstance(self.dynamicClient, instanceId):
  File "/opt/app-root/lib64/python3.9/site-packages/mas/devops/mas.py", line 134, in verifyMasInstance
    suitesAPI = dynClient.resources.get(api_version="core.mas.ibm.com/v1", kind="Suite")
  File "/opt/app-root/lib64/python3.9/site-packages/openshift/dynamic/discovery.py", line 186, in get
    raise ResourceNotFoundError('No matches found for {}'.format(kwargs))
kubernetes.dynamic.exceptions.ResourceNotFoundError: No matches found for {'api_version': 'core.mas.ibm.com/v1', 'kind': 'Suite'}
```