### PR TITLE
[minor] Add Slack utilities

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -35,6 +35,7 @@ jobs:
         env:
           OCP_TOKEN: ${{ secrets.OCP_TOKEN }}
           OCP_SERVER: ${{ secrets.OCP_SERVER }}
+          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
         run: |
           kubectl config set-cluster my-cluster --server=$OCP_SERVER
           kubectl config set-credentials my-user --token=$OCP_TOKEN

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,15 +2,15 @@ default_language_version:
     python: python
 repos:
   - repo: https://github.com/hhatto/autopep8
-    rev: v2.3.1
+    rev: v2.3.2
     hooks:
     -   id: autopep8
   - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.1
+    rev: 7.3.0
     hooks:
       - id: flake8
   - repo: https://github.com/ibm/detect-secrets
-    rev: 0.13.1+ibm.62.dss
+    rev: 0.13.1+ibm.64.dss
     hooks:
       - id: detect-secrets
         args: [--baseline, .secrets.baseline, --use-all-plugins, --fail-on-unaudited]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-09-30T07:33:15Z",
+  "generated_at": "2025-10-25T11:05:55Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -77,6 +77,24 @@
     }
   ],
   "results": {
+    "bin/mas-devops-notify-slack": [
+      {
+        "hashed_secret": "053f5ed451647be0bbb6f67b80d6726808cad97e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 27,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "765d3d433049b64dc1292181b213854947cfc6e5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 35,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "src/mas/devops/templates/ibm-entitlement-dockerconfig.json.j2": [
       {
         "hashed_secret": "d2e2ab0f407e4ee3cf2ab87d61c31b25a74085e5",
@@ -156,7 +174,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.62.dss",
+  "version": "0.13.1+ibm.64.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-10-25T11:33:24Z",
+  "generated_at": "2025-10-27T10:20:07Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -82,15 +82,15 @@
         "hashed_secret": "053f5ed451647be0bbb6f67b80d6726808cad97e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 28,
+        "line_number": 35,
         "type": "Secret Keyword",
         "verified_result": null
       },
       {
-        "hashed_secret": "765d3d433049b64dc1292181b213854947cfc6e5",
+        "hashed_secret": "4f75456d6c1887d41ed176f7ad3e2cfff3fdfd91",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 37,
+        "line_number": 44,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-10-25T11:05:55Z",
+  "generated_at": "2025-10-25T11:33:24Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -82,7 +82,7 @@
         "hashed_secret": "053f5ed451647be0bbb6f67b80d6726808cad97e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 27,
+        "line_number": 28,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -90,7 +90,7 @@
         "hashed_secret": "765d3d433049b64dc1292181b213854947cfc6e5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 35,
+        "line_number": 37,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/bin/mas-devops-notify-slack
+++ b/bin/mas-devops-notify-slack
@@ -19,7 +19,8 @@ from mas.devops.slack import SlackUtil
 def notifyProvisionFyre(rc: int) -> bool:
     name = os.getenv("CLUSTER_NAME", None)
     if name is None:
-        print("CLUSTER_NAME env var must all be set")
+        print("CLUSTER_NAME env var must be set")
+        sys.exit(1)
 
     if rc == 0:
         url = os.getenv("OCP_CLUSTER_URL", None)
@@ -28,15 +29,17 @@ def notifyProvisionFyre(rc: int) -> bool:
 
         if url is None or username is None or password is None:
             print("OCP_CLUSTER_URL, OCP_USERNAME, and OCP_PASSWORD env vars must all be set")
+            sys.exit(1)
 
         message = [
-            SlackUtil.buildSection(f":glyph-ok: *Your IBM DevIT Fyre OCP cluster ({name}) is ready to use*"),
+            SlackUtil.buildSection(f":glyph-ok: *Your IBM DevIT Fyre OCP cluster ({name}) is ready*"),
             SlackUtil.buildSection(f"{url}"),
             SlackUtil.buildSection(f"- Username: `{username}`\n - Password: `{password}`")
         ]
     else:
         message = [
             SlackUtil.buildSection(f":glyph-fail: *Your IBM DevIT Fyre OCP cluster ({name}) failed to deploy*"),
+            SlackUtil.buildSection("https://beta.fyre.ibm.com/development/vms")
         ]
 
     response = SlackUtil.postMessageBlocks("#bot-test", message)
@@ -45,6 +48,7 @@ def notifyProvisionFyre(rc: int) -> bool:
 
 
 if __name__ == "__main__":
+    # If SLACK_TOKEN env var is not set then silently exit taking no action
     SLACK_TOKEN = os.getenv("SLACK_TOKEN", None)
     if SLACK_TOKEN is None:
         sys.exit(0)

--- a/bin/mas-devops-notify-slack
+++ b/bin/mas-devops-notify-slack
@@ -22,6 +22,13 @@ def notifyProvisionFyre(channel: str, rc: int) -> bool:
         print("CLUSTER_NAME env var must be set")
         sys.exit(1)
 
+    # Support optional metadata from standard IBM CD Toolchains environment variables
+    toolchainLink = ""
+    toolchainUrl = os.getenv("TOOLCHAIN_PIPELINERUN_URL", None)
+    toolchainTriggerName = os.getenv("TOOLCHAIN_TRIGGER_NAME", None)
+    if toolchainUrl is not None and toolchainTriggerName is not None:
+        toolchainLink = f" | <{toolchainUrl}|Pipeline Run>"
+
     if rc == 0:
         url = os.getenv("OCP_CLUSTER_URL", None)
         username = os.getenv("OCP_USERNAME", None)
@@ -32,18 +39,18 @@ def notifyProvisionFyre(channel: str, rc: int) -> bool:
             sys.exit(1)
 
         message = [
-            SlackUtil.buildSection(f":glyph-ok: *Your IBM DevIT Fyre OCP cluster ({name}) is ready*"),
+            SlackUtil.buildHeader(f":glyph-ok: Your IBM DevIT Fyre OCP cluster ({name}) is ready"),
             SlackUtil.buildSection(f"{url}"),
-            SlackUtil.buildSection(f"- Username: `{username}`\n - Password: `{password}`")
+            SlackUtil.buildSection(f"- Username: `{username}`\n - Password: `{password}`"),
+            SlackUtil.buildSection(f"<https://beta.fyre.ibm.com/development/vms|Fyre Dashboard>{toolchainLink}")
         ]
     else:
         message = [
-            SlackUtil.buildSection(f":glyph-fail: *Your IBM DevIT Fyre OCP cluster ({name}) failed to deploy*"),
-            SlackUtil.buildSection("https://beta.fyre.ibm.com/development/vms")
+            SlackUtil.buildHeader(f":glyph-fail: Your IBM DevIT Fyre OCP cluster ({name}) failed to deploy"),
+            SlackUtil.buildSection(f"<https://beta.fyre.ibm.com/development/vms|Fyre Dashboard>{toolchainLink}")
         ]
 
     response = SlackUtil.postMessageBlocks(channel, message)
-
     return response.data.get("ok", False)
 
 

--- a/bin/mas-devops-notify-slack
+++ b/bin/mas-devops-notify-slack
@@ -16,7 +16,7 @@ import sys
 from mas.devops.slack import SlackUtil
 
 
-def notifyProvisionFyre(rc: int) -> bool:
+def notifyProvisionFyre(channel: str, rc: int) -> bool:
     name = os.getenv("CLUSTER_NAME", None)
     if name is None:
         print("CLUSTER_NAME env var must be set")
@@ -42,15 +42,16 @@ def notifyProvisionFyre(rc: int) -> bool:
             SlackUtil.buildSection("https://beta.fyre.ibm.com/development/vms")
         ]
 
-    response = SlackUtil.postMessageBlocks("#bot-test", message)
+    response = SlackUtil.postMessageBlocks(channel, message)
 
     return response.data.get("ok", False)
 
 
 if __name__ == "__main__":
-    # If SLACK_TOKEN env var is not set then silently exit taking no action
+    # If SLACK_TOKEN or SLACK_CHANNEL env vars are not set then silently exit taking no action
     SLACK_TOKEN = os.getenv("SLACK_TOKEN", None)
-    if SLACK_TOKEN is None:
+    SLACK_CHANNEL = os.getenv("SLACK_CHANNEL", None)
+    if SLACK_TOKEN is None or SLACK_CHANNEL is None:
         sys.exit(0)
 
     # Initialize the properties we need
@@ -62,4 +63,4 @@ if __name__ == "__main__":
     args, unknown = parser.parse_known_args()
 
     if args.action == "ocp-provision-fyre":
-        notifyProvisionFyre(args.rc)
+        notifyProvisionFyre(SLACK_CHANNEL, args.rc)

--- a/bin/mas-devops-notify-slack
+++ b/bin/mas-devops-notify-slack
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+# *****************************************************************************
+# Copyright (c) 2025 IBM Corporation and other Contributors.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# *****************************************************************************
+
+import argparse
+import os
+import sys
+from mas.devops.slack import SlackUtil
+
+
+def notifyProvisionFyre(rc: int) -> bool:
+    name = os.getenv("CLUSTER_NAME", None)
+    if name is None:
+        print("CLUSTER_NAME env var must all be set")
+
+    if rc == 0:
+        url = os.getenv("OCP_CLUSTER_URL", None)
+        username = os.getenv("OCP_USERNAME", None)
+        password = os.getenv("OCP_PASSWORD", None)
+
+        if url is None or username is None or password is None:
+            print("OCP_CLUSTER_URL, OCP_USERNAME, and OCP_PASSWORD env vars must all be set")
+
+        message = [
+            SlackUtil.buildSection(f":glyph-ok: *Your IBM DevIT Fyre OCP cluster ({name}) is ready to use*"),
+            SlackUtil.buildSection(f"{url}"),
+            SlackUtil.buildSection(f"- Username: `{username}`\n - Password: `{password}`")
+        ]
+    else:
+        message = [
+            SlackUtil.buildSection(f":glyph-fail: *Your IBM DevIT Fyre OCP cluster ({name}) failed to deploy*"),
+        ]
+
+    response = SlackUtil.postMessageBlocks("#bot-test", message)
+
+    return response.data.get("ok", False)
+
+
+if __name__ == "__main__":
+    SLACK_TOKEN = os.getenv("SLACK_TOKEN", None)
+    if SLACK_TOKEN is None:
+        sys.exit(0)
+
+    # Initialize the properties we need
+    parser = argparse.ArgumentParser()
+
+    # Primary Options
+    parser.add_argument("--action", required=True)
+    parser.add_argument("--rc", required=True, type=int)
+    args, unknown = parser.parse_known_args()
+
+    if args.action == "ocp-provision-fyre":
+        notifyProvisionFyre(args.rc)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # *****************************************************************************
-# Copyright (c) 2024 IBM Corporation and other Contributors.
+# Copyright (c) 2024, 2025 IBM Corporation and other Contributors.
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -62,7 +62,8 @@ setup(
         'jinja2',                  # BSD License
         'jinja2-base64-filters',   # MIT License
         'semver',                  # BSD License
-        'boto3'                    # Apache Software License
+        'boto3',                   # Apache Software License
+        'slack_sdk',               # MIT License
     ],
     extras_require={
         'dev': [
@@ -90,6 +91,7 @@ setup(
     scripts=[
         'bin/mas-devops-db2-validate-config',
         'bin/mas-devops-create-initial-users-for-saas',
-        'bin/mas-devops-saas-job-cleaner'
+        'bin/mas-devops-saas-job-cleaner',
+        'bin/mas-devops-notify-slack',
     ]
 )

--- a/src/mas/devops/slack.py
+++ b/src/mas/devops/slack.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+
+# *****************************************************************************
+# Copyright (c) 2025 IBM Corporation and other Contributors.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# *****************************************************************************
+
+import os
+from slack_sdk import WebClient
+from slack_sdk.web.slack_response import SlackResponse
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class SlackUtilMeta(type):
+    def __init__(cls, *args, **kwargs):
+        # Exposed by the client() property method
+        cls._client = None
+
+    @property
+    def client(cls) -> WebClient:
+        if cls._client is not None:
+            return cls._client
+        else:
+            SLACK_TOKEN = os.getenv("SLACK_TOKEN")
+            if SLACK_TOKEN is None:
+                logger.warning("SLACK_TOKEN is not set")
+                raise Exception("SLACK_TOKEN is not set")
+            else:
+                cls._client = WebClient(token=SLACK_TOKEN)
+                return cls._client
+
+    # Post message to Slack
+    # -----------------------------------------------------------------------------
+    def postMessageBlocks(cls, channelName: str, messageBlocks: list, threadId: str = None) -> SlackResponse:
+        if threadId is None:
+            logger.debug(f"Posting {len(messageBlocks)} block message to {channelName} in Slack")
+            response = cls.client.chat_postMessage(
+                channel=channelName,
+                blocks=messageBlocks,
+                text="Summary text unavailable",
+                mrkdwn=True,
+                parse="none",
+                unfurl_links=False,
+                unfurl_media=False,
+                link_names=True,
+                as_user=True,
+            )
+        else:
+            logger.debug(f"Posting {len(messageBlocks)} block message to {channelName} on thread {threadId} in Slack")
+            response = cls.client.chat_postMessage(
+                channel=channelName,
+                thread_ts=threadId,
+                blocks=messageBlocks,
+                text="Summary text unavailable",
+                mrkdwn=True,
+                parse="none",
+                unfurl_links=False,
+                unfurl_media=False,
+                link_names=True,
+                as_user=True,
+            )
+
+        if not response["ok"]:
+            logger.warning(response.data)
+            logger.warning("Failed to call Slack API")
+        return response
+
+    def postMessageText(cls, channelName, message, attachments=None, threadId=None):
+        if threadId is None:
+            logger.debug(f"Posting message to {channelName} in Slack")
+            response = cls.client.chat_postMessage(
+                channel=channelName,
+                text=message,
+                attachments=attachments,
+                mrkdwn=True,
+                parse="none",
+                unfurl_links=False,
+                unfurl_media=False,
+                link_names=True,
+                as_user=True,
+            )
+        else:
+            logger.debug(f"Posting message to {channelName} on thread {threadId} in Slack")
+            response = cls.client.chat_postMessage(
+                channel=channelName,
+                thread_ts=threadId,
+                text=message,
+                attachments=attachments,
+                mrkdwn=True,
+                parse="none",
+                unfurl_links=False,
+                unfurl_media=False,
+                link_names=True,
+                as_user=True,
+            )
+
+        if not response["ok"]:
+            logger.warning(response.data)
+            logger.warning("Failed to call Slack API")
+        return response
+
+    def createMessagePermalink(
+        cls, slackResponse: SlackResponse = None, channelId: str = None, messageTimestamp: str = None, domain: str = "ibm-mas"
+    ) -> str:
+        if slackResponse is not None:
+            channelId = slackResponse["channel"]
+            messageTimestamp = slackResponse["ts"]
+        elif channelId is None or messageTimestamp is None:
+            raise Exception("Either channelId and messageTimestamp, or slackReponse params must be provided")
+
+        return f"https://{domain}.slack.com/archives/{channelId}/p{messageTimestamp.replace('.', '')}"
+
+    # Edit message in Slack
+    # -----------------------------------------------------------------------------
+    def updateMessageBlocks(cls, channelName: str, threadId: str, messageBlocks: list) -> SlackResponse:
+        logger.debug(f"Updating {len(messageBlocks)} block message in {channelName} on thread {threadId} in Slack")
+        response = cls.client.chat_update(
+            channel=channelName,
+            ts=threadId,
+            blocks=messageBlocks,
+            mrkdwn=True,
+            parse="none",
+            unfurl_links=False,
+            unfurl_media=False,
+            link_names=True,
+            as_user=True,
+        )
+
+        if not response["ok"]:
+            logger.warning(response.data)
+            logger.warning("Failed to call Slack API")
+        return response
+
+    # Build header block for Slack message
+    # -----------------------------------------------------------------------------
+    def buildHeader(cls, title: str) -> dict:
+        return {"type": "header", "text": {"type": "plain_text", "text": title, "emoji": True}}
+
+    # Build section block for Slack message
+    # -----------------------------------------------------------------------------
+    def buildSection(cls, text: str) -> dict:
+        return {"type": "section", "text": {"type": "mrkdwn", "text": text}}
+
+    # Build context block for Slack message
+    # -----------------------------------------------------------------------------
+    def buildContext(cls, texts: list) -> dict:
+        elements = []
+        for text in texts:
+            elements.append({"type": "mrkdwn", "text": text})
+
+        return {"type": "context", "elements": elements}
+
+    # Build divider block for Slack message
+    # -----------------------------------------------------------------------------
+    def buildDivider(cls) -> dict:
+        return {"type": "divider"}
+
+
+class SlackUtil(metaclass=SlackUtilMeta):
+    pass

--- a/test/src/test_slack.py
+++ b/test/src/test_slack.py
@@ -1,0 +1,23 @@
+# *****************************************************************************
+# Copyright (c) 2025 IBM Corporation and other Contributors.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# *****************************************************************************
+
+from mas.devops.slack import SlackUtil
+
+
+def testSendMessage():
+    response = SlackUtil.postMessageText("#bot-test", "mas-devops unittest")
+
+    assert "channel" in response.data
+    assert response.data["channel"] == "C06453F9KFC"
+
+    assert "ok" in response.data
+    assert response.data["ok"] is True
+
+    assert "ts" in response.data

--- a/test/src/test_users.py
+++ b/test/src/test_users.py
@@ -1533,7 +1533,6 @@ def test_await_mas_application_availability(user_utils, requests_mock):
 
     def json_callback(request, context):
         nonlocal attempt
-        nonlocal return_values
         ret = return_values[attempt]
         attempt = attempt + 1
         return ret


### PR DESCRIPTION
Preparation to enable Slack notifications to be integrated into the MAS CLI and Ansible collection.  The `mas-devops-notify-slack` script is intended to be the notifier, and will - over time - be expanded to support different types of notifications.  For now the only notification supported is for the provisioning of a new Fyre cluster, intended to be used in the CLI's `mas provision-fyre` function.