### PR TITLE
[major] Removing not used attribute is-full-manage

### DIFF
--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -616,10 +616,6 @@ spec:
     - name: mas_app_settings_server_bundles_size
       value: "{{ mas_app_settings_server_bundles_size }}"
   {%- endif %}
-  {%- if is_full_manage is defined and is_full_manage != "" %}
-    - name: is_full_manage
-      value: "{{ is_full_manage }}"
-  {%- endif %}
   {%- if mas_app_settings_base_lang is defined and mas_app_settings_base_lang != "" %}
     - name: mas_app_settings_base_lang
       value: "{{ mas_app_settings_base_lang }}"

--- a/src/mas/devops/templates/pipelinerun-upgrade.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-upgrade.yml.j2
@@ -169,10 +169,6 @@ spec:
     - name: mas_app_settings_server_bundles_size
       value: "{{ mas_app_settings_server_bundles_size }}"
   {%- endif %}
-  {%- if is_full_manage is defined and is_full_manage != "" %}
-    - name: is_full_manage
-      value: "{{ is_full_manage }}"
-  {%- endif %}
   {%- if mas_workspace_id is defined and mas_workspace_id != "" %}
     - name: mas_workspace_id
       value: "{{ mas_workspace_id }}"


### PR DESCRIPTION
## Issue
MASCORE-7612

## Description
This env var is not used anymore, we are removing the need of having to set it explicitly;

## Test Results
I ran all sort of possible tests for this playbook including:
* Installed Foundation using both iteractive and non-iteractive mode;
* Instaled full manage using both iteractive and non iteractive mode;
* Upgraded 9.0 to 9.1 using MVI, installing foundation automatically

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
