### PR TITLE
[patch] support for kmodels components in airgap

### DIFF
--- a/src/mas/devops/data/catalogs/v9-250624-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250624-amd64.yaml
@@ -126,3 +126,7 @@ amlen_extras_version: 1.1.3
 # Default Cloud Pak for Data version
 # ------------------------------------------------------------------------------
 cpd_product_version_default: 5.1.3
+
+# Extra Images for kmodels
+# ------------------------------------------------------------------------------
+kmodels_extras_version_default: 1.0.11


### PR DESCRIPTION
This pr is for AIService airgap support requirements 
Kmodels components versions we adding to this repository instead of ansible-devops 

ansible-devops PR: https://github.com/ibm-mas/ansible-devops/pull/1832