### PR TITLE
[patch] Add to AI Service support for watsonX CA cert

### DIFF
--- a/src/mas/devops/templates/pipelinerun-aiservice-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-aiservice-install.yml.j2
@@ -245,7 +245,7 @@ spec:
       value: "{{ aiservice_watsonxai_project_id }}"
     - name: aiservice_watsonx_action
       value: "{{ aiservice_watsonx_action }}"
-      - name: aiservice_watsonxai_ca_crt
+    - name: aiservice_watsonxai_ca_crt
       value: "{{ aiservice_watsonxai_ca_crt }}"
 
   workspaces:

--- a/src/mas/devops/templates/pipelinerun-aiservice-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-aiservice-install.yml.j2
@@ -245,6 +245,8 @@ spec:
       value: "{{ aiservice_watsonxai_project_id }}"
     - name: aiservice_watsonx_action
       value: "{{ aiservice_watsonx_action }}"
+      - name: aiservice_watsonxai_ca_crt
+      value: "{{ aiservice_watsonxai_ca_crt }}"
 
   workspaces:
     # The generated configuration files


### PR DESCRIPTION
## Issue
https://jsw.ibm.com/browse/MASAIB-1432

## Description
Add support to use WastonX AI CA certificate

## Test Results
Deployment pass in both cases - with WatsonX AI CA, without WatsonX AICA