### PR TITLE
[patch] Adding a new property used in ansible-devops to differentiate the installation of Full Manage and Manage Foundation in MAS 9.1

### DIFF
--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -616,6 +616,10 @@ spec:
     - name: mas_app_settings_server_bundles_size
       value: "{{ mas_app_settings_server_bundles_size }}"
   {%- endif %}
+  {%- if is_full_manage is defined and is_full_manage != "" %}
+    - name: is_full_manage
+      value: "{{ is_full_manage }}"
+  {%- endif %}
   {%- if mas_app_settings_base_lang is defined and mas_app_settings_base_lang != "" %}
     - name: mas_app_settings_base_lang
       value: "{{ mas_app_settings_base_lang }}"


### PR DESCRIPTION
Adding a new property used in ansible-devops to differentiate the installation of Full Manage and Manage Foundation in MAS 9.1. This new property will be set by the [cli (WIP)](https://github.com/ibm-mas/cli/pull/1498)