### PR TITLE
[patch] add db2u filter metadata

### DIFF
--- a/src/mas/devops/data/catalogs/v9-250206-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250206-amd64.yaml
@@ -95,7 +95,7 @@ mongo_extras_version_7: 7.0.12
 # Extra Images for Db2u
 # ------------------------------------------------------------------------------
 db2u_extras_version: 1.0.6 # No Update
-
+db2u_filter: db2
 # Extra Images for IBM Watson Discovery
 # ------------------------------------------------------------------------------
 #wd_extras_version: 1.0.4

--- a/src/mas/devops/data/catalogs/v9-250206-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250206-amd64.yaml
@@ -38,10 +38,10 @@ elasticsearch_version: 1.1.2470              # Operator version 1.1.2470
 # Maximo Application Suite
 # -----------------------------------------------------------------------------
 mas_core_version:
-  9.1.x-feature: 9.1.0-pre.stable_7790 # tbc
-  9.0.x: 9.0.8    # tbc
-  8.10.x: 8.10.23 # updated
-  8.11.x: 8.11.20 # updated
+  9.1.x-feature: 9.1.0-pre.stable_7790 # updated
+  9.0.x: 9.0.8    # updated
+  8.10.x: 8.10.22 # updated
+  8.11.x: 8.11.19 # updated
 mas_assist_version:
   9.0.x: 9.0.3    # No Update
   8.10.x: 8.7.8   # No Update

--- a/src/mas/devops/data/catalogs/v9-250206-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250206-amd64.yaml
@@ -38,10 +38,10 @@ elasticsearch_version: 1.1.2470              # Operator version 1.1.2470
 # Maximo Application Suite
 # -----------------------------------------------------------------------------
 mas_core_version:
-  9.1.x-feature: 9.1.0-pre.stable_7790 # updated
-  9.0.x: 9.0.8    # updated
-  8.10.x: 8.10.22 # updated
-  8.11.x: 8.11.19 # updated
+  9.1.x-feature: 9.1.0-pre.stable_7790 # tbc
+  9.0.x: 9.0.8    # tbc
+  8.10.x: 8.10.23 # updated
+  8.11.x: 8.11.20 # updated
 mas_assist_version:
   9.0.x: 9.0.3    # No Update
   8.10.x: 8.7.8   # No Update


### PR DESCRIPTION
[[MASCORE-5426](https://jsw.ibm.com/browse/MASCORE-5426)] 
with newer db2u mirror catalog job, we need to add `--filter db2`
to handle this filter adding new var `db2u_filter` into catalog metadata

Slack conversation : https://ibm-watson-iot.slack.com/archives/C083YV0DU1X/p1739551262768819

Ansible-devops: https://github.com/ibm-mas/ansible-devops/pull/1631