### PR TITLE
[patch] Fix operator state condition changes

### DIFF
--- a/src/mas/devops/olm.py
+++ b/src/mas/devops/olm.py
@@ -162,11 +162,9 @@ def applySubscription(dynClient: DynamicClient, namespace: str, packageName: str
         if subscriptionResource.status.state == "AtLatestKnown":
             logger.debug(f"Subscription ready for {name} in {namespace}  ")
             return subscriptionResource
-         
+
         logger.debug(f"Subscription ready not yet for {name} in {namespace} ")
         sleep(30)
-
-   
 
 
 def deleteSubscription(dynClient: DynamicClient, namespace: str, packageName: str) -> None:

--- a/src/mas/devops/olm.py
+++ b/src/mas/devops/olm.py
@@ -156,12 +156,17 @@ def applySubscription(dynClient: DynamicClient, namespace: str, packageName: str
 
     # Wait for Subscription to complete
     logger.debug(f"Waiting for Subscription {name} in {namespace}")
-    subscriptionResource = subscriptionsAPI.get(name=name, namespace=namespace)
-    while subscriptionResource.status.state != "AtLatestKnown":
+    while True:
         subscriptionResource = subscriptionsAPI.get(name=name, namespace=namespace)
+
+        if subscriptionResource.status.state == "AtLatestKnown":
+            logger.debug(f"Subscription ready for {name} in {namespace}  ")
+            return subscriptionResource
+         
+        logger.debug(f"Subscription ready not yet for {name} in {namespace} ")
         sleep(30)
 
-    return subscriptionResource
+   
 
 
 def deleteSubscription(dynClient: DynamicClient, namespace: str, packageName: str) -> None:

--- a/src/mas/devops/olm.py
+++ b/src/mas/devops/olm.py
@@ -164,7 +164,7 @@ def applySubscription(dynClient: DynamicClient, namespace: str, packageName: str
             logger.debug(f"Subscription {name} in {namespace} reached state: {state}")
             return subscriptionResource
 
-        logger.debug(f"Subscription {name} in {namespace} not ready yet (state = {state}), retrying...")        
+        logger.debug(f"Subscription {name} in {namespace} not ready yet (state = {state}), retrying...")
         sleep(30)
 
 

--- a/src/mas/devops/olm.py
+++ b/src/mas/devops/olm.py
@@ -158,12 +158,13 @@ def applySubscription(dynClient: DynamicClient, namespace: str, packageName: str
     logger.debug(f"Waiting for Subscription {name} in {namespace}")
     while True:
         subscriptionResource = subscriptionsAPI.get(name=name, namespace=namespace)
+        state = getattr(subscriptionResource.status, "state", None)
 
-        if subscriptionResource.status.state == "AtLatestKnown":
-            logger.debug(f"Subscription ready for {name} in {namespace}  ")
+        if state == "AtLatestKnown":
+            logger.debug(f"Subscription {name} in {namespace} reached state: {state}")
             return subscriptionResource
 
-        logger.debug(f"Subscription ready not yet for {name} in {namespace} ")
+        logger.debug(f"Subscription {name} in {namespace} not ready yet (state = {state}), retrying...")        
         sleep(30)
 
 


### PR DESCRIPTION
When any operator is installed using CLI / ansible collection, sometimes due to cluster slowness we run into an error like "AttributeError: 'NoneType' object has no attribute 'state'". To ensure state of the attribute we  have added prior condition.