### PR TITLE
[patch] Handle env vars set to empty string

### DIFF
--- a/bin/mas-devops-notify-slack
+++ b/bin/mas-devops-notify-slack
@@ -56,9 +56,9 @@ def notifyProvisionFyre(channel: str, rc: int) -> bool:
 
 if __name__ == "__main__":
     # If SLACK_TOKEN or SLACK_CHANNEL env vars are not set then silently exit taking no action
-    SLACK_TOKEN = os.getenv("SLACK_TOKEN", None)
-    SLACK_CHANNEL = os.getenv("SLACK_CHANNEL", None)
-    if SLACK_TOKEN is None or SLACK_CHANNEL is None:
+    SLACK_TOKEN = os.getenv("SLACK_TOKEN", "")
+    SLACK_CHANNEL = os.getenv("SLACK_CHANNEL", "")
+    if SLACK_TOKEN == "" or SLACK_CHANNEL == "":
         sys.exit(0)
 
     # Initialize the properties we need

--- a/bin/mas-devops-notify-slack
+++ b/bin/mas-devops-notify-slack
@@ -41,7 +41,7 @@ def notifyProvisionFyre(channel: str, rc: int) -> bool:
         message = [
             SlackUtil.buildHeader(f":glyph-ok: Your IBM DevIT Fyre OCP cluster ({name}) is ready"),
             SlackUtil.buildSection(f"{url}"),
-            SlackUtil.buildSection(f"- Username: `{username}`\n - Password: `{password}`"),
+            SlackUtil.buildSection(f"- Username: `{username}`\n- Password: `{password}`"),
             SlackUtil.buildSection(f"<https://beta.fyre.ibm.com/development/vms|Fyre Dashboard>{toolchainLink}")
         ]
     else:


### PR DESCRIPTION
By defaulting and checking for `None`, we have a gap in the scenario where the env var is set, but it is set to `""`