### PR TITLE
[patch] postsync-setup-db2 fails for facilities in gitops 6.6

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-02-28T10:11:51Z",
+  "generated_at": "2025-09-30T07:33:15Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -92,7 +92,7 @@
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 263,
+        "line_number": 290,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/src/mas/devops/db2.py
+++ b/src/mas/devops/db2.py
@@ -237,10 +237,12 @@ def check_reg_cfg(db2u_instance_cr: dict, core_v1_api: client.CoreV1Api, mas_ins
     for cr_k, cr_v in reg_cfg_cr.items():
         # regex ignores any trailing [O] (which indicates the param has been overridden I think)
         matches = re.search(fr"{cr_k}=(.*?)(?:\s\[O\])?$", reg_cfg_pod, re.MULTILINE)
-        if matches is None:
+        if matches is None and cr_v != '':
             failures.append(f"[registry cfg] {cr_k} not found in output of db2set command")
             continue
-        pod_v = matches.group(1)
+        pod_v = ''
+        if cr_v != '':
+            pod_v = matches.group(1)
 
         if not cr_pod_v_matches(cr_k, cr_v, pod_v):
             failures.append(f"[registry cfg] {cr_k}: {cr_v} != {pod_v}")

--- a/test/src/test_db2.py
+++ b/test/src/test_db2.py
@@ -274,6 +274,32 @@ def test_check_reg_cfg(mocker):
     ])
 
 
+def test_check_reg_cfg_with_empty_value_in_cr(mocker):
+
+    mock_db2_pod_exec_db2set = mocker.patch("mas.devops.db2.db2_pod_exec_db2set")
+    mock_db2_pod_exec_db2set.return_value = '''
+    DB2AUTH=OSAUTHDB,ALLOW_LOCAL_FALLBACK,PLUGIN_AUTO_RELOAD
+    DB2_FMP_COMM_HEAPSZ=65536 [O]
+  '''
+
+    db2_instance_cr = dict(
+        spec=dict(
+            environment=dict(
+                instance=dict(
+                    registry=dict(
+                        DB2AUTH='WRONG',
+                        NOTFOUNDINOUTPUT="",
+                    )
+                )
+            )
+        )
+    )
+
+    assert set(db2.check_reg_cfg(db2_instance_cr, None, None, None)) == set([
+        "[registry cfg] DB2AUTH: WRONG != OSAUTHDB,ALLOW_LOCAL_FALLBACK,PLUGIN_AUTO_RELOAD"
+    ])
+
+
 @pytest.mark.parametrize("test_case_name, expected_failures", [
     # This test case simulates what will happen when we run the validate_db2_config using the IoT Db2uInstance CR
     # as we have it today in fvtsaas after the CR settings have been applied successfully to DB2


### PR DESCRIPTION
Issue: [MASCORE-9807](https://jsw.ibm.com/browse/MASCORE-9807)

## Problem
If config has empty value in CR, db2set doesn't return that config and hence we are getting config not available in db2set output. So for such configs, we should not fail