### PR TITLE
[minor] Add Longhorn storage provider support

### DIFF
--- a/src/mas/devops/mas.py
+++ b/src/mas/devops/mas.py
@@ -70,6 +70,12 @@ def getDefaultStorageClasses(dynClient: DynamicClient) -> dict:
             result.rwo = "ocs-external-storagecluster-ceph-rbd"
             result.rwx = "ocs-external-storagecluster-cephfs"
             break
+        elif storageClass.metadata.name == "longhorn":
+            result.provider = "longhorn"
+            result.providerName = "Longhorn"
+            result.rwo = "longhorn"
+            result.rwx = "longhorn"
+            break
         elif storageClass.metadata.name == "nfs-client":
             result.provider = "nfs"
             result.providerName = "NFS Client"


### PR DESCRIPTION
This update adds Longhorn (https://longhorn.io/) as a recognized storage provider that will be auto-detected when users have not explicitly defined a storage class to use (when the default `longhorn` storageclass exists).
