### PR TITLE
[patch] Return none when there is no subscription

### DIFF
--- a/src/mas/devops/mas.py
+++ b/src/mas/devops/mas.py
@@ -149,14 +149,11 @@ def getMasChannel(dynClient: DynamicClient, instanceId: str) -> str:
     """
     Get the MAS channel from the subscription
     """
-    try:
-        masSubscription = getSubscription(dynClient, f"mas-{instanceId}-core", "ibm-mas")
+    masSubscription = getSubscription(dynClient, f"mas-{instanceId}-core", "ibm-mas")
+    if masSubscription is None:
+        return None
+    else:
         return masSubscription.spec.channel
-    except NotFoundError:
-        return False
-    except UnauthorizedError:
-        logger.error("Error: Unable to verify MAS instance due to failed authorization: {e}")
-        return False
 
 
 def updateIBMEntitlementKey(dynClient: DynamicClient, namespace: str, icrUsername: str, icrPassword: str, artifactoryUsername: str = None, artifactoryPassword: str = None, secretName: str = "ibm-entitlement") -> ResourceInstance:

--- a/test/src/test_mas.py
+++ b/test/src/test_mas.py
@@ -51,3 +51,8 @@ def test_entitlement_alt_name():
     assert secret is not None
     assert isinstance(secret, ResourceInstance)
     assert secret.metadata.name == "ibm-entitlement-key"
+
+
+def test_get_channel():
+    channel = mas.getMasChannel(dynClient, "doesnotexist")
+    assert channel is None


### PR DESCRIPTION
When there is no `ibm-mas` subscription for the MAS instance ID provided return `None`, resolve this failure seen when trying to upgrade an instance that does not exist:

```
IBM Maximo Application Suite Admin CLI v12.1.1-pre.master
Powered by https://github.com/ibm-mas/ansible-devops/ and https://tekton.dev/
Traceback (most recent call last):
  File "/opt/app-root/bin/mas-cli", line 65, in <module>
    app.upgrade(argv[2:])
  File "/opt/app-root/lib64/python3.9/site-packages/mas/cli/upgrade/app.py", line 73, in upgrade
    current_mas_channel = getMasChannel(self.dynamicClient, instanceId)
  File "/opt/app-root/lib64/python3.9/site-packages/mas/devops/mas.py", line 154, in getMasChannel
    return masSubscription.spec.channel
AttributeError: 'NoneType' object has no attribute 'spec'
```