### PR TITLE
[minor] Support AI Service upgrade functionality

### DIFF
--- a/src/mas/devops/mas.py
+++ b/src/mas/devops/mas.py
@@ -178,6 +178,24 @@ def verifyMasInstance(dynClient: DynamicClient, instanceId: str) -> bool:
         logger.error(f"Error: Unable to verify MAS instance due to failed authorization: {e}")
         return False
 
+def verifyAiServiceInstance(dynClient: DynamicClient, instanceId: str) -> bool:
+    """
+    Validate that the chosen AI Service instance exists
+    """
+    try:
+        aiserviceAPI = dynClient.resources.get(api_version="aiservice.ibm.com/v1", kind="AIServiceApp")
+        aiserviceAPI.get(name=instanceId, namespace=f"aiservice-{instanceId}")
+        return True
+    except NotFoundError:
+        print("NOT FOUND")
+        return False
+    except ResourceNotFoundError:
+        # The AIServiceApp CRD has not even been installed in the cluster
+        print("RESOURCE NOT FOUND")
+        return False
+    except UnauthorizedError as e:
+        logger.error(f"Error: Unable to verify AI Service instance due to failed authorization: {e}")
+        return False
 
 def verifyAppInstance(dynClient: DynamicClient, instanceId: str, applicationId: str) -> bool:
     """
@@ -224,6 +242,15 @@ def getMasChannel(dynClient: DynamicClient, instanceId: str) -> str:
     else:
         return masSubscription.spec.channel
 
+def getAiserviceChannel(dynClient: DynamicClient, instanceId: str) -> str:
+    """
+    Get the AI Service channel from the subscription
+    """
+    aiserviceSubscription = getSubscription(dynClient, f"aiservice-{instanceId}", "ibm-aiservice")
+    if aiserviceSubscription is None:
+        return None
+    else:
+        return aiserviceSubscription.spec.channel
 
 def updateIBMEntitlementKey(dynClient: DynamicClient, namespace: str, icrUsername: str, icrPassword: str, artifactoryUsername: str = None, artifactoryPassword: str = None, secretName: str = "ibm-entitlement") -> ResourceInstance:
     if secretName is None:

--- a/src/mas/devops/mas.py
+++ b/src/mas/devops/mas.py
@@ -178,6 +178,7 @@ def verifyMasInstance(dynClient: DynamicClient, instanceId: str) -> bool:
         logger.error(f"Error: Unable to verify MAS instance due to failed authorization: {e}")
         return False
 
+
 def verifyAiServiceInstance(dynClient: DynamicClient, instanceId: str) -> bool:
     """
     Validate that the chosen AI Service instance exists
@@ -196,6 +197,7 @@ def verifyAiServiceInstance(dynClient: DynamicClient, instanceId: str) -> bool:
     except UnauthorizedError as e:
         logger.error(f"Error: Unable to verify AI Service instance due to failed authorization: {e}")
         return False
+
 
 def verifyAppInstance(dynClient: DynamicClient, instanceId: str, applicationId: str) -> bool:
     """
@@ -242,6 +244,7 @@ def getMasChannel(dynClient: DynamicClient, instanceId: str) -> str:
     else:
         return masSubscription.spec.channel
 
+
 def getAiserviceChannel(dynClient: DynamicClient, instanceId: str) -> str:
     """
     Get the AI Service channel from the subscription
@@ -251,6 +254,7 @@ def getAiserviceChannel(dynClient: DynamicClient, instanceId: str) -> str:
         return None
     else:
         return aiserviceSubscription.spec.channel
+
 
 def updateIBMEntitlementKey(dynClient: DynamicClient, namespace: str, icrUsername: str, icrPassword: str, artifactoryUsername: str = None, artifactoryPassword: str = None, secretName: str = "ibm-entitlement") -> ResourceInstance:
     if secretName is None:

--- a/src/mas/devops/tekton.py
+++ b/src/mas/devops/tekton.py
@@ -465,10 +465,10 @@ def launchAiServiceInstallPipeline(dynClient: DynamicClient, params: dict) -> st
 
 
 def launchAiServiceUpgradePipeline(dynClient: DynamicClient,
-                          aiserviceInstanceId: str,
-                          skipPreCheck: bool = False,
-                          masChannel: str = "",
-                          params: dict = {}) -> str:
+                                   aiserviceInstanceId: str,
+                                   skipPreCheck: bool = False,
+                                   masChannel: str = "",
+                                   params: dict = {}) -> str:
     """
     Create a PipelineRun to upgrade the chosen AI Service instance
     """

--- a/src/mas/devops/tekton.py
+++ b/src/mas/devops/tekton.py
@@ -462,3 +462,35 @@ def launchAiServiceInstallPipeline(dynClient: DynamicClient, params: dict) -> st
 
     pipelineURL = f"{getConsoleURL(dynClient)}/k8s/ns/aiservice-{instanceId}-pipelines/tekton.dev~v1beta1~PipelineRun/{instanceId}-install-{timestamp}"
     return pipelineURL
+
+
+def launchAiServiceUpgradePipeline(dynClient: DynamicClient,
+                          aiserviceInstanceId: str,
+                          skipPreCheck: bool = False,
+                          masChannel: str = "",
+                          params: dict = {}) -> str:
+    """
+    Create a PipelineRun to upgrade the chosen AI Service instance
+    """
+    pipelineRunsAPI = dynClient.resources.get(api_version="tekton.dev/v1beta1", kind="PipelineRun")
+    namespace = f"aiservice-{aiserviceInstanceId}-pipelines"
+    timestamp = datetime.now().strftime("%y%m%d-%H%M")
+    # Create the PipelineRun
+    templateDir = path.join(path.abspath(path.dirname(__file__)), "templates")
+    env = Environment(
+        loader=FileSystemLoader(searchpath=templateDir)
+    )
+    template = env.get_template("pipelinerun-upgrade.yml.j2")
+    renderedTemplate = template.render(
+        timestamp=timestamp,
+        mas_instance_id=aiserviceInstanceId,
+        skip_pre_check=skipPreCheck,
+        mas_channel=masChannel,
+        **params
+    )
+    logger.debug(renderedTemplate)
+    pipelineRun = yaml.safe_load(renderedTemplate)
+    pipelineRunsAPI.apply(body=pipelineRun, namespace=namespace)
+
+    pipelineURL = f"{getConsoleURL(dynClient)}/k8s/ns/aiservice-{aiserviceInstanceId}-pipelines/tekton.dev~v1beta1~PipelineRun/{aiserviceInstanceId}-upgrade-{timestamp}"
+    return pipelineURL

--- a/src/mas/devops/tekton.py
+++ b/src/mas/devops/tekton.py
@@ -467,7 +467,7 @@ def launchAiServiceInstallPipeline(dynClient: DynamicClient, params: dict) -> st
 def launchAiServiceUpgradePipeline(dynClient: DynamicClient,
                                    aiserviceInstanceId: str,
                                    skipPreCheck: bool = False,
-                                   masChannel: str = "",
+                                   aiserviceChannel: str = "",
                                    params: dict = {}) -> str:
     """
     Create a PipelineRun to upgrade the chosen AI Service instance
@@ -480,12 +480,12 @@ def launchAiServiceUpgradePipeline(dynClient: DynamicClient,
     env = Environment(
         loader=FileSystemLoader(searchpath=templateDir)
     )
-    template = env.get_template("pipelinerun-upgrade.yml.j2")
+    template = env.get_template("pipelinerun-aiservice-upgrade.yml.j2")
     renderedTemplate = template.render(
         timestamp=timestamp,
-        mas_instance_id=aiserviceInstanceId,
+        aiservice_instance_id=aiserviceInstanceId,
         skip_pre_check=skipPreCheck,
-        mas_channel=masChannel,
+        aiservice_channel=aiserviceChannel,
         **params
     )
     logger.debug(renderedTemplate)

--- a/src/mas/devops/templates/pipelinerun-aiservice-upgrade.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-aiservice-upgrade.yml.j2
@@ -1,0 +1,56 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "{{ aiservice_instance_id }}-upgrade-{{ timestamp }}"
+  labels:
+    tekton.dev/pipeline: aiservice-upgrade
+spec:
+  pipelineRef:
+    name: aiservice-upgrade
+
+  serviceAccountName: "{{ service_account_name | default('pipeline', True) }}"
+  timeouts:
+    pipeline: "0"
+
+  params:
+    # Target AI Service Instance
+    # -------------------------------------------------------------------------
+    - name: aiservice_instance_id
+      value: "{{ aiservice_instance_id }}"
+    - name: aiservice_channel
+      value: "{{ aiservice_channel }}"
+
+    # IBM Entitlement Key
+    # -------------------------------------------------------------------------
+    - name: ibm_entitlement_key
+      value: "{{ ibm_entitlement_key }}"
+
+{%- if skip_pre_check is defined and skip_pre_check != "" %}
+    # Skip pre-check
+    # -------------------------------------------------------------------------
+    - name: skip_pre_check
+      value: "{{ skip_pre_check }}"
+{%- endif %}
+{%- if artifactory_username is defined and artifactory_username != "" %}
+
+    # Enable development catalogs
+    # -------------------------------------------------------------------------
+    - name: artifactory_username
+      value: "{{ artifactory_username }}"
+    - name: artifactory_token
+      value: "{{ artifactory_token }}"
+{%- endif %}
+
+  workspaces:
+    # The generated configuration files
+    # -------------------------------------------------------------------------
+    - name: shared-configs
+      persistentVolumeClaim:
+        claimName: config-pvc
+
+    # PodTemplates configurations
+    # -------------------------------------------------------------------------
+    - name: shared-pod-templates
+      secret:
+        secretName: pipeline-pod-templates


### PR DESCRIPTION
Introduce new upgrade pipeline - **aiservice-upgrade**
Add some utility functions for Ai Service Instance and Channels.

Related Issues:
https://github.com/ibm-mas/cli/pull/1799
https://github.com/ibm-mas/ansible-devops/pull/1942

Tests:
[ibmmas/cli:15.6.2-pre.aisvc-upgrade]mascli$` mas aiservice-upgrade --dev-mode

IBM Maximo Application Suite Admin CLI v15.6.2-pre.aisvc-upgrade
Powered by https://github.com/ibm-mas/ansible-devops/ and https://tekton.dev/


1) Set Target OpenShift Cluster
Already connected to OCP Cluster:
 https://console-openshift-console.apps.o1-945291.cp.fyre.ibm.com/

Proceed with this cluster? [y/n] y

2) AI Service Instance Selection
Select a AI Service instance to upgrade from the list below:
- apmdevops v9.1.6

Enter AI Service instance ID: apmdevops
Custom channel 9.2.x

3) Review Settings
AI Service Instance ID ..................... apmdevops
Current AI Service Channel ............. 9.1.x
Next AI Service Channel ................ 9.2.x
Skip Pre-Upgrade Checks ......... False

Proceed with these settings? [y/n] y

4) Launch Upgrade
✅️ OpenShift Pipelines Operator is installed and ready to use
✅️ Namespace is ready (aiservice-apmdevops-pipelines)
✅️ Latest Tekton definitions are installed (v15.6.2-pre.aisvc-upgrade)
✅️ PipelineRun for apmdevops upgrade submitted

View progress:
  https://console-openshift-console.apps.o1-945291.cp.fyre.ibm.com/k8s/ns/aiservice-apmdevops-pipelines/tekton.dev~v1beta1~PipelineRun/apmdevops-upgrade-250930-1753

[ibmmas/cli:15.6.2-pre.aisvc-upgrade]mascli$


<img width="2874" height="1794" alt="Screenshot 2025-09-30 at 11 36 18 PM" src="https://github.com/user-attachments/assets/b68ccace-9178-477a-9a60-2f14795033ce" />
<img width="2890" height="988" alt="Screenshot 2025-09-30 at 11 36 38 PM" src="https://github.com/user-attachments/assets/177b64a5-f8ce-4e9b-b805-a4ee4c825e55" />
