### PR TITLE
[minor] Support for independant CloudPak For Data install

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,3 +38,15 @@ Manually run the pre-commit hooks against all files
 ```bash
 pre-commit run -a
 ```
+
+Building locally
+-------------------------------------------------------------------------------
+Clone the python-devops repository locally. From the top level directory, run
+```
+make install build
+```
+
+NOTE: if building on MacOS you will need to first install pandoc:
+```
+brew install pandoc
+```

--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -278,6 +278,12 @@ spec:
       value: "{{ cpd_install_openscale }}"
     - name: cpd_install_cognos
       value: "{{ cpd_install_cognos }}"
+    - name: cpd_install_ws
+      value: "{{ cpd_install_ws }}"
+    - name: cpd_install_wml
+      value: "{{ cpd_install_wml }}"
+    - name: cpd_install_ae
+      value: "{{ cpd_install_ae }}"
 {%- endif %}
 
     # Dependencies - SLS


### PR DESCRIPTION
This PR introduces the ability to install each of the supported CloudPak For Data services independently of the MAS applications that use them. This allows for installation of those services to be more easily tested.

This has been successfully tested in personal fvt environment pfvtcpd51.

**Note - this needs to be merged at the same time as https://github.com/ibm-mas/cli/pull/1454**