### PR TITLE
[minor] Add support for improved SLS flow in the CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist
 *.egg-info
 pandoc-*-amd64.deb
 pandoc-*-windows-x86_64.msi
+pandoc-*-x86_64-macOS.pkg
 README.rst
 
 # Environments

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         'kubeconfig',               # BSD License
         'jinja2',                   # BSD License
         'jinja2-base64-filters',    # MIT License
-        # 'requests'                  # Apache Software License
+        'requests'                  # Apache Software License
     ],
     extras_require={
         'dev': [

--- a/setup.py
+++ b/setup.py
@@ -55,13 +55,12 @@ setup(
     description='Python for Maximo Application Suite Dev/Ops',
     long_description=long_description,
     install_requires=[
-        'pyyaml',                   # MIT License
-        'openshift',                # Apache Software License
-        'kubernetes',               # Apache Software License
-        'kubeconfig',               # BSD License
-        'jinja2',                   # BSD License
-        'jinja2-base64-filters',    # MIT License
-        'requests'                  # Apache Software License
+        'pyyaml',                  # MIT License
+        'openshift',               # Apache Software License
+        'kubernetes',              # Apache Software License
+        'kubeconfig',              # BSD License
+        'jinja2',                  # BSD License
+        'jinja2-base64-filters'    # MIT License
     ],
     extras_require={
         'dev': [

--- a/setup.py
+++ b/setup.py
@@ -55,12 +55,13 @@ setup(
     description='Python for Maximo Application Suite Dev/Ops',
     long_description=long_description,
     install_requires=[
-        'pyyaml',         # MIT License
-        'openshift',      # Apache Software License
-        'kubernetes',     # Apache Software License
-        'kubeconfig',     # BSD License
-        'jinja2',         # BSD License
-        'jinja2-base64-filters'  # MIT License
+        'pyyaml',                   # MIT License
+        'openshift',                # Apache Software License
+        'kubernetes',               # Apache Software License
+        'kubeconfig',               # BSD License
+        'jinja2',                   # BSD License
+        'jinja2-base64-filters',    # MIT License
+        # 'requests'                  # Apache Software License
     ],
     extras_require={
         'dev': [

--- a/src/mas/devops/ocp.py
+++ b/src/mas/devops/ocp.py
@@ -61,6 +61,22 @@ def connect(server: str, token: str, skipVerify: bool = False) -> bool:
     return True
 
 
+def getNamespace(dynClient: DynamicClient, namespace: str) -> dict:
+    """
+    Get a namespace
+    """
+    namespaceAPI = dynClient.resources.get(api_version="v1", kind="Namespace")
+    namespace = {}
+
+    try:
+        namespace = namespaceAPI.get(name=namespace)
+        logger.debug(f"Namespace {namespace} exists")
+    except NotFoundError:
+        logger.debug(f"Namespace {namespace} does not exist")
+
+    return namespace
+
+
 def createNamespace(dynClient: DynamicClient, namespace: str) -> bool:
     """
     Create a namespace if it does not exist

--- a/src/mas/devops/ocp.py
+++ b/src/mas/devops/ocp.py
@@ -66,15 +66,15 @@ def getNamespace(dynClient: DynamicClient, namespace: str) -> dict:
     Get a namespace
     """
     namespaceAPI = dynClient.resources.get(api_version="v1", kind="Namespace")
-    namespace = {}
 
     try:
-        namespace = namespaceAPI.get(name=namespace)
+        ns = namespaceAPI.get(name=namespace)
         logger.debug(f"Namespace {namespace} exists")
+        return ns
     except NotFoundError:
         logger.debug(f"Namespace {namespace} does not exist")
 
-    return namespace
+    return {}
 
 
 def createNamespace(dynClient: DynamicClient, namespace: str) -> bool:

--- a/src/mas/devops/sls.py
+++ b/src/mas/devops/sls.py
@@ -17,10 +17,10 @@ def listSLSInstances(dynClient: DynamicClient) -> list:
         logger.info("There are no SLS instances installed on this cluster")
         return []
     except ResourceNotFoundError:
-        # The LicenseService CRD has not even been installed in the cluster
+        logger.info("LicenseService CRD not found on cluster")
         return []
     except UnauthorizedError:
-        logger.error("Error: Unable to verify SLS instance(s) due to failed authorization: {e}")
+        logger.error("Error: Unable to verify SLS instances due to failed authorization: {e}")
         return []
 
 

--- a/src/mas/devops/sls.py
+++ b/src/mas/devops/sls.py
@@ -32,8 +32,8 @@ def findSLSByNamespace(namespace: str, instances: list = None, dynClient: Dynami
         instances = listSLSInstances(dynClient)
 
     for instance in instances:
-            if namespace in instance['metadata']['namespace']:
-                return True
+        if namespace in instance['metadata']['namespace']:
+            return True
     return False
 
 def verifySLSConnection(sls_url: str, server_ca: str) -> bool:

--- a/src/mas/devops/sls.py
+++ b/src/mas/devops/sls.py
@@ -1,3 +1,13 @@
+# *****************************************************************************
+# Copyright (c) 2025 IBM Corporation and other Contributors.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# *****************************************************************************
+
 import logging
 from openshift.dynamic import DynamicClient
 from openshift.dynamic.exceptions import NotFoundError, ResourceNotFoundError, UnauthorizedError

--- a/src/mas/devops/sls.py
+++ b/src/mas/devops/sls.py
@@ -36,6 +36,7 @@ def findSLSByNamespace(namespace: str, instances: list = None, dynClient: Dynami
             return True
     return False
 
+
 def verifySLSConnection(sls_url: str, server_ca: str) -> bool:
     logger.info("Checking SLS connection")
     response = requests.get(f"{sls_url}/api/probes/readiness", verify=server_ca)

--- a/src/mas/devops/sls.py
+++ b/src/mas/devops/sls.py
@@ -1,5 +1,4 @@
 import logging
-import requests
 from openshift.dynamic import DynamicClient
 from openshift.dynamic.exceptions import NotFoundError, ResourceNotFoundError, UnauthorizedError
 
@@ -34,12 +33,4 @@ def findSLSByNamespace(namespace: str, instances: list = None, dynClient: Dynami
     for instance in instances:
         if namespace in instance['metadata']['namespace']:
             return True
-    return False
-
-
-def verifySLSConnection(sls_url: str, server_ca: str) -> bool:
-    logger.info("Checking SLS connection")
-    response = requests.get(f"{sls_url}/api/probes/readiness", verify=server_ca)
-    if response.status_code == 200:
-        return True
     return False

--- a/src/mas/devops/sls.py
+++ b/src/mas/devops/sls.py
@@ -24,6 +24,18 @@ def listSLSInstances(dynClient: DynamicClient) -> list:
         return []
 
 
+def findSLSByNamespace(namespace: str, instances: list = None, dynClient: DynamicClient = None):
+    if not instances and not dynClient:
+        return False
+
+    if not instances and dynClient:
+        instances = listSLSInstances(dynClient)
+
+    for instance in instances:
+            if namespace in instance['metadata']['namespace']:
+                return True
+    return False
+
 def verifySLSConnection(sls_url: str, server_ca: str) -> bool:
     logger.info("Checking SLS connection")
     response = requests.get(f"{sls_url}/api/probes/readiness", verify=server_ca)

--- a/src/mas/devops/sls.py
+++ b/src/mas/devops/sls.py
@@ -1,5 +1,5 @@
 import logging
-# import requests
+import requests
 from openshift.dynamic import DynamicClient
 from openshift.dynamic.exceptions import NotFoundError, ResourceNotFoundError, UnauthorizedError
 
@@ -24,10 +24,9 @@ def listSLSInstances(dynClient: DynamicClient) -> list:
         return []
 
 
-# def verifySLSConnection(sls_url: str, server_ca: str) -> bool:
-#     logger.info("Checking SLS connection")
-#     response = requests.get(f"{sls_url}api/probes/readiness", verify=server_ca)
-#     if response.status_code == 200:
-#             return True
-#     return False
-#     # response.raise_for_status()
+def verifySLSConnection(sls_url: str, server_ca: str) -> bool:
+    logger.info("Checking SLS connection")
+    response = requests.get(f"{sls_url}api/probes/readiness", verify=server_ca)
+    if response.status_code == 200:
+            return True
+    return False

--- a/src/mas/devops/sls.py
+++ b/src/mas/devops/sls.py
@@ -3,6 +3,7 @@ from openshift.dynamic import DynamicClient
 
 logger = logging.getLogger(__name__)
 
+
 def listSLSInstances(dynClient: DynamicClient) -> list:
     """
     Get a list of SLS instances on the cluster
@@ -14,7 +15,7 @@ def listSLSInstances(dynClient: DynamicClient) -> list:
     numSLS = len(licenseservices)
 
     if numSLS == 1:
-        logger.info(f"There is 1 SLS instance installed on this cluster:")
+        logger.info("There is 1 SLS instance installed on this cluster:")
         logger.info(f" * {licenseservices[0]['metadata']['name']} ({{licenseservices[0]['metadata']['namespace']}}) v{licenseservices[0]['status']['versions']['reconciled']}")
     elif numSLS > 0:
         logger.info(f"There are {numSLS} SLS instances installed on this cluster:")

--- a/src/mas/devops/sls.py
+++ b/src/mas/devops/sls.py
@@ -1,0 +1,25 @@
+import logging
+from openshift.dynamic import DynamicClient
+
+logger = logging.getLogger(__name__)
+
+def listSLSInstances(dynClient: DynamicClient) -> list:
+    """
+    Get a list of SLS instances on the cluster
+    """
+    slsAPI = dynClient.resources.get(api_version="sls.ibm.com/v1", kind="LicenseService")
+
+    licenseservices = slsAPI.get().to_dict()['items']
+
+    numSLS = len(licenseservices)
+
+    if numSLS == 1:
+        logger.info(f"There is 1 SLS instance installed on this cluster:")
+        logger.info(f" * {licenseservices[0]['metadata']['name']} ({{licenseservices[0]['metadata']['namespace']}}) v{licenseservices[0]['status']['versions']['reconciled']}")
+    elif numSLS > 0:
+        logger.info(f"There are {numSLS} SLS instances installed on this cluster:")
+        for licenseservice in licenseservices:
+            logger.info(f" * {licenseservice['metadata']['name']} ({{licenseservice['metadata']['namespace']}}) v{licenseservice['status']['versions']['reconciled']}")
+    else:
+        logger.info("There are no SLS instances installed on this cluster")
+    return licenseservices

--- a/src/mas/devops/sls.py
+++ b/src/mas/devops/sls.py
@@ -28,5 +28,5 @@ def verifySLSConnection(sls_url: str, server_ca: str) -> bool:
     logger.info("Checking SLS connection")
     response = requests.get(f"{sls_url}api/probes/readiness", verify=server_ca)
     if response.status_code == 200:
-            return True
+        return True
     return False

--- a/src/mas/devops/sls.py
+++ b/src/mas/devops/sls.py
@@ -1,5 +1,7 @@
 import logging
+# import requests
 from openshift.dynamic import DynamicClient
+from openshift.dynamic.exceptions import NotFoundError, ResourceNotFoundError, UnauthorizedError
 
 logger = logging.getLogger(__name__)
 
@@ -8,19 +10,24 @@ def listSLSInstances(dynClient: DynamicClient) -> list:
     """
     Get a list of SLS instances on the cluster
     """
-    slsAPI = dynClient.resources.get(api_version="sls.ibm.com/v1", kind="LicenseService")
-
-    licenseservices = slsAPI.get().to_dict()['items']
-
-    numSLS = len(licenseservices)
-
-    if numSLS == 1:
-        logger.info("There is 1 SLS instance installed on this cluster:")
-        logger.info(f" * {licenseservices[0]['metadata']['name']} ({{licenseservices[0]['metadata']['namespace']}}) v{licenseservices[0]['status']['versions']['reconciled']}")
-    elif numSLS > 0:
-        logger.info(f"There are {numSLS} SLS instances installed on this cluster:")
-        for licenseservice in licenseservices:
-            logger.info(f" * {licenseservice['metadata']['name']} ({{licenseservice['metadata']['namespace']}}) v{licenseservice['status']['versions']['reconciled']}")
-    else:
+    try:
+        slsAPI = dynClient.resources.get(api_version="sls.ibm.com/v1", kind="LicenseService")
+        return slsAPI.get().to_dict()['items']
+    except NotFoundError:
         logger.info("There are no SLS instances installed on this cluster")
-    return licenseservices
+        return []
+    except ResourceNotFoundError:
+        # The LicenseService CRD has not even been installed in the cluster
+        return []
+    except UnauthorizedError:
+        logger.error("Error: Unable to verify SLS instance(s) due to failed authorization: {e}")
+        return []
+
+
+# def verifySLSConnection(sls_url: str, server_ca: str) -> bool:
+#     logger.info("Checking SLS connection")
+#     response = requests.get(f"{sls_url}api/probes/readiness", verify=server_ca)
+#     if response.status_code == 200:
+#             return True
+#     return False
+#     # response.raise_for_status()

--- a/src/mas/devops/sls.py
+++ b/src/mas/devops/sls.py
@@ -26,7 +26,7 @@ def listSLSInstances(dynClient: DynamicClient) -> list:
 
 def verifySLSConnection(sls_url: str, server_ca: str) -> bool:
     logger.info("Checking SLS connection")
-    response = requests.get(f"{sls_url}api/probes/readiness", verify=server_ca)
+    response = requests.get(f"{sls_url}/api/probes/readiness", verify=server_ca)
     if response.status_code == 200:
         return True
     return False

--- a/src/mas/devops/tekton.py
+++ b/src/mas/devops/tekton.py
@@ -148,7 +148,7 @@ def preparePipelinesNamespace(dynClient: DynamicClient, instanceId: str = None, 
                 sleep(15)
 
 
-def prepareInstallSecrets(dynClient: DynamicClient, instanceId: str, slsLicenseFile: str, additionalConfigs: dict = None, certs: str = None, podTemplates: str = None) -> None:
+def prepareInstallSecrets(dynClient: DynamicClient, instanceId: str, slsLicenseFile: str = None, additionalConfigs: dict = None, certs: str = None, podTemplates: str = None) -> None:
     namespace = f"mas-{instanceId}-pipelines"
     secretsAPI = dynClient.resources.get(api_version="v1", kind="Secret")
 
@@ -178,10 +178,21 @@ def prepareInstallSecrets(dynClient: DynamicClient, instanceId: str, slsLicenseF
     except NotFoundError:
         pass
 
-    # TODO: Convert this to using secretsAPI.create()
-    result = kubectl.run(subcmd_args=['-n', namespace, 'create', 'secret', 'generic', 'pipeline-sls-entitlement', '--from-file', slsLicenseFile])
-    for line in result.split("\n"):
-        logger.debug(line)
+    if slsLicenseFile is None:
+        slsLicenseFile = {
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "type": "Opaque",
+            "metadata": {
+                "name": "pipeline-sls-entitlement"
+            }
+        }
+        secretsAPI.create(body=slsLicenseFile, namespace=namespace)
+    else:
+        # TODO: Convert this to using secretsAPI.create()
+        result = kubectl.run(subcmd_args=['-n', namespace, 'create', 'secret', 'generic', 'pipeline-sls-entitlement', '--from-file', slsLicenseFile])
+        for line in result.split("\n"):
+            logger.debug(line)
 
     # 3. Secret/pipeline-certificates
     # -------------------------------------------------------------------------

--- a/src/mas/devops/tekton.py
+++ b/src/mas/devops/tekton.py
@@ -187,12 +187,7 @@ def prepareInstallSecrets(dynClient: DynamicClient, instanceId: str, slsLicenseF
                 "name": "pipeline-sls-entitlement"
             }
         }
-        secretsAPI.create(body=slsLicenseFile, namespace=namespace)
-    else:
-        # TODO: Convert this to using secretsAPI.create()
-        result = kubectl.run(subcmd_args=['-n', namespace, 'create', 'secret', 'generic', 'pipeline-sls-entitlement', '--from-file', slsLicenseFile])
-        for line in result.split("\n"):
-            logger.debug(line)
+    secretsAPI.create(body=slsLicenseFile, namespace=namespace)
 
     # 3. Secret/pipeline-certificates
     # -------------------------------------------------------------------------

--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -300,18 +300,6 @@ spec:
     - name: sls_mongodb_cfg_file
       value: "{{ sls_mongodb_cfg_file }}"
 {%- endif %}
-{%- if sls_tls_crt_local_file_path is defined and sls_tls_crt_local_file_path != "" %}
-    - name: sls_tls_crt_local_file_path
-      value: "{{ sls_tls_crt_local_file_path }}"
-{%- endif %}
-{%- if sls_registration_key is defined and sls_registration_key != "" %}
-    - name: sls_registration_key
-      value: "{{ sls_registration_key }}"
-{%- endif %}
-{%- if sls_url is defined and sls_url != "" %}
-    - name: sls_url
-      value: "{{ sls_url }}"
-{%- endif %}
 {%- if sls_action is defined and sls_action != "" %}
     - name: sls_action
       value: "{{ sls_action }}"

--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -284,8 +284,10 @@ spec:
     # -------------------------------------------------------------------------
     - name: sls_channel
       value: '3.x'
+{%- if sls_entitlement_file is defined and sls_entitlement_file != "" %}
     - name: sls_entitlement_file
       value: "{{ sls_entitlement_file }}"
+{%- endif %}
 {%- if sls_namespace is defined and sls_namespace != "" %}
     - name: sls_namespace
       value: "{{ sls_namespace }}"
@@ -298,6 +300,23 @@ spec:
     - name: sls_mongodb_cfg_file
       value: "{{ sls_mongodb_cfg_file }}"
 {%- endif %}
+{%- if sls_tls_crt_local_file_path is defined and sls_tls_crt_local_file_path != "" %}
+    - name: sls_tls_crt_local_file_path
+      value: "{{ sls_tls_crt_local_file_path }}"
+{%- endif %}
+{%- if sls_registration_key is defined and sls_registration_key != "" %}
+    - name: sls_registration_key
+      value: "{{ sls_registration_key }}"
+{%- endif %}
+{%- if sls_url is defined and sls_url != "" %}
+    - name: sls_url
+      value: "{{ sls_url }}"
+{%- endif %}
+{%- if sls_action is defined and sls_action != "" %}
+    - name: sls_action
+      value: "{{ sls_action }}"
+{%- endif %}
+
 
     # Dependencies - UDS/DRO (Required)
     # -------------------------------------------------------------------------

--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -300,9 +300,9 @@ spec:
     - name: sls_mongodb_cfg_file
       value: "{{ sls_mongodb_cfg_file }}"
 {%- endif %}
-{%- if sls_tls_crt_local_file_base64_path is defined and sls_tls_crt_local_file_base64_path != "" %}
-    - name: sls_tls_crt_local_file_base64_path
-      value: "{{ sls_tls_crt_local_file_base64_path }}"
+{%- if sls_tls_crt_local_file_path is defined and sls_tls_crt_local_file_path != "" %}
+    - name: sls_tls_crt_local_file_path
+      value: "{{ sls_tls_crt_local_file_path }}"
 {%- endif %}
 {%- if sls_registration_key is defined and sls_registration_key != "" %}
     - name: sls_registration_key

--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -300,9 +300,9 @@ spec:
     - name: sls_mongodb_cfg_file
       value: "{{ sls_mongodb_cfg_file }}"
 {%- endif %}
-{%- if sls_tls_crt_local_file_path is defined and sls_tls_crt_local_file_path != "" %}
-    - name: sls_tls_crt_local_file_path
-      value: "{{ sls_tls_crt_local_file_path }}"
+{%- if sls_tls_crt_local_file_base64_path is defined and sls_tls_crt_local_file_base64_path != "" %}
+    - name: sls_tls_crt_local_file_base64_path
+      value: "{{ sls_tls_crt_local_file_base64_path }}"
 {%- endif %}
 {%- if sls_registration_key is defined and sls_registration_key != "" %}
     - name: sls_registration_key


### PR DESCRIPTION
## Description

- Added `pandoc-*-x86_64-macOS.pkg` to `.gitignore` as it was missing for macs
- Added `getNamespace` function in `ocp.py`
- Created new file `src/mas/devops/sls.py`:
  - Added `listSLSInstances` function
  - Added `findSLSByNamespace` function
- Converted `slsLicenseFile` to use `secretsAPI.create()` like the other secrets
  - Also, the secret with the actual license file now gets created within the cli
- Added `sls_action` optional param for sls in `pipelinerun-install.yml.j2`

## Testing

- All of the above have been tested via the CLI