### PR TITLE
[major] Replace ICSP with IDMS

### DIFF
--- a/src/mas/devops/mas.py
+++ b/src/mas/devops/mas.py
@@ -24,13 +24,18 @@ from .olm import getSubscription
 logger = logging.getLogger(__name__)
 
 
-def isAirgapInstall(dynClient: DynamicClient) -> bool:
-    try:
+def isAirgapInstall(dynClient: DynamicClient, checkICSP: bool = False) -> bool:
+    if checkICSP:
+        try:
+            ICSPApi = dynClient.resources.get(api_version="operator.openshift.io/v1alpha1", kind="ImageContentSourcePolicy")
+            ICSPApi.get(name="ibm-mas-and-dependencies")
+            return True
+        except NotFoundError:
+            return False
+    else:
         IDMSApi = dynClient.resources.get(api_version="config.openshift.io/v1", kind="ImageDigestMirrorSet")
         masIDMS = IDMSApi.get(label_selector="mas.ibm.com/idmsContent=ibm")
         return len(masIDMS.items) > 0
-    except NotFoundError:
-        return False
 
 
 def getDefaultStorageClasses(dynClient: DynamicClient) -> dict:

--- a/src/mas/devops/mas.py
+++ b/src/mas/devops/mas.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 def isAirgapInstall(dynClient: DynamicClient) -> bool:
     try:
         IDMSApi = dynClient.resources.get(api_version="config.openshift.io/v1", kind="ImageDigestMirrorSet")
-        masIDMS = IDMSApi.get(label_selector="mas.ibm.com/idms")
+        masIDMS = IDMSApi.get(label_selector="mas.ibm.com/idmsContent=ibm")
         return len(masIDMS.items) > 0
     except NotFoundError:
         return False

--- a/src/mas/devops/mas.py
+++ b/src/mas/devops/mas.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 def isAirgapInstall(dynClient: DynamicClient) -> bool:
     try:
         IDMSApi = dynClient.resources.get(api_version="config.openshift.io/v1", kind="ImageDigestMirrorSet")
-        masIDMS = IDMSApi.get(label_selector="mas.ibm.com/idmsGroup")
+        masIDMS = IDMSApi.get(label_selector="mas.ibm.com/idms")
         return len(masIDMS.items) > 0
     except NotFoundError:
         return False

--- a/src/mas/devops/mas.py
+++ b/src/mas/devops/mas.py
@@ -26,9 +26,9 @@ logger = logging.getLogger(__name__)
 
 def isAirgapInstall(dynClient: DynamicClient) -> bool:
     try:
-        ICSPApi = dynClient.resources.get(api_version="operator.openshift.io/v1alpha1", kind="ImageContentSourcePolicy")
-        ICSPApi.get(name="ibm-mas-and-dependencies")
-        return True
+        IDMSApi = dynClient.resources.get(api_version="config.openshift.io/v1", kind="ImageDigestMirrorSet")
+        masIDMS = IDMSApi.get(label_selector="mas.ibm.com/idmsGroup")
+        return len(masIDMS.items) > 0
     except NotFoundError:
         return False
 

--- a/test/src/test_mas.py
+++ b/test/src/test_mas.py
@@ -56,3 +56,9 @@ def test_entitlement_alt_name():
 def test_get_channel():
     channel = mas.getMasChannel(dynClient, "doesnotexist")
     assert channel is None
+
+
+def test_is_airgap_install():
+    # The cluster we are using to test with does not have the MAS ICSP or IDMS installed
+    assert mas.isAirgapInstall(dynClient) is False
+    assert mas.isAirgapInstall(dynClient, checkICSP=False) is False


### PR DESCRIPTION
Now that we have dropped support for OpenShift Container Platform 4.12 we are ready to remove support for the deprecated **ImageContentSourcePolicy** (ICSP) and replace it with the new **ImageDigestMirrorSet** (IDMS).

The `isAirgapInstall()` function will now only identify a cluster as configured for airgap install mode if one (or more) MAS IDMS are present on the cluster, hence **this is a major version bump** (breaking change).

See also: 
- https://github.com/ibm-mas/ansible-devops/pull/1594
- https://github.com/ibm-mas/cli/pull/1407
- https://jsw.ibm.com/browse/MASCORE-3812