### PR TITLE
[patch] add ocp_ingress for dns override

### DIFF
--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -369,6 +369,8 @@ spec:
     # -------------------------------------------------------------------------
     - name: dns_provider
       value: "{{ dns_provider }}"
+    - name: ocp_ingress
+      value: "{{ ocp_ingress }}"
   {%- if cloudflare_apitoken is defined and cloudflare_apitoken != "" %}
 
     # MAS DNS Integrations - Cloudflare Support


### PR DESCRIPTION
## Issue
https://github.com/ibm-mas/ansible-devops/issues/1231

## Description
Add an overwrite variable to OCP ingress domain.

## Test

This test verifies if the PipelineRun resource succesfully loads the new parameter `ocp_ingress`

### Conditions
- `ocp_ingress` not empty
<img width="591" height="634" alt="image" src="https://github.com/user-attachments/assets/1f720f62-ff44-4a30-a959-08baea9112c3" />

- `ocp_ingress` empty
<img width="2376" height="1240" alt="image" src="https://github.com/user-attachments/assets/514e160c-6519-42bb-aea0-2fefa126991e" />
NOTE: In this case it failed because the docker image used doesn't exist (ran locally).

<img width="1818" height="766" alt="image" src="https://github.com/user-attachments/assets/d14eb6f7-afdd-4021-bc5d-332e23025bf7" />

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
