### PR TITLE
[patch] add mas app cfg retries to pipeline run

### DIFF
--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -356,6 +356,10 @@ spec:
     - name: mas_catalog_digest
       value: "{{ mas_catalog_digest }}"
 {%- endif %}
+{%- if mas_app_cfg_retries is defined and mas_app_cfg_retries != "" %}
+    - name: mas_app_cfg_retries
+      value: "{{ mas_app_cfg_retries }}"
+{%- endif%}
 
     # Dependencies - Certificate Manager
     # -------------------------------------------------------------------------


### PR DESCRIPTION
**Changes**
- Add `mas_app_cfg_retries` in the pipeline run to allow increase of retries. It was required for Techzone.