### PR TITLE
[minor] Add manage online upgrade support

### DIFF
--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -676,6 +676,10 @@ spec:
     - name: mas_app_settings_default_jms
       value: "{{ mas_app_settings_default_jms }}"
   {%- endif %}
+  {%- if mas_appws_upgrade_type is defined and mas_appws_upgrade_type != "" %}
+    - name: mas_appws_upgrade_type
+      value: "{{ mas_appws_upgrade_type }}"
+  {%- endif %}
 {%- endif %}
 {%- if mas_app_channel_monitor is defined and mas_app_channel_monitor != "" %}
 

--- a/src/mas/devops/templates/pipelinerun-upgrade.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-upgrade.yml.j2
@@ -237,6 +237,10 @@ spec:
     - name: mas_app_settings_default_jms
       value: "{{ mas_app_settings_default_jms }}"
   {%- endif %}
+  {%- if mas_appws_upgrade_type is defined and mas_appws_upgrade_type != "" %}
+    - name: mas_appws_upgrade_type
+      value: "{{ mas_appws_upgrade_type }}"
+  {%- endif %}
 {%- endif %}
 
 

--- a/src/mas/devops/templates/pipelinerun-upgrade.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-upgrade.yml.j2
@@ -237,10 +237,6 @@ spec:
     - name: mas_app_settings_default_jms
       value: "{{ mas_app_settings_default_jms }}"
   {%- endif %}
-  {%- if mas_appws_upgrade_type is defined and mas_appws_upgrade_type != "" %}
-    - name: mas_appws_upgrade_type
-      value: "{{ mas_appws_upgrade_type }}"
-  {%- endif %}
 {%- endif %}
 
 


### PR DESCRIPTION
## Description:
Adds new manage upgrade type variable support in install pipeline

## Related Links:
MAXMF-2303

## Dependent PRs:
https://github.com/ibm-mas/cli/pull/1669
https://github.com/ibm-mas/ansible-devops/pull/1829

## Testing:
Tested in a quickburn.
Dashboard (Run #5423): https://dashboard.masdev.wiotp.sl.hursley.ibm.com/tests/htday2