### PR TITLE
[minor] Support configurable serviceaccounts

### DIFF
--- a/src/mas/devops/tekton.py
+++ b/src/mas/devops/tekton.py
@@ -102,25 +102,26 @@ def updateTektonDefinitions(namespace: str, yamlFile: str) -> None:
         logger.debug(line)
 
 
-def preparePipelinesNamespace(dynClient: DynamicClient, instanceId: str = None, storageClass: str = None, accessMode: str = None, waitForBind: bool = True):
-    templateDir = path.join(path.abspath(path.dirname(__file__)), "templates")
-    env = Environment(
-        loader=FileSystemLoader(searchpath=templateDir)
-    )
+def preparePipelinesNamespace(dynClient: DynamicClient, instanceId: str = None, storageClass: str = None, accessMode: str = None, waitForBind: bool = True, configureRBAC: bool = True):
+    if configureRBAC:
+        templateDir = path.join(path.abspath(path.dirname(__file__)), "templates")
+        env = Environment(
+            loader=FileSystemLoader(searchpath=templateDir)
+        )
 
-    if instanceId is None:
-        namespace = "mas-pipelines"
-        template = env.get_template("pipelines-rbac-cluster.yml.j2")
-    else:
-        namespace = f"mas-{instanceId}-pipelines"
-        template = env.get_template("pipelines-rbac.yml.j2")
+        if instanceId is None:
+            namespace = "mas-pipelines"
+            template = env.get_template("pipelines-rbac-cluster.yml.j2")
+        else:
+            namespace = f"mas-{instanceId}-pipelines"
+            template = env.get_template("pipelines-rbac.yml.j2")
 
-    # Create RBAC
-    renderedTemplate = template.render(mas_instance_id=instanceId)
-    logger.debug(renderedTemplate)
-    crb = yaml.safe_load(renderedTemplate)
-    clusterRoleBindingAPI = dynClient.resources.get(api_version="rbac.authorization.k8s.io/v1", kind="ClusterRoleBinding")
-    clusterRoleBindingAPI.apply(body=crb, namespace=namespace)
+        # Create RBAC
+        renderedTemplate = template.render(mas_instance_id=instanceId)
+        logger.debug(renderedTemplate)
+        crb = yaml.safe_load(renderedTemplate)
+        clusterRoleBindingAPI = dynClient.resources.get(api_version="rbac.authorization.k8s.io/v1", kind="ClusterRoleBinding")
+        clusterRoleBindingAPI.apply(body=crb, namespace=namespace)
 
     # Create PVC (instanceId namespace only)
     if instanceId is not None:

--- a/src/mas/devops/tekton.py
+++ b/src/mas/devops/tekton.py
@@ -103,19 +103,18 @@ def updateTektonDefinitions(namespace: str, yamlFile: str) -> None:
 
 
 def preparePipelinesNamespace(dynClient: DynamicClient, instanceId: str = None, storageClass: str = None, accessMode: str = None, waitForBind: bool = True, configureRBAC: bool = True):
+    templateDir = path.join(path.abspath(path.dirname(__file__)), "templates")
+    env = Environment(
+        loader=FileSystemLoader(searchpath=templateDir)
+    )
+    if instanceId is None:
+        namespace = "mas-pipelines"
+        template = env.get_template("pipelines-rbac-cluster.yml.j2")
+    else:
+        namespace = f"mas-{instanceId}-pipelines"
+        template = env.get_template("pipelines-rbac.yml.j2")
+
     if configureRBAC:
-        templateDir = path.join(path.abspath(path.dirname(__file__)), "templates")
-        env = Environment(
-            loader=FileSystemLoader(searchpath=templateDir)
-        )
-
-        if instanceId is None:
-            namespace = "mas-pipelines"
-            template = env.get_template("pipelines-rbac-cluster.yml.j2")
-        else:
-            namespace = f"mas-{instanceId}-pipelines"
-            template = env.get_template("pipelines-rbac.yml.j2")
-
         # Create RBAC
         renderedTemplate = template.render(mas_instance_id=instanceId)
         logger.debug(renderedTemplate)

--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -9,7 +9,7 @@ spec:
   pipelineRef:
     name: mas-install
 
-  serviceAccountName: pipeline
+  serviceAccountName: "{{ service_account_name | default('pipeline', True) }}"
   timeouts:
     pipeline: "0"
 

--- a/src/mas/devops/templates/pipelinerun-uninstall.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-uninstall.yml.j2
@@ -9,7 +9,7 @@ spec:
   pipelineRef:
     name: mas-uninstall
 
-  serviceAccountName: pipeline
+  serviceAccountName: "{{ service_account_name | default('pipeline', True) }}"
   timeouts:
     pipeline: "0"
 
@@ -34,4 +34,4 @@ spec:
       value: {{ uds_action }}
     - name: dro_namespace
       value: {{ dro_namespace }}
-    
+

--- a/src/mas/devops/templates/pipelinerun-update.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-update.yml.j2
@@ -9,7 +9,7 @@ spec:
   pipelineRef:
     name: mas-update
 
-  serviceAccountName: pipeline
+  serviceAccountName: "{{ service_account_name | default('pipeline', True) }}"
   timeouts:
     pipeline: "0"
 

--- a/src/mas/devops/templates/pipelinerun-upgrade.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-upgrade.yml.j2
@@ -9,7 +9,7 @@ spec:
   pipelineRef:
     name: mas-upgrade
 
-  serviceAccountName: pipeline
+  serviceAccountName: "{{ service_account_name | default('pipeline', True) }}"
   timeouts:
     pipeline: "0"
 


### PR DESCRIPTION
**serviceAccountName** default remains as `pipeline`, but can now be modified by passing in `service_account_name`.