### PR TITLE
[patch] support for additional props in facilities

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,8 @@ setup(
         'kubernetes',              # Apache Software License
         'kubeconfig',              # BSD License
         'jinja2',                  # BSD License
-        'jinja2-base64-filters'    # MIT License
+        'jinja2-base64-filters',   # MIT License
+        'semver'                   # BSD License
     ],
     extras_require={
         'dev': [

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         'kubeconfig',              # BSD License
         'jinja2',                  # BSD License
         'jinja2-base64-filters',   # MIT License
-        'semver'                   # BSD License
+        'semver',                  # BSD License
         'boto3'                    # Apache Software License
     ],
     extras_require={

--- a/src/mas/devops/mas.py
+++ b/src/mas/devops/mas.py
@@ -18,6 +18,7 @@ from kubernetes.dynamic.resource import ResourceInstance
 from openshift.dynamic import DynamicClient
 from openshift.dynamic.exceptions import NotFoundError, ResourceNotFoundError, UnauthorizedError
 from jinja2 import Environment, FileSystemLoader
+import semver
 
 from .ocp import getStorageClasses
 from .olm import getSubscription
@@ -305,3 +306,41 @@ def patchPendingPVC(dynClient: DynamicClient, namespace: str, pvcName: str, stor
     except NotFoundError:
         logger.error(f"PVC {pvcName} does not exist")
         return False
+
+
+def isVersionBefore(_compare_to_version, _current_version):
+    """
+    The method does a modified semantic version comparison,
+    as we want to treat any pre-release as == to the real release
+    but in strict semantic versioning it is <
+    ie. '8.6.0-pre.m1dev86' is converted to '8.6.0'
+    """
+    if _current_version is None:
+        print("Version is not informed. Returning False")
+        return False
+
+    strippedVersion = _current_version.split("-")[0]
+    if '.x' in strippedVersion:
+        strippedVersion = strippedVersion.replace('.x', '.0')
+    current_version = semver.VersionInfo.parse(strippedVersion)
+    compareToVersion = semver.VersionInfo.parse(_compare_to_version)
+    return current_version.compare(compareToVersion) < 0
+
+
+def isVersionAfter(_compare_to_version, _current_version):
+    """
+    The method does a modified semantic version comparison,
+    as we want to treat any pre-release as == to the real release
+    but in strict semantic versioning it is <
+    ie. '8.6.0-pre.m1dev86' is converted to '8.6.0'
+    """
+    if _current_version is None:
+        print("Version is not informed. Returning False")
+        return False
+
+    strippedVersion = _current_version.split("-")[0]
+    if '.x' in strippedVersion:
+        strippedVersion = strippedVersion.replace('.x', '.0')
+    current_version = semver.VersionInfo.parse(strippedVersion)
+    compareToVersion = semver.VersionInfo.parse(_compare_to_version)
+    return current_version.compare(compareToVersion) >= 0

--- a/src/mas/devops/mas.py
+++ b/src/mas/devops/mas.py
@@ -327,7 +327,7 @@ def isVersionBefore(_compare_to_version, _current_version):
     return current_version.compare(compareToVersion) < 0
 
 
-def isVersionAfter(_compare_to_version, _current_version):
+def isVersionEqualOrAfter(_compare_to_version, _current_version):
     """
     The method does a modified semantic version comparison,
     as we want to treat any pre-release as == to the real release

--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -112,6 +112,8 @@ spec:
       value: "{{ db2_action_system }}"
     - name: db2_action_manage
       value: "{{ db2_action_manage }}"
+    - name: db2_action_facilities
+      value: "{{ db2_action_facilities}}"
 
     # Dependencies - Db2u Operator
     # -------------------------------------------------------------------------
@@ -814,6 +816,64 @@ spec:
       value: "{{ mas_aibroker_db_secret_key }}"
     - name: mas_aibroker_db_secret_value
       value: "{{ mas_aibroker_db_secret_value }}"
+{%- endif %}
+
+{%- if mas_app_channel_facilities is defined and mas_app_channel_facilities != "" %}
+
+    # Real Estate anda Facilities Application
+    # -------------------------------------------------------------------------
+    - name: mas_app_channel_facilities
+      value: "{{ mas_app_channel_facilities }}"
+
+{%- if mas_ws_facilities_size is defined and mas_ws_facilities_size != "" %}    
+    - name: mas_ws_facilities_size
+      value: "{{ mas_ws_facilities_size }}"
+{%- endif %}
+{%- if mas_ws_facilities_routes_timeout is defined and mas_ws_facilities_routes_timeout != "" %}    
+    - name: mas_ws_facilities_routes_timeout
+      value: "{{ mas_ws_facilities_routes_timeout }}"
+{%- endif %}
+{%- if mas_ws_facilities_liberty_extension_XML is defined and mas_ws_facilities_liberty_extension_XML != "" %}    
+    - name: mas_ws_facilities_liberty_extension_XML
+      value: "{{ mas_ws_facilities_liberty_extension_XML }}"
+{%- endif %}
+{%- if mas_ws_facilities_vault_secret is defined and mas_ws_facilities_vault_secret != "" %}    
+    - name: mas_ws_facilities_vault_secret
+      value: "{{ mas_ws_facilities_vault_secret }}"
+{%- endif %}
+{%- if mas_ws_facilities_pull_policy is defined and mas_ws_facilities_pull_policy != "" %}    
+    - name: mas_ws_facilities_pull_policy
+      value: "{{ mas_ws_facilities_pull_policy }}"
+{%- endif %}
+    - name: mas_ws_facilities_storage_log_class
+      value: "{{ mas_ws_facilities_storage_log_class }}"
+{%- if mas_ws_facilities_storage_log_mode is defined and mas_ws_facilities_storage_log_mode != "" %}    
+    - name: mas_ws_facilities_storage_log_mode
+      value: "{{ mas_ws_facilities_storage_log_mode }}"
+{%- endif %}
+{%- if mas_ws_facilities_storage_log_size is defined and mas_ws_facilities_storage_log_size != "" %}    
+    - name: mas_ws_facilities_storage_log_size
+      value: "{{ mas_ws_facilities_storage_log_size }}"
+{%- endif %}
+    - name: mas_ws_facilities_storage_userfiles_class
+      value: "{{ mas_ws_facilities_storage_userfiles_class }}"
+{%- if mas_ws_facilities_storage_userfiles_mode is defined and mas_ws_facilities_storage_userfiles_mode != "" %}    
+    - name: mas_ws_facilities_storage_userfiles_mode
+      value: "{{ mas_ws_facilities_storage_userfiles_mode }}"
+{%- endif %}
+{%- if mas_ws_facilities_storage_userfiles_size is defined and mas_ws_facilities_storage_userfiles_size != "" %}    
+    - name: mas_ws_facilities_storage_userfiles_size
+      value: "{{ mas_ws_facilities_storage_userfiles_size }}"
+{%- endif %}
+{%- if mas_ws_facilities_dwfagents is defined and mas_ws_facilities_dwfagents != "" %}
+    - name: mas_ws_facilities_dwfagents
+      value: "{{ mas_ws_facilities_dwfagents }}"
+{%- endif %}
+{%- if mas_ws_facilities_db_maxconnpoolsize is defined and mas_ws_facilities_db_maxconnpoolsize != "" %}    
+    - name: mas_ws_facilities_db_maxconnpoolsize
+      value: "{{ mas_ws_facilities_db_maxconnpoolsize }}"
+{%- endif %}
+
 {%- endif %}
 
   workspaces:

--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -850,28 +850,16 @@ spec:
     - name: mas_ws_facilities_storage_log_mode
       value: "{{ mas_ws_facilities_storage_log_mode }}"
 {%- endif %}
-# {%- if mas_ws_facilities_storage_log_size is defined and mas_ws_facilities_storage_log_size != "" %}    
-#     - name: mas_ws_facilities_storage_log_size
-#       value: "{{ mas_ws_facilities_storage_log_size }}"
-# {%- endif %}
     - name: mas_ws_facilities_storage_userfiles_class
       value: "{{ mas_ws_facilities_storage_userfiles_class }}"
 {%- if mas_ws_facilities_storage_userfiles_mode is defined and mas_ws_facilities_storage_userfiles_mode != "" %}    
     - name: mas_ws_facilities_storage_userfiles_mode
       value: "{{ mas_ws_facilities_storage_userfiles_mode }}"
 {%- endif %}
-# {%- if mas_ws_facilities_storage_userfiles_size is defined and mas_ws_facilities_storage_userfiles_size != "" %}    
-#     - name: mas_ws_facilities_storage_userfiles_size
-#       value: "{{ mas_ws_facilities_storage_userfiles_size }}"
-# {%- endif %}
-{%- if mas_ws_facilities_dwfagents is defined and mas_ws_facilities_dwfagents != "" %}
-    - name: mas_ws_facilities_dwfagents
-      value: "{{ mas_ws_facilities_dwfagents }}"
+{%- if mas_ws_facilities_config_map_name is defined and mas_ws_facilities_config_map_name != "" %}
+    - name: mas_ws_facilities_config_map_name
+      value: "{{ mas_ws_facilities_config_map_name }}"
 {%- endif %}
-# {%- if mas_ws_facilities_db_maxconnpoolsize is defined and mas_ws_facilities_db_maxconnpoolsize != "" %}    
-#     - name: mas_ws_facilities_db_maxconnpoolsize
-#       value: "{{ mas_ws_facilities_db_maxconnpoolsize }}"
-# {%- endif %}
 
     - name: db2_action_facilities
       value: "{{ db2_action_facilities}}"

--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -112,8 +112,6 @@ spec:
       value: "{{ db2_action_system }}"
     - name: db2_action_manage
       value: "{{ db2_action_manage }}"
-    - name: db2_action_facilities
-      value: "{{ db2_action_facilities}}"
 
     # Dependencies - Db2u Operator
     # -------------------------------------------------------------------------
@@ -874,6 +872,9 @@ spec:
 #     - name: mas_ws_facilities_db_maxconnpoolsize
 #       value: "{{ mas_ws_facilities_db_maxconnpoolsize }}"
 # {%- endif %}
+
+    - name: db2_action_facilities
+      value: "{{ db2_action_facilities}}"
 
 {%- endif %}
 

--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -818,6 +818,7 @@ spec:
       value: "{{ mas_aibroker_db_secret_value }}"
 {%- endif %}
 
+# TODO: Fix type for storage sizes and max conn pool size
 {%- if mas_app_channel_facilities is defined and mas_app_channel_facilities != "" %}
 
     # Real Estate anda Facilities Application
@@ -851,28 +852,28 @@ spec:
     - name: mas_ws_facilities_storage_log_mode
       value: "{{ mas_ws_facilities_storage_log_mode }}"
 {%- endif %}
-{%- if mas_ws_facilities_storage_log_size is defined and mas_ws_facilities_storage_log_size != "" %}    
-    - name: mas_ws_facilities_storage_log_size
-      value: "{{ mas_ws_facilities_storage_log_size }}"
-{%- endif %}
+# {%- if mas_ws_facilities_storage_log_size is defined and mas_ws_facilities_storage_log_size != "" %}    
+#     - name: mas_ws_facilities_storage_log_size
+#       value: "{{ mas_ws_facilities_storage_log_size }}"
+# {%- endif %}
     - name: mas_ws_facilities_storage_userfiles_class
       value: "{{ mas_ws_facilities_storage_userfiles_class }}"
 {%- if mas_ws_facilities_storage_userfiles_mode is defined and mas_ws_facilities_storage_userfiles_mode != "" %}    
     - name: mas_ws_facilities_storage_userfiles_mode
       value: "{{ mas_ws_facilities_storage_userfiles_mode }}"
 {%- endif %}
-{%- if mas_ws_facilities_storage_userfiles_size is defined and mas_ws_facilities_storage_userfiles_size != "" %}    
-    - name: mas_ws_facilities_storage_userfiles_size
-      value: "{{ mas_ws_facilities_storage_userfiles_size }}"
-{%- endif %}
+# {%- if mas_ws_facilities_storage_userfiles_size is defined and mas_ws_facilities_storage_userfiles_size != "" %}    
+#     - name: mas_ws_facilities_storage_userfiles_size
+#       value: "{{ mas_ws_facilities_storage_userfiles_size }}"
+# {%- endif %}
 {%- if mas_ws_facilities_dwfagents is defined and mas_ws_facilities_dwfagents != "" %}
     - name: mas_ws_facilities_dwfagents
       value: "{{ mas_ws_facilities_dwfagents }}"
 {%- endif %}
-{%- if mas_ws_facilities_db_maxconnpoolsize is defined and mas_ws_facilities_db_maxconnpoolsize != "" %}    
-    - name: mas_ws_facilities_db_maxconnpoolsize
-      value: "{{ mas_ws_facilities_db_maxconnpoolsize }}"
-{%- endif %}
+# {%- if mas_ws_facilities_db_maxconnpoolsize is defined and mas_ws_facilities_db_maxconnpoolsize != "" %}    
+#     - name: mas_ws_facilities_db_maxconnpoolsize
+#       value: "{{ mas_ws_facilities_db_maxconnpoolsize }}"
+# {%- endif %}
 
 {%- endif %}
 

--- a/test/src/test_mas.py
+++ b/test/src/test_mas.py
@@ -62,3 +62,18 @@ def test_is_airgap_install():
     # The cluster we are using to test with does not have the MAS ICSP or IDMS installed
     assert mas.isAirgapInstall(dynClient) is False
     assert mas.isAirgapInstall(dynClient, checkICSP=False) is False
+    
+def test_version_before():
+    assert mas.isVersionBefore('9.1.0','9.1.x-feature') is False
+    assert mas.isVersionBefore('9.1.0','9.0.0') is True
+    assert mas.isVersionBefore('8.11.1','9.1.0') is False
+    assert mas.isVersionBefore('9.1.0','9.1.x-stable') is False
+
+def test_version_before():
+    assert mas.isVersionAfter('9.1.0','9.2.x-feature') is True
+    assert mas.isVersionAfter('9.1.0','9.0.0') is False
+    assert mas.isVersionAfter('8.11.1','9.1.0') is True
+    assert mas.isVersionAfter('9.2.0','9.1.x-stable') is False
+
+if __name__ == '__main__':
+    test_version_before()

--- a/test/src/test_mas.py
+++ b/test/src/test_mas.py
@@ -62,15 +62,17 @@ def test_is_airgap_install():
     # The cluster we are using to test with does not have the MAS ICSP or IDMS installed
     assert mas.isAirgapInstall(dynClient) is False
     assert mas.isAirgapInstall(dynClient, checkICSP=False) is False
-    
+
+
 def test_version_before():
-    assert mas.isVersionBefore('9.1.0','9.1.x-feature') is False
-    assert mas.isVersionBefore('9.1.0','9.0.0') is True
-    assert mas.isVersionBefore('8.11.1','9.1.0') is False
-    assert mas.isVersionBefore('9.1.0','9.1.x-stable') is False
+    assert mas.isVersionBefore('9.1.0', '9.1.x-feature') is False
+    assert mas.isVersionBefore('9.1.0', '9.0.0') is True
+    assert mas.isVersionBefore('8.11.1', '9.1.0') is False
+    assert mas.isVersionBefore('9.1.0', '9.1.x-stable') is False
+
 
 def test_version_equal_of_after():
-    assert mas.isVersionEqualOrAfter('9.1.0','9.2.x-feature') is True
-    assert mas.isVersionEqualOrAfter('9.1.0','9.0.0') is False
-    assert mas.isVersionEqualOrAfter('8.11.1','9.1.0') is True
-    assert mas.isVersionEqualOrAfter('9.2.0','9.1.x-stable') is False
+    assert mas.isVersionEqualOrAfter('9.1.0', '9.2.x-feature') is True
+    assert mas.isVersionEqualOrAfter('9.1.0', '9.0.0') is False
+    assert mas.isVersionEqualOrAfter('8.11.1', '9.1.0') is True
+    assert mas.isVersionEqualOrAfter('9.2.0', '9.1.x-stable') is False

--- a/test/src/test_mas.py
+++ b/test/src/test_mas.py
@@ -74,6 +74,3 @@ def test_version_equal_of_after():
     assert mas.isVersionEqualOrAfter('9.1.0','9.0.0') is False
     assert mas.isVersionEqualOrAfter('8.11.1','9.1.0') is True
     assert mas.isVersionEqualOrAfter('9.2.0','9.1.x-stable') is False
-
-if __name__ == '__main__':
-    test_version_before()

--- a/test/src/test_mas.py
+++ b/test/src/test_mas.py
@@ -69,11 +69,11 @@ def test_version_before():
     assert mas.isVersionBefore('8.11.1','9.1.0') is False
     assert mas.isVersionBefore('9.1.0','9.1.x-stable') is False
 
-def test_version_before():
-    assert mas.isVersionAfter('9.1.0','9.2.x-feature') is True
-    assert mas.isVersionAfter('9.1.0','9.0.0') is False
-    assert mas.isVersionAfter('8.11.1','9.1.0') is True
-    assert mas.isVersionAfter('9.2.0','9.1.x-stable') is False
+def test_version_equal_of_after():
+    assert mas.isVersionEqualOrAfter('9.1.0','9.2.x-feature') is True
+    assert mas.isVersionEqualOrAfter('9.1.0','9.0.0') is False
+    assert mas.isVersionEqualOrAfter('8.11.1','9.1.0') is True
+    assert mas.isVersionEqualOrAfter('9.2.0','9.1.x-stable') is False
 
 if __name__ == '__main__':
     test_version_before()


### PR DESCRIPTION
**Description**
Some fields in `FacilitiesWorkspace` are not allowed in Tekton pipelines. Therefore, they were transferred to the pipelines through a ConfigMap called `facilities-config`. 

**Evidence**
- `facilities-config` ConfigMap
![image](https://github.com/user-attachments/assets/e3efdbc8-1d0f-4463-9b37-e39807050d87)
- Generation of FacilitiesWorkspace CR
![image](https://github.com/user-attachments/assets/ccd0727a-e1dd-4168-9648-ba90569ac44c)
- `FacilitiesWorkspace` CR
![image](https://github.com/user-attachments/assets/ac111e6d-2d70-4260-bb55-140db7487f42)
