### PR TITLE
[patch] additional params for facilities

### DIFF
--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -850,28 +850,16 @@ spec:
     - name: mas_ws_facilities_storage_log_mode
       value: "{{ mas_ws_facilities_storage_log_mode }}"
 {%- endif %}
-# {%- if mas_ws_facilities_storage_log_size is defined and mas_ws_facilities_storage_log_size != "" %}    
-#     - name: mas_ws_facilities_storage_log_size
-#       value: "{{ mas_ws_facilities_storage_log_size }}"
-# {%- endif %}
     - name: mas_ws_facilities_storage_userfiles_class
       value: "{{ mas_ws_facilities_storage_userfiles_class }}"
 {%- if mas_ws_facilities_storage_userfiles_mode is defined and mas_ws_facilities_storage_userfiles_mode != "" %}    
     - name: mas_ws_facilities_storage_userfiles_mode
       value: "{{ mas_ws_facilities_storage_userfiles_mode }}"
 {%- endif %}
-# {%- if mas_ws_facilities_storage_userfiles_size is defined and mas_ws_facilities_storage_userfiles_size != "" %}    
-#     - name: mas_ws_facilities_storage_userfiles_size
-#       value: "{{ mas_ws_facilities_storage_userfiles_size }}"
-# {%- endif %}
-{%- if mas_ws_facilities_dwfagents is defined and mas_ws_facilities_dwfagents != "" %}
-    - name: mas_ws_facilities_dwfagents
-      value: "{{ mas_ws_facilities_dwfagents }}"
+{%- if mas_ws_facilities_config_map_name is defined and mas_ws_facilities_config_map_name != "" %}
+    - name: mas_ws_facilities_config_map_name
+      value: "{{ mas_ws_facilities_config_map_name }}"
 {%- endif %}
-# {%- if mas_ws_facilities_db_maxconnpoolsize is defined and mas_ws_facilities_db_maxconnpoolsize != "" %}    
-#     - name: mas_ws_facilities_db_maxconnpoolsize
-#       value: "{{ mas_ws_facilities_db_maxconnpoolsize }}"
-# {%- endif %}
 
     - name: db2_action_facilities
       value: "{{ db2_action_facilities}}"

--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -816,7 +816,6 @@ spec:
       value: "{{ mas_aibroker_db_secret_value }}"
 {%- endif %}
 
-# TODO: Fix type for storage sizes and max conn pool size
 {%- if mas_app_channel_facilities is defined and mas_app_channel_facilities != "" %}
 
     # Real Estate anda Facilities Application


### PR DESCRIPTION
**Description**
Some fields in `FacilitiesWorkspace` are not allowed in Tekton pipelines. Therefore, they were transferred to the pipelines through a ConfigMap called `facilities-config`. 

**Evidence**
- `facilities-config` ConfigMap
![image](https://github.com/user-attachments/assets/e3efdbc8-1d0f-4463-9b37-e39807050d87)
- Generation of FacilitiesWorkspace CR
![image](https://github.com/user-attachments/assets/ccd0727a-e1dd-4168-9648-ba90569ac44c)
- `FacilitiesWorkspace` CR
![image](https://github.com/user-attachments/assets/ac111e6d-2d70-4260-bb55-140db7487f42)
