### PR TITLE
[minor] Support for May catalog update

### DIFF
--- a/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
@@ -21,9 +21,9 @@ ibm_zen_version: 6.0.1+20240708.121250.32    # For CPD5 ibm-zen has to be explic
 db2u_version: 6.0.1+20240704.142950.9960     # Operator version 110509.0.2 to find the version 6.0.1, search CASE_VERSION in db2u, catalog.yaml into ibm-maximo-operator-catalog (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
 events_version: 5.0.1                        # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
 uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
-sls_version: 3.11.1 # tbc                # Operator version 3.10.0 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
-tsm_version: 1.6.2  # Updated              # Operator version 1.5.4 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
-dd_version: 1.1.17  # updated                # Operator version 1.1.14 (https://github.ibm.com/maximoappsuite/ibm-data-dictionary/releases)
+sls_version: 3.11.1 # tbc                    # Operator version 3.10.0 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
+tsm_version: 1.6.2  # tbc                    # Operator version 1.5.4 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
+dd_version: 1.1.17  # tbc                    # Operator version 1.1.14 (https://github.ibm.com/maximoappsuite/ibm-data-dictionary/releases)
 appconnect_version: 6.2.0                    # Operator version 6.2.0 # sticking to 6.2.0 version # Please do Not Change
 wsl_version: 9.0.0                           # Operator version 9.0.0
 wml_version: 9.0.0                           # Operator version 5.0.0
@@ -39,9 +39,9 @@ elasticsearch_version: 1.1.2570              # Operator version 1.1.2470
 # -----------------------------------------------------------------------------
 mas_core_version:
   9.1.x-feature: 9.1.0-pre.stable_8193 # No Update
-  9.0.x: 9.0.10   # updated
-  8.10.x: 8.10.24 # updated
-  8.11.x: 8.11.21 # updated
+  9.0.x: 9.0.10   # tbc
+  8.10.x: 8.10.24 # tbc
+  8.11.x: 8.11.21 # tbc
 mas_assist_version:
   9.0.x: 9.0.4    # No Update
   8.10.x: 8.7.8   # No Update
@@ -51,32 +51,32 @@ mas_hputilities_version:
   8.10.x: 8.6.7   # tbc
   8.11.x: ""      # Not Supported
 mas_iot_version:
-  9.0.x: 9.0.7    # updated
-  8.10.x: 8.7.21  # updated
-  8.11.x: 8.8.17  # updated
+  9.0.x: 9.0.7    # tbc
+  8.10.x: 8.7.21  # tbc
+  8.11.x: 8.8.17  # tbc
 mas_manage_version:
   9.1.x-feature: 9.1.0-pre.stable_9992 # No Update
-  9.0.x: 9.0.11   # updated
-  8.10.x: 8.6.24  # updated
-  8.11.x: 8.7.18  # updated
+  9.0.x: 9.0.11   # tbc
+  8.10.x: 8.6.24  # tbc
+  8.11.x: 8.7.18  # tbc
 mas_monitor_version:
-  9.0.x: 9.0.8    # updated
-  8.10.x: 8.10.18 # updated
-  8.11.x: 8.11.16 # updated
+  9.0.x: 9.0.8    # tbc
+  8.10.x: 8.10.18 # tbc
+  8.11.x: 8.11.16 # tbc
 mas_optimizer_version:
   9.1.x-feature: 9.1.0-pre.stable_1813 # No Update
-  9.0.x: 9.0.9    # updated
-  8.10.x: 8.4.16  # updated
-  8.11.x: 8.5.15  # updated
+  9.0.x: 9.0.9    # tbc
+  8.10.x: 8.4.16  # tbc
+  8.11.x: 8.5.15  # tbc
 mas_predict_version:
-  9.0.x: 9.0.6    # updated
-  8.10.x: 8.8.7   # updated
-  8.11.x: 8.9.9   # updated
+  9.0.x: 9.0.6    # tbc
+  8.10.x: 8.8.7   # tbc
+  8.11.x: 8.9.9   # tbc
 mas_visualinspection_version:
   9.1.x-feature: 9.1.0-pre.stable_2246 # No Update
-  9.0.x: 9.0.8    # updated
+  9.0.x: 9.0.8    # tbc
   8.10.x: 8.8.4   # No Update
-  8.11.x: 8.9.11  # updated
+  8.11.x: 8.9.11  # tbc
 
 # Extra Images for UDS
 # ------------------------------------------------------------------------------

--- a/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
@@ -5,7 +5,7 @@
 # catalog itself, but not everything in the catalog supports this yet (including MAS)
 # so we need to use the CASE bundle mirror process still.
 
-catalog_digest: sha256:18f72f1ed0c1acdf8c871b64328a2ddf58142a0d54e2cc8b95efe980d0f2266b
+catalog_digest: sha256:4d6d9c22b97dd6ccc6333d5fc616c7e1b1d9d6f524ba098fdacf497a8fbbed54
 
 # Dependencies
 # -----------------------------------------------------------------------------
@@ -38,7 +38,7 @@ elasticsearch_version: 1.1.2570              # Operator version 1.1.2470
 # Maximo Application Suite
 # -----------------------------------------------------------------------------
 mas_core_version:
-  9.1.x-feature: 9.1.0-pre.stable_9709 # No Update
+  9.1.x-feature: 9.1.0-pre.stable_9718 # No Update
   9.0.x: 9.0.11   # tbc
   8.10.x: 8.10.25 # tbc
   8.11.x: 8.11.22 # tbc
@@ -65,9 +65,9 @@ mas_monitor_version:
   8.11.x: 8.11.17 # tbc
 mas_optimizer_version:
   9.1.x-feature: 9.1.0-pre.stable_1943 # No Update
-  9.0.x: 9.0.9    # tbc
-  8.10.x: 8.4.16  # tbc
-  8.11.x: 8.5.15  # tbc
+  9.0.x: 9.0.10   # tbc
+  8.10.x: 8.4.17  # tbc
+  8.11.x: 8.5.16  # tbc
 mas_predict_version:
   9.0.x: 9.0.7    # tbc
   8.10.x: 8.8.8   # tbc

--- a/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
@@ -5,7 +5,7 @@
 # catalog itself, but not everything in the catalog supports this yet (including MAS)
 # so we need to use the CASE bundle mirror process still.
 
-catalog_digest: sha256:25ae7b227916eaa6fac8a04afb1ca5cedbc49fbd1196b6c6490b537af8a28f33
+catalog_digest: sha256:55feb1250f29536a2c9f6b355456280af0e195bf743da2fd60b089f0872accfb
 
 # Dependencies
 # -----------------------------------------------------------------------------
@@ -55,7 +55,7 @@ mas_iot_version:
   8.10.x: 8.7.22  # tbc
   8.11.x: 8.8.18  # tbc
 mas_manage_version:
-  9.1.x-feature: 9.1.0-pre.stable_9992 # No Update
+  9.1.x-feature: 9.1.0-pre.stable_10993 # No Update
   9.0.x: 9.0.12   # tbc
   8.10.x: 8.6.25  # tbc
   8.11.x: 8.7.19  # tbc
@@ -64,10 +64,10 @@ mas_monitor_version:
   8.10.x: 8.10.19 # tbc
   8.11.x: 8.11.17 # tbc
 mas_optimizer_version:
-  9.1.x-feature: 9.1.0-pre.stable_1813 # No Update
-  9.0.x: 9.0.10   # tbc
-  8.10.x: 8.4.17  # tbc
-  8.11.x: 8.5.16  # tbc
+  9.1.x-feature: 9.1.0-pre.stable_1943 # No Update
+  9.0.x: 9.0.9    # tbc
+  8.10.x: 8.4.16  # tbc
+  8.11.x: 8.5.15  # tbc
 mas_predict_version:
   9.0.x: 9.0.7    # tbc
   8.10.x: 8.8.8   # tbc

--- a/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
@@ -5,7 +5,7 @@
 # catalog itself, but not everything in the catalog supports this yet (including MAS)
 # so we need to use the CASE bundle mirror process still.
 
-catalog_digest: sha256:6652ba9de686c61c4bb41c89ad1b0ed4d4073ec130cf609a11d3133014f1f187
+catalog_digest: sha256:61d2174bb39c102179b923af37e2555aca488520ede60d4516e8f8ed1e204752
 
 # Dependencies
 # -----------------------------------------------------------------------------

--- a/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
@@ -5,7 +5,7 @@
 # catalog itself, but not everything in the catalog supports this yet (including MAS)
 # so we need to use the CASE bundle mirror process still.
 
-catalog_digest: sha256:47c92c48c5da0ad9c4e98d6dce31095fe33a77d642bc5622b6685773cf8594f5
+catalog_digest: sha256:6652ba9de686c61c4bb41c89ad1b0ed4d4073ec130cf609a11d3133014f1f187
 
 # Dependencies
 # -----------------------------------------------------------------------------

--- a/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
@@ -10,13 +10,11 @@ catalog_digest: sha256:47c92c48c5da0ad9c4e98d6dce31095fe33a77d642bc5622b6685773c
 # Dependencies
 # -----------------------------------------------------------------------------
 ibm_licensing_version: 4.2.12                 # Operator version 4.2.11 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-licensing)
-common_svcs_version: 4.7.0                   # check once why we have 4.3.0 in all previous versions since so long it's 4.3.0   # Operator version 4.3.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
-common_svcs_version_2: 4.8.0
-common_svcs_version_1: 4.3.0 #+20240702.100000 # common_svcs is a mess
+common_svcs_version: 4.10.0 # check once why we have 4.3.0 in all previous versions since so long it's 4.3.0 # Operator version 4.3.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
 
-cp4d_platform_version: 5.0.0 #+20240716.101015 # Operator version 5.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-datacore/4.0.0%2B20231213.115030)
+cp4d_platform_version: 5.1.0  #+20240716.101015 # Operator version 5.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-datacore/4.0.0%2B20231213.115030)
 
-ibm_zen_version: 6.0.1+20240708.121250.32    # For CPD5 ibm-zen has to be explicitily mirrored
+ibm_zen_version: 6.1.0+20241120.004836.207     # For CPD5 ibm-zen has to be explicitily mirrored
 
 db2u_version: 6.0.1+20240704.142950.9960     # Operator version 110509.0.2 to find the version 6.0.1, search CASE_VERSION in db2u, catalog.yaml into ibm-maximo-operator-catalog (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
 events_version: 5.0.1                        # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
@@ -25,12 +23,12 @@ sls_version: 3.11.1 # tbc                    # Operator version 3.10.0 (https://
 tsm_version: 1.6.2  # tbc                    # Operator version 1.5.4 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
 dd_version: 1.1.17  # tbc                    # Operator version 1.1.14 (https://github.ibm.com/maximoappsuite/ibm-data-dictionary/releases)
 appconnect_version: 6.2.0                    # Operator version 6.2.0 # sticking to 6.2.0 version # Please do Not Change
-wsl_version: 9.0.0                           # Operator version 9.0.0
-wml_version: 9.0.0                           # Operator version 5.0.0
+wsl_version: 10.0.0
+wml_version: 10.0.0
 # ccs_build: +20240528.144404.460              # ibm-ccs from version 9.0.0 requires the build version
 # datarefinery_build: +20240517.202103.146
-spark_version: 9.0.0                         # Operator version 5.0.0
-cognos_version: 25.0.0                       # Operator version 25.0.0
+spark_version: 10.0.0                         # Operator version 5.0.0
+cognos_version: 27.0.0                       # Operator version 25.0.0
 couchdb_version: 1.0.13                      # Operator version 2.2.1 (This is required for Assist 9.0, https://github.com/IBM/cloud-pak/blob/master/repo/case/ibm-couchdb/index.yaml)
 elasticsearch_version: 1.1.2570              # Operator version 1.1.2470
 
@@ -107,4 +105,4 @@ amlen_extras_version: 1.1.2
 
 # Default Cloud Pak for Data version
 # ------------------------------------------------------------------------------
-cpd_product_version_default: 5.0.0
+cpd_product_version_default: 5.1.0

--- a/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
@@ -21,7 +21,7 @@ events_version: 5.0.1                        # Operator version 5.0.1 (https://g
 uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
 sls_version: 3.11.1 # tbc                    # Operator version 3.10.0 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
 tsm_version: 1.6.2  # tbc                    # Operator version 1.5.4 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
-dd_version: 1.1.17  # tbc                    # Operator version 1.1.14 (https://github.ibm.com/maximoappsuite/ibm-data-dictionary/releases)
+dd_version: 1.1.18  # tbc                    # Operator version 1.1.14 (https://github.ibm.com/maximoappsuite/ibm-data-dictionary/releases)
 appconnect_version: 6.2.0                    # Operator version 6.2.0 # sticking to 6.2.0 version # Please do Not Change
 wsl_version: 10.0.0
 wml_version: 10.0.0
@@ -58,23 +58,23 @@ mas_manage_version:
   8.10.x: 8.6.24  # tbc
   8.11.x: 8.7.18  # tbc
 mas_monitor_version:
-  9.0.x: 9.0.8    # tbc
-  8.10.x: 8.10.18 # tbc
-  8.11.x: 8.11.16 # tbc
+  9.0.x: 9.0.9    # tbc
+  8.10.x: 8.10.19 # tbc
+  8.11.x: 8.11.17 # tbc
 mas_optimizer_version:
   9.1.x-feature: 9.1.0-pre.stable_1813 # No Update
-  9.0.x: 9.0.9    # tbc
-  8.10.x: 8.4.16  # tbc
-  8.11.x: 8.5.15  # tbc
+  9.0.x: 9.0.10   # tbc
+  8.10.x: 8.4.17  # tbc
+  8.11.x: 8.5.16  # tbc
 mas_predict_version:
-  9.0.x: 9.0.6    # tbc
-  8.10.x: 8.8.7   # tbc
-  8.11.x: 8.9.9   # tbc
+  9.0.x: 9.0.7    # tbc
+  8.10.x: 8.8.8   # tbc
+  8.11.x: 8.9.10  # tbc
 mas_visualinspection_version:
   9.1.x-feature: 9.1.0-pre.stable_2246 # No Update
-  9.0.x: 9.0.8    # tbc
+  9.0.x: 9.0.9    # tbc
   8.10.x: 8.8.4   # No Update
-  8.11.x: 8.9.11  # tbc
+  8.11.x: 8.9.12  # tbc
 
 # Extra Images for UDS
 # ------------------------------------------------------------------------------

--- a/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
@@ -10,13 +10,11 @@ catalog_digest: sha256:25ae7b227916eaa6fac8a04afb1ca5cedbc49fbd1196b6c6490b537af
 # Dependencies
 # -----------------------------------------------------------------------------
 ibm_licensing_version: 4.2.12                 # Operator version 4.2.11 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-licensing)
-common_svcs_version: 4.7.0                   # check once why we have 4.3.0 in all previous versions since so long it's 4.3.0   # Operator version 4.3.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
-common_svcs_version_2: 4.8.0
-common_svcs_version_1: 4.3.0 #+20240702.100000 # common_svcs is a mess
+common_svcs_version: 4.10.0 # check once why we have 4.3.0 in all previous versions since so long it's 4.3.0 # Operator version 4.3.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
 
-cp4d_platform_version: 5.0.0 #+20240716.101015 # Operator version 5.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-datacore/4.0.0%2B20231213.115030)
+cp4d_platform_version: 5.1.0  #+20240716.101015 # Operator version 5.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-datacore/4.0.0%2B20231213.115030)
 
-ibm_zen_version: 6.0.1+20240708.121250.32    # For CPD5 ibm-zen has to be explicitily mirrored
+ibm_zen_version: 6.1.0+20241120.004836.207     # For CPD5 ibm-zen has to be explicitily mirrored
 
 db2u_version: 6.0.1+20240704.142950.9960     # Operator version 110509.0.2 to find the version 6.0.1, search CASE_VERSION in db2u, catalog.yaml into ibm-maximo-operator-catalog (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
 events_version: 5.0.1                        # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
@@ -25,12 +23,12 @@ sls_version: 3.11.1 # tbc                    # Operator version 3.10.0 (https://
 tsm_version: 1.6.2  # tbc                    # Operator version 1.5.4 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
 dd_version: 1.1.18  # tbc                    # Operator version 1.1.14 (https://github.ibm.com/maximoappsuite/ibm-data-dictionary/releases)
 appconnect_version: 6.2.0                    # Operator version 6.2.0 # sticking to 6.2.0 version # Please do Not Change
-wsl_version: 9.0.0                           # Operator version 9.0.0
-wml_version: 9.0.0                           # Operator version 5.0.0
+wsl_version: 10.0.0
+wml_version: 10.0.0
 # ccs_build: +20240528.144404.460              # ibm-ccs from version 9.0.0 requires the build version
 # datarefinery_build: +20240517.202103.146
-spark_version: 9.0.0                         # Operator version 5.0.0
-cognos_version: 25.0.0                       # Operator version 25.0.0
+spark_version: 10.0.0                         # Operator version 5.0.0
+cognos_version: 27.0.0                       # Operator version 25.0.0
 couchdb_version: 1.0.13                      # Operator version 2.2.1 (This is required for Assist 9.0, https://github.com/IBM/cloud-pak/blob/master/repo/case/ibm-couchdb/index.yaml)
 elasticsearch_version: 1.1.2570              # Operator version 1.1.2470
 
@@ -107,4 +105,4 @@ amlen_extras_version: 1.1.2
 
 # Default Cloud Pak for Data version
 # ------------------------------------------------------------------------------
-cpd_product_version_default: 5.0.0
+cpd_product_version_default: 5.1.0

--- a/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
@@ -5,7 +5,7 @@
 # catalog itself, but not everything in the catalog supports this yet (including MAS)
 # so we need to use the CASE bundle mirror process still.
 
-catalog_digest: sha256:cfc8151b42a8d705ee68024897afe4224e5a1cae9249dc09188c4b2e5b7c77bb
+catalog_digest: sha256:25ae7b227916eaa6fac8a04afb1ca5cedbc49fbd1196b6c6490b537af8a28f33
 
 # Dependencies
 # -----------------------------------------------------------------------------

--- a/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
@@ -5,7 +5,7 @@
 # catalog itself, but not everything in the catalog supports this yet (including MAS)
 # so we need to use the CASE bundle mirror process still.
 
-catalog_digest: sha256:b514c75a2fa0bf4c31dad913e9e2088989a47f30c91a4310abee257c6820f5d1
+catalog_digest: sha256:47c92c48c5da0ad9c4e98d6dce31095fe33a77d642bc5622b6685773cf8594f5
 
 # Dependencies
 # -----------------------------------------------------------------------------

--- a/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
@@ -5,7 +5,7 @@
 # catalog itself, but not everything in the catalog supports this yet (including MAS)
 # so we need to use the CASE bundle mirror process still.
 
-catalog_digest: sha256:4d6d9c22b97dd6ccc6333d5fc616c7e1b1d9d6f524ba098fdacf497a8fbbed54
+catalog_digest: sha256:5121d783b8f59d35d32d6bf6cdbfe63f79b81f7f330016d07d5b58609171ccab
 
 # Dependencies
 # -----------------------------------------------------------------------------
@@ -56,9 +56,9 @@ mas_iot_version:
   8.11.x: 8.8.18  # tbc
 mas_manage_version:
   9.1.x-feature: 9.1.0-pre.stable_10993 # No Update
-  9.0.x: 9.0.12   # tbc
-  8.10.x: 8.6.25  # tbc
-  8.11.x: 8.7.19  # tbc
+  9.0.x: 9.0.13   # tbc
+  8.10.x: 8.6.26  # tbc
+  8.11.x: 8.7.20  # tbc
 mas_monitor_version:
   9.0.x: 9.0.9    # tbc
   8.10.x: 8.10.19 # tbc

--- a/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
@@ -5,7 +5,7 @@
 # catalog itself, but not everything in the catalog supports this yet (including MAS)
 # so we need to use the CASE bundle mirror process still.
 
-catalog_digest: sha256:61d2174bb39c102179b923af37e2555aca488520ede60d4516e8f8ed1e204752
+catalog_digest: sha256:6a34de6e00791707056512e0f60575ce3391efdb1fc140188c27cc843b60437b
 
 # Dependencies
 # -----------------------------------------------------------------------------
@@ -38,10 +38,10 @@ elasticsearch_version: 1.1.2570              # Operator version 1.1.2470
 mas_core_version:
   9.1.x-feature: 9.1.0-pre.stable_8193 # No Update
   9.0.x: 9.0.10   # tbc
-  8.10.x: 8.10.24 # tbc
-  8.11.x: 8.11.21 # tbc
+  8.10.x: 8.10.25 # tbc
+  8.11.x: 8.11.22 # tbc
 mas_assist_version:
-  9.0.x: 9.0.4    # No Update
+  9.0.x: 9.0.5    # No Update
   8.10.x: 8.7.8   # No Update
   8.11.x: 8.8.7   # No Update
 mas_hputilities_version:
@@ -49,14 +49,14 @@ mas_hputilities_version:
   8.10.x: 8.6.7   # tbc
   8.11.x: ""      # Not Supported
 mas_iot_version:
-  9.0.x: 9.0.7    # tbc
-  8.10.x: 8.7.21  # tbc
-  8.11.x: 8.8.17  # tbc
+  9.0.x: 9.0.8    # tbc
+  8.10.x: 8.7.22  # tbc
+  8.11.x: 8.8.18  # tbc
 mas_manage_version:
   9.1.x-feature: 9.1.0-pre.stable_9992 # No Update
-  9.0.x: 9.0.11   # tbc
-  8.10.x: 8.6.24  # tbc
-  8.11.x: 8.7.18  # tbc
+  9.0.x: 9.0.12   # tbc
+  8.10.x: 8.6.25  # tbc
+  8.11.x: 8.7.19  # tbc
 mas_monitor_version:
   9.0.x: 9.0.9    # tbc
   8.10.x: 8.10.19 # tbc
@@ -71,7 +71,7 @@ mas_predict_version:
   8.10.x: 8.8.8   # tbc
   8.11.x: 8.9.10  # tbc
 mas_visualinspection_version:
-  9.1.x-feature: 9.1.0-pre.stable_2246 # No Update
+  9.1.x-feature: 9.1.0-pre.stable_2405 # No Update
   9.0.x: 9.0.9    # tbc
   8.10.x: 8.8.4   # No Update
   8.11.x: 8.9.12  # tbc

--- a/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
@@ -1,0 +1,110 @@
+---
+# Case bundle configuration for IBM Maximo Operator Catalog 250403
+# -----------------------------------------------------------------------------
+# In the future this won't be necessary as we'll be able to mirror from the
+# catalog itself, but not everything in the catalog supports this yet (including MAS)
+# so we need to use the CASE bundle mirror process still.
+
+catalog_digest: sha256:b514c75a2fa0bf4c31dad913e9e2088989a47f30c91a4310abee257c6820f5d1
+
+# Dependencies
+# -----------------------------------------------------------------------------
+ibm_licensing_version: 4.2.12                 # Operator version 4.2.11 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-licensing)
+common_svcs_version: 4.7.0                   # check once why we have 4.3.0 in all previous versions since so long it's 4.3.0   # Operator version 4.3.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+common_svcs_version_2: 4.8.0
+common_svcs_version_1: 4.3.0 #+20240702.100000 # common_svcs is a mess
+
+cp4d_platform_version: 5.0.0 #+20240716.101015 # Operator version 5.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-datacore/4.0.0%2B20231213.115030)
+
+ibm_zen_version: 6.0.1+20240708.121250.32    # For CPD5 ibm-zen has to be explicitily mirrored
+
+db2u_version: 6.0.1+20240704.142950.9960     # Operator version 110509.0.2 to find the version 6.0.1, search CASE_VERSION in db2u, catalog.yaml into ibm-maximo-operator-catalog (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+events_version: 5.0.1                        # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
+uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
+sls_version: 3.11.1 # tbc                # Operator version 3.10.0 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
+tsm_version: 1.6.2  # Updated              # Operator version 1.5.4 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
+dd_version: 1.1.17  # updated                # Operator version 1.1.14 (https://github.ibm.com/maximoappsuite/ibm-data-dictionary/releases)
+appconnect_version: 6.2.0                    # Operator version 6.2.0 # sticking to 6.2.0 version # Please do Not Change
+wsl_version: 9.0.0                           # Operator version 9.0.0
+wml_version: 9.0.0                           # Operator version 5.0.0
+# ccs_build: +20240528.144404.460              # ibm-ccs from version 9.0.0 requires the build version
+# datarefinery_build: +20240517.202103.146
+spark_version: 9.0.0                         # Operator version 5.0.0
+cognos_version: 25.0.0                       # Operator version 25.0.0
+couchdb_version: 1.0.13                      # Operator version 2.2.1 (This is required for Assist 9.0, https://github.com/IBM/cloud-pak/blob/master/repo/case/ibm-couchdb/index.yaml)
+elasticsearch_version: 1.1.2570              # Operator version 1.1.2470
+
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  9.1.x-feature: 9.1.0-pre.stable_8193 # No Update
+  9.0.x: 9.0.10   # updated
+  8.10.x: 8.10.24 # updated
+  8.11.x: 8.11.21 # updated
+mas_assist_version:
+  9.0.x: 9.0.4    # No Update
+  8.10.x: 8.7.8   # No Update
+  8.11.x: 8.8.7   # No Update
+mas_hputilities_version:
+  9.0.x: ""       # Not Supported
+  8.10.x: 8.6.7   # tbc
+  8.11.x: ""      # Not Supported
+mas_iot_version:
+  9.0.x: 9.0.7    # updated
+  8.10.x: 8.7.21  # updated
+  8.11.x: 8.8.17  # updated
+mas_manage_version:
+  9.1.x-feature: 9.1.0-pre.stable_9992 # No Update
+  9.0.x: 9.0.11   # updated
+  8.10.x: 8.6.24  # updated
+  8.11.x: 8.7.18  # updated
+mas_monitor_version:
+  9.0.x: 9.0.8    # updated
+  8.10.x: 8.10.18 # updated
+  8.11.x: 8.11.16 # updated
+mas_optimizer_version:
+  9.1.x-feature: 9.1.0-pre.stable_1813 # No Update
+  9.0.x: 9.0.9    # updated
+  8.10.x: 8.4.16  # updated
+  8.11.x: 8.5.15  # updated
+mas_predict_version:
+  9.0.x: 9.0.6    # updated
+  8.10.x: 8.8.7   # updated
+  8.11.x: 8.9.9   # updated
+mas_visualinspection_version:
+  9.1.x-feature: 9.1.0-pre.stable_2246 # No Update
+  9.0.x: 9.0.8    # updated
+  8.10.x: 8.8.4   # No Update
+  8.11.x: 8.9.11  # updated
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.5.0
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version_default: 7.0.12
+
+# Variables used to mirror additional mongo image versions
+mongo_extras_version_4: 4.4.21
+mongo_extras_version_5: 5.0.23
+mongo_extras_version_6: 6.0.12
+mongo_extras_version_7: 7.0.12
+
+# Extra Images for Db2u
+# ------------------------------------------------------------------------------
+db2u_extras_version: 1.0.6 # No Update
+db2u_filter: db2
+
+# Extra Images for IBM Watson Discovery
+# ------------------------------------------------------------------------------
+#wd_extras_version: 1.0.4
+
+# Extra Images for Amlen
+# ------------------------------------------------------------------------------
+amlen_extras_version: 1.1.2
+
+# Default Cloud Pak for Data version
+# ------------------------------------------------------------------------------
+cpd_product_version_default: 5.0.0

--- a/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
@@ -5,7 +5,7 @@
 # catalog itself, but not everything in the catalog supports this yet (including MAS)
 # so we need to use the CASE bundle mirror process still.
 
-catalog_digest: sha256:6a34de6e00791707056512e0f60575ce3391efdb1fc140188c27cc843b60437b
+catalog_digest: sha256:cfc8151b42a8d705ee68024897afe4224e5a1cae9249dc09188c4b2e5b7c77bb
 
 # Dependencies
 # -----------------------------------------------------------------------------
@@ -39,7 +39,7 @@ elasticsearch_version: 1.1.2570              # Operator version 1.1.2470
 # -----------------------------------------------------------------------------
 mas_core_version:
   9.1.x-feature: 9.1.0-pre.stable_8193 # No Update
-  9.0.x: 9.0.10   # tbc
+  9.0.x: 9.0.11   # tbc
   8.10.x: 8.10.25 # tbc
   8.11.x: 8.11.22 # tbc
 mas_assist_version:

--- a/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
@@ -5,7 +5,7 @@
 # catalog itself, but not everything in the catalog supports this yet (including MAS)
 # so we need to use the CASE bundle mirror process still.
 
-catalog_digest: sha256:55feb1250f29536a2c9f6b355456280af0e195bf743da2fd60b089f0872accfb
+catalog_digest: sha256:18f72f1ed0c1acdf8c871b64328a2ddf58142a0d54e2cc8b95efe980d0f2266b
 
 # Dependencies
 # -----------------------------------------------------------------------------
@@ -38,7 +38,7 @@ elasticsearch_version: 1.1.2570              # Operator version 1.1.2470
 # Maximo Application Suite
 # -----------------------------------------------------------------------------
 mas_core_version:
-  9.1.x-feature: 9.1.0-pre.stable_8193 # No Update
+  9.1.x-feature: 9.1.0-pre.stable_9709 # No Update
   9.0.x: 9.0.11   # tbc
   8.10.x: 8.10.25 # tbc
   8.11.x: 8.11.22 # tbc

--- a/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
@@ -1,5 +1,5 @@
 ---
-# Case bundle configuration for IBM Maximo Operator Catalog 250403
+# Case bundle configuration for IBM Maximo Operator Catalog 250501
 # -----------------------------------------------------------------------------
 # In the future this won't be necessary as we'll be able to mirror from the
 # catalog itself, but not everything in the catalog supports this yet (including MAS)

--- a/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
@@ -10,11 +10,13 @@ catalog_digest: sha256:6a34de6e00791707056512e0f60575ce3391efdb1fc140188c27cc843
 # Dependencies
 # -----------------------------------------------------------------------------
 ibm_licensing_version: 4.2.12                 # Operator version 4.2.11 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-licensing)
-common_svcs_version: 4.10.0 # check once why we have 4.3.0 in all previous versions since so long it's 4.3.0 # Operator version 4.3.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+common_svcs_version: 4.7.0                   # check once why we have 4.3.0 in all previous versions since so long it's 4.3.0   # Operator version 4.3.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+common_svcs_version_2: 4.8.0
+common_svcs_version_1: 4.3.0 #+20240702.100000 # common_svcs is a mess
 
-cp4d_platform_version: 5.1.0  #+20240716.101015 # Operator version 5.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-datacore/4.0.0%2B20231213.115030)
+cp4d_platform_version: 5.0.0 #+20240716.101015 # Operator version 5.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-datacore/4.0.0%2B20231213.115030)
 
-ibm_zen_version: 6.1.0+20241120.004836.207     # For CPD5 ibm-zen has to be explicitily mirrored
+ibm_zen_version: 6.0.1+20240708.121250.32    # For CPD5 ibm-zen has to be explicitily mirrored
 
 db2u_version: 6.0.1+20240704.142950.9960     # Operator version 110509.0.2 to find the version 6.0.1, search CASE_VERSION in db2u, catalog.yaml into ibm-maximo-operator-catalog (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
 events_version: 5.0.1                        # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
@@ -23,12 +25,12 @@ sls_version: 3.11.1 # tbc                    # Operator version 3.10.0 (https://
 tsm_version: 1.6.2  # tbc                    # Operator version 1.5.4 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
 dd_version: 1.1.18  # tbc                    # Operator version 1.1.14 (https://github.ibm.com/maximoappsuite/ibm-data-dictionary/releases)
 appconnect_version: 6.2.0                    # Operator version 6.2.0 # sticking to 6.2.0 version # Please do Not Change
-wsl_version: 10.0.0
-wml_version: 10.0.0
+wsl_version: 9.0.0                           # Operator version 9.0.0
+wml_version: 9.0.0                           # Operator version 5.0.0
 # ccs_build: +20240528.144404.460              # ibm-ccs from version 9.0.0 requires the build version
 # datarefinery_build: +20240517.202103.146
-spark_version: 10.0.0                         # Operator version 5.0.0
-cognos_version: 27.0.0                       # Operator version 25.0.0
+spark_version: 9.0.0                         # Operator version 5.0.0
+cognos_version: 25.0.0                       # Operator version 25.0.0
 couchdb_version: 1.0.13                      # Operator version 2.2.1 (This is required for Assist 9.0, https://github.com/IBM/cloud-pak/blob/master/repo/case/ibm-couchdb/index.yaml)
 elasticsearch_version: 1.1.2570              # Operator version 1.1.2470
 
@@ -105,4 +107,4 @@ amlen_extras_version: 1.1.2
 
 # Default Cloud Pak for Data version
 # ------------------------------------------------------------------------------
-cpd_product_version_default: 5.1.0
+cpd_product_version_default: 5.0.0

--- a/src/mas/devops/data/catalogs/v9-250501-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-s390x.yaml
@@ -1,0 +1,40 @@
+---
+# Case bundle configuration for IBM Maximo Operator Catalog 250403
+# -----------------------------------------------------------------------------
+# In the future this won't be necessary as we'll be able to mirror from the
+# catalog itself, but not everything in the catalog supports this yet (including MAS)
+# so we need to use the CASE bundle mirror process still.
+
+catalog_digest: sha256:45f4a5de29d15b936399adc28a80258557420094f1f7740c97e8d44a84446a85
+
+uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
+sls_version: 3.11.1 # tbc                    # Operator version 3.10.0 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
+tsm_version: 1.6.1  # No Update              # Operator version 1.5.4 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
+
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  9.1.x-feature: 9.1.0-pre.stable_8193 # tbc
+  9.0.x: 9.0.10    # updated
+  8.10.x: "" # Not Supported
+  8.11.x: "" # Not Supported
+mas_manage_version:
+  9.1.x-feature: 9.1.0-pre.stable_9992 # tbc
+  9.0.x: 9.0.11    # updated
+  8.10.x: ""  # Not Supported
+  8.11.x: ""  # Not Supported
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.5.0
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version_default: 7.0.12
+
+# Variables used to mirror additional mongo image versions
+mongo_extras_version_4: 4.4.21
+mongo_extras_version_5: 5.0.23
+mongo_extras_version_6: 6.0.12
+mongo_extras_version_7: 7.0.12

--- a/src/mas/devops/data/catalogs/v9-250501-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-s390x.yaml
@@ -5,7 +5,7 @@
 # catalog itself, but not everything in the catalog supports this yet (including MAS)
 # so we need to use the CASE bundle mirror process still.
 
-catalog_digest: sha256:07eb918b45ccd94c36daf5b9aa2d4b7d287b8fe3f75fa47813216b181d98ae7d
+catalog_digest: sha256:76c9c49e45cf9e52ae42f8eb214dabc1e9e8dd79037e8d6eeea2b200fce86dea
 
 uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
 sls_version: 3.11.1 # tbc                    # Operator version 3.10.0 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
@@ -21,7 +21,7 @@ mas_core_version:
   8.11.x: "" # Not Supported
 mas_manage_version:
   9.1.x-feature: 9.1.0-pre.stable_9992 # tbc
-  9.0.x: 9.0.11    # tbc
+  9.0.x: 9.0.12    # tbc
   8.10.x: ""  # Not Supported
   8.11.x: ""  # Not Supported
 

--- a/src/mas/devops/data/catalogs/v9-250501-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-s390x.yaml
@@ -5,11 +5,11 @@
 # catalog itself, but not everything in the catalog supports this yet (including MAS)
 # so we need to use the CASE bundle mirror process still.
 
-catalog_digest: tbc
+catalog_digest: sha256:3e54f36aa4bac7c0ee2be788cb8e00153a1c066a19a4734e624503ef39c03777
 
 uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
 sls_version: 3.11.1 # tbc                    # Operator version 3.10.0 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
-tsm_version: 1.6.1  # No Update              # Operator version 1.5.4 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
+tsm_version: 1.6.2  # No Update              # Operator version 1.5.4 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
 
 
 # Maximo Application Suite

--- a/src/mas/devops/data/catalogs/v9-250501-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-s390x.yaml
@@ -5,7 +5,7 @@
 # catalog itself, but not everything in the catalog supports this yet (including MAS)
 # so we need to use the CASE bundle mirror process still.
 
-catalog_digest: sha256:76c9c49e45cf9e52ae42f8eb214dabc1e9e8dd79037e8d6eeea2b200fce86dea
+catalog_digest: sha256:3c4256570660cc42c4eea67c2144b8a151bf4b241d3682d699cb5986f8fd6517
 
 uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
 sls_version: 3.11.1 # tbc                    # Operator version 3.10.0 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
@@ -16,7 +16,7 @@ tsm_version: 1.6.2  # No Update              # Operator version 1.5.4 (https://g
 # -----------------------------------------------------------------------------
 mas_core_version:
   9.1.x-feature: 9.1.0-pre.stable_8193 # tbc
-  9.0.x: 9.0.10    # tbc
+  9.0.x: 9.0.11    # tbc
   8.10.x: "" # Not Supported
   8.11.x: "" # Not Supported
 mas_manage_version:

--- a/src/mas/devops/data/catalogs/v9-250501-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-s390x.yaml
@@ -5,7 +5,7 @@
 # catalog itself, but not everything in the catalog supports this yet (including MAS)
 # so we need to use the CASE bundle mirror process still.
 
-catalog_digest: sha256:ef9b2763060e8e142f42530eb94e37f15d50e2ffe18dd62de93a1fceb4957c83
+catalog_digest: sha256:101f126494d4840f7cda7aa87b30d49aafd9abf736d455bf65597f0b35b1c070
 
 uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
 sls_version: 3.11.1 # tbc                    # Operator version 3.10.0 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
@@ -21,7 +21,7 @@ mas_core_version:
   8.11.x: "" # Not Supported
 mas_manage_version:
   9.1.x-feature: 9.1.0-pre.stable_10993 # tbc
-  9.0.x: 9.0.12    # tbc
+  9.0.x: 9.0.13    # tbc
   8.10.x: ""  # Not Supported
   8.11.x: ""  # Not Supported
 

--- a/src/mas/devops/data/catalogs/v9-250501-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-s390x.yaml
@@ -5,7 +5,7 @@
 # catalog itself, but not everything in the catalog supports this yet (including MAS)
 # so we need to use the CASE bundle mirror process still.
 
-catalog_digest: sha256:45f4a5de29d15b936399adc28a80258557420094f1f7740c97e8d44a84446a85
+catalog_digest: tbc
 
 uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
 sls_version: 3.11.1 # tbc                    # Operator version 3.10.0 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
@@ -16,12 +16,12 @@ tsm_version: 1.6.1  # No Update              # Operator version 1.5.4 (https://g
 # -----------------------------------------------------------------------------
 mas_core_version:
   9.1.x-feature: 9.1.0-pre.stable_8193 # tbc
-  9.0.x: 9.0.10    # updated
+  9.0.x: 9.0.10    # tbc
   8.10.x: "" # Not Supported
   8.11.x: "" # Not Supported
 mas_manage_version:
   9.1.x-feature: 9.1.0-pre.stable_9992 # tbc
-  9.0.x: 9.0.11    # updated
+  9.0.x: 9.0.11    # tbc
   8.10.x: ""  # Not Supported
   8.11.x: ""  # Not Supported
 

--- a/src/mas/devops/data/catalogs/v9-250501-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-s390x.yaml
@@ -5,7 +5,7 @@
 # catalog itself, but not everything in the catalog supports this yet (including MAS)
 # so we need to use the CASE bundle mirror process still.
 
-catalog_digest: sha256:21756e2a2e870df1d3e831e39d21d82dfbb662bd76dc6cabadd1b8c6efb4a126
+catalog_digest: sha256:ef9b2763060e8e142f42530eb94e37f15d50e2ffe18dd62de93a1fceb4957c83
 
 uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
 sls_version: 3.11.1 # tbc                    # Operator version 3.10.0 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
@@ -15,7 +15,7 @@ tsm_version: 1.6.2  # No Update              # Operator version 1.5.4 (https://g
 # Maximo Application Suite
 # -----------------------------------------------------------------------------
 mas_core_version:
-  9.1.x-feature: 9.1.0-pre.stable_9709 # tbc
+  9.1.x-feature: 9.1.0-pre.stable_9718 # tbc
   9.0.x: 9.0.11    # tbc
   8.10.x: "" # Not Supported
   8.11.x: "" # Not Supported

--- a/src/mas/devops/data/catalogs/v9-250501-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-s390x.yaml
@@ -5,7 +5,7 @@
 # catalog itself, but not everything in the catalog supports this yet (including MAS)
 # so we need to use the CASE bundle mirror process still.
 
-catalog_digest: sha256:3e54f36aa4bac7c0ee2be788cb8e00153a1c066a19a4734e624503ef39c03777
+catalog_digest: sha256:3108d9fcab4e7cbc622af4fc16d2d7f476b4bb18a21b6d25376badbda3f6dfdc
 
 uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
 sls_version: 3.11.1 # tbc                    # Operator version 3.10.0 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)

--- a/src/mas/devops/data/catalogs/v9-250501-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-s390x.yaml
@@ -5,7 +5,7 @@
 # catalog itself, but not everything in the catalog supports this yet (including MAS)
 # so we need to use the CASE bundle mirror process still.
 
-catalog_digest: sha256:24bddbf965ccfcb4fb231233d9c383890eb114ca73f5ce708dfd7c4725bed1ef
+catalog_digest: sha256:ff3a9a5845e932fc8e695f47529ca37c12793b87a275a01abef9537bacbbf606
 
 uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
 sls_version: 3.11.1 # tbc                    # Operator version 3.10.0 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
@@ -20,7 +20,7 @@ mas_core_version:
   8.10.x: "" # Not Supported
   8.11.x: "" # Not Supported
 mas_manage_version:
-  9.1.x-feature: 9.1.0-pre.stable_9992 # tbc
+  9.1.x-feature: 9.1.0-pre.stable_10993 # tbc
   9.0.x: 9.0.12    # tbc
   8.10.x: ""  # Not Supported
   8.11.x: ""  # Not Supported

--- a/src/mas/devops/data/catalogs/v9-250501-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-s390x.yaml
@@ -5,7 +5,7 @@
 # catalog itself, but not everything in the catalog supports this yet (including MAS)
 # so we need to use the CASE bundle mirror process still.
 
-catalog_digest: sha256:3c4256570660cc42c4eea67c2144b8a151bf4b241d3682d699cb5986f8fd6517
+catalog_digest: sha256:24bddbf965ccfcb4fb231233d9c383890eb114ca73f5ce708dfd7c4725bed1ef
 
 uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
 sls_version: 3.11.1 # tbc                    # Operator version 3.10.0 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)

--- a/src/mas/devops/data/catalogs/v9-250501-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-s390x.yaml
@@ -5,7 +5,7 @@
 # catalog itself, but not everything in the catalog supports this yet (including MAS)
 # so we need to use the CASE bundle mirror process still.
 
-catalog_digest: sha256:3108d9fcab4e7cbc622af4fc16d2d7f476b4bb18a21b6d25376badbda3f6dfdc
+catalog_digest: sha256:07eb918b45ccd94c36daf5b9aa2d4b7d287b8fe3f75fa47813216b181d98ae7d
 
 uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
 sls_version: 3.11.1 # tbc                    # Operator version 3.10.0 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)

--- a/src/mas/devops/data/catalogs/v9-250501-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-s390x.yaml
@@ -1,5 +1,5 @@
 ---
-# Case bundle configuration for IBM Maximo Operator Catalog 250403
+# Case bundle configuration for IBM Maximo Operator Catalog 250501
 # -----------------------------------------------------------------------------
 # In the future this won't be necessary as we'll be able to mirror from the
 # catalog itself, but not everything in the catalog supports this yet (including MAS)

--- a/src/mas/devops/data/catalogs/v9-250501-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-s390x.yaml
@@ -5,7 +5,7 @@
 # catalog itself, but not everything in the catalog supports this yet (including MAS)
 # so we need to use the CASE bundle mirror process still.
 
-catalog_digest: sha256:ff3a9a5845e932fc8e695f47529ca37c12793b87a275a01abef9537bacbbf606
+catalog_digest: sha256:21756e2a2e870df1d3e831e39d21d82dfbb662bd76dc6cabadd1b8c6efb4a126
 
 uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
 sls_version: 3.11.1 # tbc                    # Operator version 3.10.0 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
@@ -15,7 +15,7 @@ tsm_version: 1.6.2  # No Update              # Operator version 1.5.4 (https://g
 # Maximo Application Suite
 # -----------------------------------------------------------------------------
 mas_core_version:
-  9.1.x-feature: 9.1.0-pre.stable_8193 # tbc
+  9.1.x-feature: 9.1.0-pre.stable_9709 # tbc
   9.0.x: 9.0.11    # tbc
   8.10.x: "" # Not Supported
   8.11.x: "" # Not Supported

--- a/src/mas/devops/mas.py
+++ b/src/mas/devops/mas.py
@@ -250,7 +250,7 @@ def patchPendingPVC(dynClient: DynamicClient, namespace: str, pvcName: str, stor
                 except NotFoundError:
                     logger.error("The patched PVC {pvcName} does not exist.")
                     return False
-            
+
             return foundReadyPVC
 
     except NotFoundError:

--- a/src/mas/devops/mas.py
+++ b/src/mas/devops/mas.py
@@ -12,6 +12,7 @@ import logging
 import re
 import yaml
 from os import path
+from time import sleep
 from types import SimpleNamespace
 from kubernetes.dynamic.resource import ResourceInstance
 from openshift.dynamic import DynamicClient
@@ -194,3 +195,62 @@ def updateIBMEntitlementKey(dynClient: DynamicClient, namespace: str, icrUsernam
 
     secret = secretsAPI.apply(body=secret, namespace=namespace)
     return secret
+
+def waitForPVC(dynClient: DynamicClient, namespace: str, pvcName: str) -> bool:
+    pvcAPI = dynClient.resources.get(api_version="v1", kind="PersistentVolumeClaim")
+    maxRetries = 60
+    foundReadyPVC = False
+    retries = 0
+    while not foundReadyPVC and retries < maxRetries:
+        retries += 1
+        try:
+            pvc = pvcAPI.get(name=pvcName, namespace=namespace)
+            if pvc.status.phase == "Bound":
+                foundReadyPVC = True
+            else:
+                logger.debug("Waiting 5s for PVC {pvcName} to be ready before checking again ...")
+                sleep(5)
+        except NotFoundError:
+            logger.debug("Waiting 5s for PVC {pvcName} to be created before checking again ...")
+            sleep(5)
+    return foundReadyPVC
+
+
+def patchPendingPVC(dynClient: DynamicClient, namespace: str, pvcName: str, storageClassName: str = None) -> bool:
+    pvcAPI = dynClient.resources.get(api_version="v1", kind="PersistentVolumeClaim")
+    try:
+        pvc = pvcAPI.get(name=pvcName, namespace=namespace)
+        if pvc.status.phase == "Pending" and pvc.spec.storageClassName is None:
+            if storageClassName is not None and storageClassName(dynClient, name=storageClassName) is not None:
+                pvc.spec.storageClassName = storageClassName
+            else:
+                defaultStorageClasses = getDefaultStorageClasses(dynClient)
+                if defaultStorageClasses.provider is not None:
+                    pvc.spec.storageClassName = defaultStorageClasses.rwo
+                else:
+                    logger.error("Unable to set storageClassName in PVC {pvcName}.")
+                    return False
+
+            pvcAPI.patch(body=pvc, namespace=namespace)
+
+            maxRetries = 60
+            foundReadyPVC = False
+            retries = 0
+            while not foundReadyPVC and retries < maxRetries:
+                retries += 1
+                try:
+                    patchedPVC = pvcAPI.get(name=pvcName, namespace=namespace)
+                    if patchedPVC.status.phase == "Bound":
+                        foundReadyPVC = True
+                    else:
+                        logger.debug("Waiting 5s for PVC {pvcName} to be bound before checking again ...")
+                        sleep(5)
+                except NotFoundError:
+                    logger.error("The patched PVC {pvcName} does not exist.")
+                    return False
+            
+            return foundReadyPVC
+
+    except NotFoundError:
+        logger.error("PVC {pvcName} does not exist")
+        return False

--- a/src/mas/devops/mas.py
+++ b/src/mas/devops/mas.py
@@ -146,8 +146,8 @@ def verifyMasInstance(dynClient: DynamicClient, instanceId: str) -> bool:
     except ResourceNotFoundError:
         # The MAS Suite CRD has not even been installed in the cluster
         return False
-    except UnauthorizedError:
-        logger.error("Error: Unable to verify MAS instance due to failed authorization: {e}")
+    except UnauthorizedError as e:
+        logger.error(f"Error: Unable to verify MAS instance due to failed authorization: {e}")
         return False
 
 
@@ -209,10 +209,10 @@ def waitForPVC(dynClient: DynamicClient, namespace: str, pvcName: str) -> bool:
             if pvc.status.phase == "Bound":
                 foundReadyPVC = True
             else:
-                logger.debug("Waiting 5s for PVC {pvcName} to be ready before checking again ...")
+                logger.debug(f"Waiting 5s for PVC {pvcName} to be ready before checking again ...")
                 sleep(5)
         except NotFoundError:
-            logger.debug("Waiting 5s for PVC {pvcName} to be created before checking again ...")
+            logger.debug(f"Waiting 5s for PVC {pvcName} to be created before checking again ...")
             sleep(5)
 
     return foundReadyPVC
@@ -230,7 +230,7 @@ def patchPendingPVC(dynClient: DynamicClient, namespace: str, pvcName: str, stor
                 if defaultStorageClasses.provider is not None:
                     pvc.spec.storageClassName = defaultStorageClasses.rwo
                 else:
-                    logger.error("Unable to set storageClassName in PVC {pvcName}.")
+                    logger.error(f"Unable to set storageClassName in PVC {pvcName}.")
                     return False
 
             pvcAPI.patch(body=pvc, namespace=namespace)
@@ -245,14 +245,14 @@ def patchPendingPVC(dynClient: DynamicClient, namespace: str, pvcName: str, stor
                     if patchedPVC.status.phase == "Bound":
                         foundReadyPVC = True
                     else:
-                        logger.debug("Waiting 5s for PVC {pvcName} to be bound before checking again ...")
+                        logger.debug(f"Waiting 5s for PVC {pvcName} to be bound before checking again ...")
                         sleep(5)
                 except NotFoundError:
-                    logger.error("The patched PVC {pvcName} does not exist.")
+                    logger.error(f"The patched PVC {pvcName} does not exist.")
                     return False
 
             return foundReadyPVC
 
     except NotFoundError:
-        logger.error("PVC {pvcName} does not exist")
+        logger.error(f"PVC {pvcName} does not exist")
         return False

--- a/src/mas/devops/mas.py
+++ b/src/mas/devops/mas.py
@@ -196,6 +196,7 @@ def updateIBMEntitlementKey(dynClient: DynamicClient, namespace: str, icrUsernam
     secret = secretsAPI.apply(body=secret, namespace=namespace)
     return secret
 
+
 def waitForPVC(dynClient: DynamicClient, namespace: str, pvcName: str) -> bool:
     pvcAPI = dynClient.resources.get(api_version="v1", kind="PersistentVolumeClaim")
     maxRetries = 60
@@ -213,6 +214,7 @@ def waitForPVC(dynClient: DynamicClient, namespace: str, pvcName: str) -> bool:
         except NotFoundError:
             logger.debug("Waiting 5s for PVC {pvcName} to be created before checking again ...")
             sleep(5)
+
     return foundReadyPVC
 
 

--- a/src/mas/devops/ocp.py
+++ b/src/mas/devops/ocp.py
@@ -159,65 +159,6 @@ def waitForDeployment(dynClient: DynamicClient, namespace: str, deploymentName: 
             sleep(5)
     return foundReadyDeployment
 
-def waitForPVC(dynClient: DynamicClient, namespace: str, pvcName: str) -> bool:
-    pvcAPI = dynClient.resources.get(api_version="v1", kind="PersistentVolumeClaim")
-    maxRetries = 60
-    foundReadyPVC = False
-    retries = 0
-    while not foundReadyPVC and retries < maxRetries:
-        retries += 1
-        try:
-            pvc = pvcAPI.get(name=pvcName, namespace=namespace)
-            if pvc.status.phase == "Bound":
-                foundReadyPVC = True
-            else:
-                logger.debug("Waiting 5s for PVC {pvcName} to be ready before checking again ...")
-                sleep(5)
-        except NotFoundError:
-            logger.debug("Waiting 5s for PVC {pvcName} to be created before checking again ...")
-            sleep(5)
-    return foundReadyPVC
-
-
-def patchPendingPVC(dynClient: DynamicClient, namespace: str, pvcName: str, storageClassName: str = None) -> bool:
-    pvcAPI = dynClient.resources.get(api_version="v1", kind="PersistentVolumeClaim")
-    try:
-        pvc = pvcAPI.get(name=pvcName, namespace=namespace)
-        if pvc.status.phase == "Pending" and pvc.spec.storageClassName is None:
-            if getStorageClasses is not None:
-                pvc.spec.storageClassName = storageClassName
-            else:
-                defaultStorageClasses = getDefaultStorageClasses(dynClient)
-                if defaultStorageClasses.provider is not None:
-                    pvc.spec.storageClassName = defaultStorageClasses.rwo
-                else:
-                    logger.error("Unable to set storageClassName in PVC {pvcName}.")
-                    return False
-
-            pvcAPI.patch(body=pvc, namespace=namespace)
-
-            maxRetries = 60
-            foundReadyPVC = False
-            retries = 0
-            while not foundReadyPVC and retries < maxRetries:
-                retries += 1
-                try:
-                    patchedPVC = pvcAPI.get(name=pvcName, namespace=namespace)
-                    if patchedPVC.status.phase == "Bound":
-                        foundReadyPVC = True
-                    else:
-                        logger.debug("Waiting 5s for PVC {pvcName} to be bound before checking again ...")
-                        sleep(5)
-                except NotFoundError:
-                    logger.error("The patched PVC {pvcName} does not exist.")
-                    return False
-            
-            return foundReadyPVC
-
-    except NotFoundError:
-        logger.error("PVC {pvcName} does not exist")
-        return False
-
 def getConsoleURL(dynClient: DynamicClient) -> str:
     routesAPI = dynClient.resources.get(api_version="route.openshift.io/v1", kind="Route")
     consoleRoute = routesAPI.get(name="console", namespace="openshift-console")
@@ -257,6 +198,65 @@ def crdExists(dynClient: DynamicClient, crdName: str) -> bool:
         return True
     except NotFoundError:
         logger.debug(f"CRD does not exist: {crdName}")
+        return False
+
+def waitForPVC(dynClient: DynamicClient, namespace: str, pvcName: str) -> bool:
+    pvcAPI = dynClient.resources.get(api_version="v1", kind="PersistentVolumeClaim")
+    maxRetries = 60
+    foundReadyPVC = False
+    retries = 0
+    while not foundReadyPVC and retries < maxRetries:
+        retries += 1
+        try:
+            pvc = pvcAPI.get(name=pvcName, namespace=namespace)
+            if pvc.status.phase == "Bound":
+                foundReadyPVC = True
+            else:
+                logger.debug("Waiting 5s for PVC {pvcName} to be ready before checking again ...")
+                sleep(5)
+        except NotFoundError:
+            logger.debug("Waiting 5s for PVC {pvcName} to be created before checking again ...")
+            sleep(5)
+    return foundReadyPVC
+
+
+def patchPendingPVC(dynClient: DynamicClient, namespace: str, pvcName: str, storageClassName: str = None) -> bool:
+    pvcAPI = dynClient.resources.get(api_version="v1", kind="PersistentVolumeClaim")
+    try:
+        pvc = pvcAPI.get(name=pvcName, namespace=namespace)
+        if pvc.status.phase == "Pending" and pvc.spec.storageClassName is None:
+            if storageClassName is not None and storageClassName(dynClient, name=storageClassName) is not None:
+                pvc.spec.storageClassName = storageClassName
+            else:
+                defaultStorageClasses = getDefaultStorageClasses(dynClient)
+                if defaultStorageClasses.provider is not None:
+                    pvc.spec.storageClassName = defaultStorageClasses.rwo
+                else:
+                    logger.error("Unable to set storageClassName in PVC {pvcName}.")
+                    return False
+
+            pvcAPI.patch(body=pvc, namespace=namespace)
+
+            maxRetries = 60
+            foundReadyPVC = False
+            retries = 0
+            while not foundReadyPVC and retries < maxRetries:
+                retries += 1
+                try:
+                    patchedPVC = pvcAPI.get(name=pvcName, namespace=namespace)
+                    if patchedPVC.status.phase == "Bound":
+                        foundReadyPVC = True
+                    else:
+                        logger.debug("Waiting 5s for PVC {pvcName} to be bound before checking again ...")
+                        sleep(5)
+                except NotFoundError:
+                    logger.error("The patched PVC {pvcName} does not exist.")
+                    return False
+            
+            return foundReadyPVC
+
+    except NotFoundError:
+        logger.error("PVC {pvcName} does not exist")
         return False
 
 

--- a/src/mas/devops/ocp.py
+++ b/src/mas/devops/ocp.py
@@ -150,10 +150,10 @@ def waitForDeployment(dynClient: DynamicClient, namespace: str, deploymentName: 
                 # NoneType and int comparison TypeError
                 foundReadyDeployment = True
             else:
-                logger.debug("Waiting 5s for deployment {deploymentName} to be ready before checking again ...")
+                logger.debug(f"Waiting 5s for deployment {deploymentName} to be ready before checking again ...")
                 sleep(5)
         except NotFoundError:
-            logger.debug("Waiting 5s for deployment {deploymentName} to be created before checking again ...")
+            logger.debug(f"Waiting 5s for deployment {deploymentName} to be created before checking again ...")
             sleep(5)
     return foundReadyDeployment
 

--- a/src/mas/devops/ocp.py
+++ b/src/mas/devops/ocp.py
@@ -190,6 +190,9 @@ def patchPendingPVC(dynClient: DynamicClient, namespace: str, pvcName: str, stor
                 defaultStorageClasses = getDefaultStorageClasses(dynClient)
                 if defaultStorageClasses.provider is not None:
                     pvc.spec.storageClassName = defaultStorageClasses.rwo
+                else:
+                    logger.error("Unable to set storageClassName in PVC {pvcName}.")
+                    return False
 
             pvcAPI.patch(body=pvc, namespace=namespace)
 

--- a/src/mas/devops/ocp.py
+++ b/src/mas/devops/ocp.py
@@ -20,6 +20,8 @@ from kubernetes import client
 from kubernetes.stream import stream
 from kubernetes.stream.ws_client import ERROR_CHANNEL
 
+from .mas import getDefaultStorageClasses
+
 import yaml
 
 logger = logging.getLogger(__name__)
@@ -177,12 +179,18 @@ def waitForPVC(dynClient: DynamicClient, namespace: str, pvcName: str) -> bool:
     return foundReadyPVC
 
 
-def patchPendingPVC(dynClient: DynamicClient, namespace: str, pvcName: str, storageClassName: str) -> bool:
+def patchPendingPVC(dynClient: DynamicClient, namespace: str, pvcName: str, storageClassName: str = None) -> bool:
     pvcAPI = dynClient.resources.get(api_version="v1", kind="PersistentVolumeClaim")
     try:
         pvc = pvcAPI.get(name=pvcName, namespace=namespace)
         if pvc.status.phase == "Pending" and pvc.spec.storageClassName is None:
-            pvc.spec.storageClassName = storageClassName
+            if getStorageClasses is not None:
+                pvc.spec.storageClassName = storageClassName
+            else:
+                defaultStorageClasses = getDefaultStorageClasses(dynClient)
+                if defaultStorageClasses.provider is not None:
+                    pvc.spec.storageClassName = defaultStorageClasses.rwo
+
             pvcAPI.patch(body=pvc, namespace=namespace)
 
             maxRetries = 60

--- a/src/mas/devops/ocp.py
+++ b/src/mas/devops/ocp.py
@@ -157,6 +157,7 @@ def waitForDeployment(dynClient: DynamicClient, namespace: str, deploymentName: 
             sleep(5)
     return foundReadyDeployment
 
+
 def getConsoleURL(dynClient: DynamicClient) -> str:
     routesAPI = dynClient.resources.get(api_version="route.openshift.io/v1", kind="Route")
     consoleRoute = routesAPI.get(name="console", namespace="openshift-console")

--- a/src/mas/devops/ocp.py
+++ b/src/mas/devops/ocp.py
@@ -157,6 +157,55 @@ def waitForDeployment(dynClient: DynamicClient, namespace: str, deploymentName: 
             sleep(5)
     return foundReadyDeployment
 
+def waitForPVC(dynClient: DynamicClient, namespace: str, pvcName: str) -> bool:
+    pvcAPI = dynClient.resources.get(api_version="v1", kind="PersistentVolumeClaim")
+    maxRetries = 60
+    foundReadyPVC = False
+    retries = 0
+    while not foundReadyPVC and retries < maxRetries:
+        retries += 1
+        try:
+            pvc = pvcAPI.get(name=pvcName, namespace=namespace)
+            if pvc.status.phase == "Bound":
+                foundReadyPVC = True
+            else:
+                logger.debug("Waiting 5s for PVC {pvcName} to be ready before checking again ...")
+                sleep(5)
+        except NotFoundError:
+            logger.debug("Waiting 5s for PVC {pvcName} to be created before checking again ...")
+            sleep(5)
+    return foundReadyPVC
+
+
+def patchPendingPVC(dynClient: DynamicClient, namespace: str, pvcName: str, storageClassName: str) -> bool:
+    pvcAPI = dynClient.resources.get(api_version="v1", kind="PersistentVolumeClaim")
+    try:
+        pvc = pvcAPI.get(name=pvcName, namespace=namespace)
+        if pvc.status.phase == "Pending" and pvc.spec.storageClassName is None:
+            pvc.spec.storageClassName = storageClassName
+            pvcAPI.patch(body=pvc, namespace=namespace)
+
+            maxRetries = 60
+            foundReadyPVC = False
+            retries = 0
+            while not foundReadyPVC and retries < maxRetries:
+                retries += 1
+                try:
+                    patchedPVC = pvcAPI.get(name=pvcName, namespace=namespace)
+                    if patchedPVC.status.phase == "Bound":
+                        foundReadyPVC = True
+                    else:
+                        logger.debug("Waiting 5s for PVC {pvcName} to be bound before checking again ...")
+                        sleep(5)
+                except NotFoundError:
+                    logger.error("The patched PVC {pvcName} does not exist.")
+                    return False
+            
+            return foundReadyPVC
+
+    except NotFoundError:
+        logger.error("PVC {pvcName} does not exist")
+        return False
 
 def getConsoleURL(dynClient: DynamicClient) -> str:
     routesAPI = dynClient.resources.get(api_version="route.openshift.io/v1", kind="Route")

--- a/src/mas/devops/ocp.py
+++ b/src/mas/devops/ocp.py
@@ -20,8 +20,6 @@ from kubernetes import client
 from kubernetes.stream import stream
 from kubernetes.stream.ws_client import ERROR_CHANNEL
 
-from .mas import getDefaultStorageClasses
-
 import yaml
 
 logger = logging.getLogger(__name__)
@@ -198,65 +196,6 @@ def crdExists(dynClient: DynamicClient, crdName: str) -> bool:
         return True
     except NotFoundError:
         logger.debug(f"CRD does not exist: {crdName}")
-        return False
-
-def waitForPVC(dynClient: DynamicClient, namespace: str, pvcName: str) -> bool:
-    pvcAPI = dynClient.resources.get(api_version="v1", kind="PersistentVolumeClaim")
-    maxRetries = 60
-    foundReadyPVC = False
-    retries = 0
-    while not foundReadyPVC and retries < maxRetries:
-        retries += 1
-        try:
-            pvc = pvcAPI.get(name=pvcName, namespace=namespace)
-            if pvc.status.phase == "Bound":
-                foundReadyPVC = True
-            else:
-                logger.debug("Waiting 5s for PVC {pvcName} to be ready before checking again ...")
-                sleep(5)
-        except NotFoundError:
-            logger.debug("Waiting 5s for PVC {pvcName} to be created before checking again ...")
-            sleep(5)
-    return foundReadyPVC
-
-
-def patchPendingPVC(dynClient: DynamicClient, namespace: str, pvcName: str, storageClassName: str = None) -> bool:
-    pvcAPI = dynClient.resources.get(api_version="v1", kind="PersistentVolumeClaim")
-    try:
-        pvc = pvcAPI.get(name=pvcName, namespace=namespace)
-        if pvc.status.phase == "Pending" and pvc.spec.storageClassName is None:
-            if storageClassName is not None and storageClassName(dynClient, name=storageClassName) is not None:
-                pvc.spec.storageClassName = storageClassName
-            else:
-                defaultStorageClasses = getDefaultStorageClasses(dynClient)
-                if defaultStorageClasses.provider is not None:
-                    pvc.spec.storageClassName = defaultStorageClasses.rwo
-                else:
-                    logger.error("Unable to set storageClassName in PVC {pvcName}.")
-                    return False
-
-            pvcAPI.patch(body=pvc, namespace=namespace)
-
-            maxRetries = 60
-            foundReadyPVC = False
-            retries = 0
-            while not foundReadyPVC and retries < maxRetries:
-                retries += 1
-                try:
-                    patchedPVC = pvcAPI.get(name=pvcName, namespace=namespace)
-                    if patchedPVC.status.phase == "Bound":
-                        foundReadyPVC = True
-                    else:
-                        logger.debug("Waiting 5s for PVC {pvcName} to be bound before checking again ...")
-                        sleep(5)
-                except NotFoundError:
-                    logger.error("The patched PVC {pvcName} does not exist.")
-                    return False
-            
-            return foundReadyPVC
-
-    except NotFoundError:
-        logger.error("PVC {pvcName} does not exist")
         return False
 
 

--- a/src/mas/devops/tekton.py
+++ b/src/mas/devops/tekton.py
@@ -22,7 +22,7 @@ from openshift.dynamic.exceptions import NotFoundError, UnprocessibleEntityError
 
 from jinja2 import Environment, FileSystemLoader
 
-from .ocp import getConsoleURL, waitForCRD, waitForDeployment, crdExists
+from .ocp import getConsoleURL, waitForCRD, waitForDeployment, waitForPVC, patchPendingPVC, crdExists
 
 logger = logging.getLogger(__name__)
 
@@ -79,10 +79,26 @@ def installOpenShiftPipelines(dynClient: DynamicClient) -> bool:
     foundReadyWebhook = waitForDeployment(dynClient, namespace="openshift-pipelines", deploymentName="tekton-pipelines-webhook")
     if foundReadyWebhook:
         logger.info("OpenShift Pipelines Webhook is installed and ready")
-        return True
     else:
         logger.error("OpenShift Pipelines Webhook is NOT installed and ready")
         return False
+
+    # Wait for the postgredb-tekton-results-postgres-0 PVC to be ready
+    # this PVC doesn't come up when there's no default storage class is  in the cluster,
+    # this is causing the pvc to be in pending state and causing the tekton-results-postgres statefulSet in pending, 
+    # due to these resources not coming up, the MAS pre-install check in the pipeline times out checking the health of this statefulSet,
+    # causing failure in pipeline. 
+    # Refer https://github.com/ibm-mas/cli/issues/1511
+    logger.debug("Waiting for postgredb-tekton-results-postgres-0 PVC to be ready")
+    foundReadyPVC = waitForPVC(dynClient, namespace="openshift-pipelines", pvcName="postgredb-tekton-results-postgres-0")
+    if foundReadyPVC:
+        logger.info("OpenShift Pipelines postgres is installed and ready")
+    else:
+        patchedPVC = patchPVC(dynClient, namespace="openshift-pipelines", pvcName="postgredb-tekton-results-postgres-0")
+        if patchPVC:
+            logger.info("OpenShift Pipelines postgres is installed and ready")
+        else:
+            logger.error("OpenShift Pipelines postgres PVC is NOT ready")
 
 
 def updateTektonDefinitions(namespace: str, yamlFile: str) -> None:

--- a/src/mas/devops/tekton.py
+++ b/src/mas/devops/tekton.py
@@ -86,10 +86,10 @@ def installOpenShiftPipelines(dynClient: DynamicClient, customStorageClassName: 
         return False
 
     # Wait for the postgredb-tekton-results-postgres-0 PVC to be ready
-    # this PVC doesn't come up when there's no default storage class is  in the cluster,
-    # this is causing the pvc to be in pending state and causing the tekton-results-postgres statefulSet in pending, 
+    # this PVC doesn't come up when there's no default storage class is in the cluster,
+    # this is causing the pvc to be in pending state and causing the tekton-results-postgres statefulSet in pending,
     # due to these resources not coming up, the MAS pre-install check in the pipeline times out checking the health of this statefulSet,
-    # causing failure in pipeline. 
+    # causing failure in pipeline.
     # Refer https://github.com/ibm-mas/cli/issues/1511
     logger.debug("Waiting for postgredb-tekton-results-postgres-0 PVC to be ready")
     foundReadyPVC = waitForPVC(dynClient, namespace="openshift-pipelines", pvcName="postgredb-tekton-results-postgres-0")

--- a/src/mas/devops/tekton.py
+++ b/src/mas/devops/tekton.py
@@ -27,7 +27,7 @@ from .ocp import getConsoleURL, waitForCRD, waitForDeployment, waitForPVC, patch
 logger = logging.getLogger(__name__)
 
 
-def installOpenShiftPipelines(dynClient: DynamicClient) -> bool:
+def installOpenShiftPipelines(dynClient: DynamicClient, customStorageClassName: str = None) -> bool:
     """
     Install the OpenShift Pipelines Operator and wait for it to be ready to use
     """
@@ -94,8 +94,8 @@ def installOpenShiftPipelines(dynClient: DynamicClient) -> bool:
     if foundReadyPVC:
         logger.info("OpenShift Pipelines postgres is installed and ready")
     else:
-        patchedPVC = patchPVC(dynClient, namespace="openshift-pipelines", pvcName="postgredb-tekton-results-postgres-0")
-        if patchPVC:
+        patchedPVC = patchPendingPVC(dynClient, namespace="openshift-pipelines", pvcName="postgredb-tekton-results-postgres-0", storageClassName=customStorageClassName)
+        if patchedPVC:
             logger.info("OpenShift Pipelines postgres is installed and ready")
         else:
             logger.error("OpenShift Pipelines postgres PVC is NOT ready")

--- a/src/mas/devops/tekton.py
+++ b/src/mas/devops/tekton.py
@@ -26,7 +26,8 @@ from .ocp import getConsoleURL, waitForCRD, waitForDeployment, waitForPVC, patch
 
 logger = logging.getLogger(__name__)
 
-
+# customStorageClassName is used when no default Storageclass is available on cluster,
+# openshift-pipelines creates PVC which looks for default. customStorageClassName is patched into PVC when default is unavailable.
 def installOpenShiftPipelines(dynClient: DynamicClient, customStorageClassName: str = None) -> bool:
     """
     Install the OpenShift Pipelines Operator and wait for it to be ready to use

--- a/src/mas/devops/tekton.py
+++ b/src/mas/devops/tekton.py
@@ -96,12 +96,15 @@ def installOpenShiftPipelines(dynClient: DynamicClient, customStorageClassName: 
     foundReadyPVC = waitForPVC(dynClient, namespace="openshift-pipelines", pvcName="postgredb-tekton-results-postgres-0")
     if foundReadyPVC:
         logger.info("OpenShift Pipelines postgres is installed and ready")
+        return True
     else:
         patchedPVC = patchPendingPVC(dynClient, namespace="openshift-pipelines", pvcName="postgredb-tekton-results-postgres-0", storageClassName=customStorageClassName)
         if patchedPVC:
             logger.info("OpenShift Pipelines postgres is installed and ready")
+            return True
         else:
             logger.error("OpenShift Pipelines postgres PVC is NOT ready")
+            return False
 
 
 def updateTektonDefinitions(namespace: str, yamlFile: str) -> None:

--- a/src/mas/devops/tekton.py
+++ b/src/mas/devops/tekton.py
@@ -22,7 +22,8 @@ from openshift.dynamic.exceptions import NotFoundError, UnprocessibleEntityError
 
 from jinja2 import Environment, FileSystemLoader
 
-from .ocp import getConsoleURL, waitForCRD, waitForDeployment, waitForPVC, patchPendingPVC, crdExists
+from .ocp import getConsoleURL, waitForCRD, waitForDeployment, crdExists
+from .mas import waitForPVC, patchPendingPVC
 
 logger = logging.getLogger(__name__)
 

--- a/src/mas/devops/tekton.py
+++ b/src/mas/devops/tekton.py
@@ -27,6 +27,7 @@ from .mas import waitForPVC, patchPendingPVC
 
 logger = logging.getLogger(__name__)
 
+
 # customStorageClassName is used when no default Storageclass is available on cluster,
 # openshift-pipelines creates PVC which looks for default. customStorageClassName is patched into PVC when default is unavailable.
 def installOpenShiftPipelines(dynClient: DynamicClient, customStorageClassName: str = None) -> bool:

--- a/test/src/test_data.py
+++ b/test/src/test_data.py
@@ -26,7 +26,7 @@ def test_list_catalogs():
 def test_get_newest_catalog_tag():
     catalogTag = getNewestCatalogTag("amd64")
     # Reminder: update this test when adding a new catalog each month!
-    assert catalogTag == "v9-250403-amd64"
+    assert catalogTag == "v9-250501-amd64"
 
 
 def test_get_newest_catalog_tag_fail():


### PR DESCRIPTION
Add support for May catalog update:

- CPD 5.1 upgrade
- Log messages fixes
- Add missing "wait for PVC" implementation
- Fix issue with OpenShift Pipelines not starting properly when there is no default storage class
