### PR TITLE
[patch] Include mongodb_action in pipelinerun-update.yml.j2

### DIFF
--- a/src/mas/devops/templates/pipelinerun-update.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-update.yml.j2
@@ -49,6 +49,8 @@ spec:
 
     # MongoDb CE update
     # -------------------------------------------------------------------------
+    - name: mongodb_action
+      value: "{{ mongodb_action }}"
     - name: mongodb_namespace
       value: "{{ mongodb_namespace }}"
     - name: mongodb_version


### PR DESCRIPTION
## Description

- Added `mongodb_action` in `pipelinerun-update.yml.j2` which allows us to pass in `none` when we don't have mongodb ce on the cluster

## Related Issues

- https://github.com/ibm-mas/cli/pull/1658

## Testing

Installed MAS `9.0.2` from `v9-240827-amd64` catalog using CLI `11.1.3`
Updated MAS to `9.0.10` with `v9-250403-amd64` catalog using CLI `13.27.0-pre.mongo-upd-arm64`
Observed mas update pipeline - mongodb task ran and updated mongodb from `6.0.12` to `7.0.12`
Removed everything from cluster using mas uninstall
- This test shows that when mongodb ce installed on the cluster the mongodb task in the pipeline will update it as usual

Installed MAS `9.0.2` from `v9-240827-amd64` catalog using CLI `11.1.3`
Removed MongoDB CE from cluster and connected MAS to external MongoDB
Updated MAS to `9.0.10` with `v9-250403-amd64` catalog using CLI `13.27.0-pre.mongo-upd-arm64`
Observed mas update pipeline - mongodb task did not update mongodb because we pass in `none` as mongodb_action
- This test shows that when mongodb ce is not on the cluster the mongodb task does not fail in the pipeline nor will it do anything as expected

<img width="1248" alt="Screenshot 2025-07-02 at 9 53 47 pm" src="https://github.com/user-attachments/assets/6deaf8fa-14ae-4f42-96aa-dced7b6a980f" />
