### PR TITLE
[patch] patch namespace if it's created and without kyverno label

### DIFF
--- a/src/mas/devops/ocp.py
+++ b/src/mas/devops/ocp.py
@@ -100,8 +100,17 @@ def createNamespace(dynClient: DynamicClient, namespace: str, kyvernoLabel: str 
     """
     namespaceAPI = dynClient.resources.get(api_version="v1", kind="Namespace")
     try:
-        namespaceAPI.get(name=namespace)
-        logger.debug(f"Namespace {namespace} already exists")
+        ns = namespaceAPI.get(name=namespace)
+        logger.info(f"Namespace {namespace} already exists")
+        if kyvernoLabel is not None:
+            if ns.metadata.labels is None or "ibm.com/kyverno" not in ns.metadata.labels.keys() or ns.metadata.labels["ibm.com/kyverno"] != kyvernoLabel:
+                logger.info(f"Patching namespace with Kyverno Labels ibm.com/kyverno: {kyvernoLabel}")
+                body = {"metadata":{"labels":{"ibm.com/kyverno": kyvernoLabel}}}
+                namespaceAPI.patch(
+                    name=namespace,
+                    body=body,
+                    content_type="application/merge-patch+json"
+                )
     except NotFoundError:
         nsObj = {
             "apiVersion": "v1",

--- a/src/mas/devops/ocp.py
+++ b/src/mas/devops/ocp.py
@@ -105,7 +105,7 @@ def createNamespace(dynClient: DynamicClient, namespace: str, kyvernoLabel: str 
         if kyvernoLabel is not None:
             if ns.metadata.labels is None or "ibm.com/kyverno" not in ns.metadata.labels.keys() or ns.metadata.labels["ibm.com/kyverno"] != kyvernoLabel:
                 logger.info(f"Patching namespace with Kyverno Labels ibm.com/kyverno: {kyvernoLabel}")
-                body = {"metadata":{"labels":{"ibm.com/kyverno": kyvernoLabel}}}
+                body = {"metadata": {"labels": {"ibm.com/kyverno": kyvernoLabel}}}
                 namespaceAPI.patch(
                     name=namespace,
                     body=body,


### PR DESCRIPTION
## Issue
N/A

## Test
A simple test was run to verify if it's going to patch the namespace:
```
from kubernetes import config
from kubernetes.client import api_client
from openshift import dynamic
from mas.devops.ocp import createNamespace

dynClient = dynamic.DynamicClient(
    api_client.ApiClient(configuration=config.load_kube_config())
)

createNamespace(dynClient=dynClient,namespace="mas-fvt91x-core")
createNamespace(dynClient=dynClient,namespace="mas-fvt91x-core",kyvernoLabel="audit")
createNamespace(dynClient=dynClient,namespace="mas-fvt91x-core",kyvernoLabel="audit") #second time to make sure that is not going to throw an error
```
### Results
<img width="604" height="655" alt="image" src="https://github.com/user-attachments/assets/3df606e5-dbc6-412e-8d02-2af936f163d4" />
