### PR TITLE
[Minor] Adding MongoDB CE v8.0 support

### DIFF
--- a/src/mas/devops/data/catalogs/v9-251127-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-251127-amd64.yaml
@@ -1,0 +1,144 @@
+---
+# Case bundle configuration for IBM Maximo Operator Catalog 251030 (AMD64)
+# -----------------------------------------------------------------------------
+# In the future this won't be necessary as we'll be able to mirror from the
+# catalog itself, but not everything in the catalog supports this yet (including MAS)
+# so we need to use the CASE bundle mirror process still.
+
+catalog_digest: sha256:e1822cc642b155a22d82f0ed7149f72cfe67e4458605fac37e7ad43ad0a4ac6d
+
+ocp_compatibility:
+  - 4.15
+  - 4.16
+  - 4.17
+  - 4.18
+  - 4.19
+
+# Dependencies
+# -----------------------------------------------------------------------------
+ibm_licensing_version: 4.2.17                # Operator version 4.2.14 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-licensing)
+common_svcs_version: 4.12.0                  # Operator version 4.12.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+common_svcs_version_1: 4.11.0                  # Additional version 4.11.0
+
+cp4d_platform_version: 5.1.1                 # Operator version 5.1.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-datacore/)
+ibm_zen_version: 6.1.1+20250218.180746.89    # For CPD5 ibm-zen has to be explicitily mirrored
+
+db2u_version: 7.3.1+20250821.161005.16793    # Operator version 110509.0.6 to find the version 7.3.1+20250821.161005.16793, search db2u-operator digest on repo (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+events_version: 5.0.1                        # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
+uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
+sls_version: 3.12.2                          # Operator version 3.10.0 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
+tsm_version: 1.7.2                           # Operator version 1.5.4 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
+dd_version: 1.1.20                           # Operator version 1.1.14 (https://github.ibm.com/maximoappsuite/ibm-data-dictionary/releases)
+appconnect_version: 6.2.0                    # Operator version 6.2.0 # sticking to 6.2.0 version # Please do Not Change
+wsl_version: 10.2.0                          # used for wsl and wsl_runtimes unless wsl_runtimes_version also specified
+wsl_runtimes_version: 10.3.0                 # cpd 5.1.3 uses version 10.3.0 of wsl runtimes but only 10.2.0 for wsl itself
+wml_version: 10.2.0                          # Operator version 5.0.0
+
+# Why are these commented out?
+# ccs_build: +20240528.144404.460            # ibm-ccs from version 9.0.0 requires the build version
+# datarefinery_build: +20240517.202103.146
+
+spark_version: 10.2.0                        # Operator version 7.3.0
+cognos_version: 27.2.0                       # Operator version 25.0.0
+couchdb_version: 1.0.13                      # Operator version 2.2.1 (1.0.13) sticking with 1.0.13 # (This is required for Assist 9.0, https://github.com/IBM/cloud-pak/blob/master/repo/case/ibm-couchdb/index.yaml)
+elasticsearch_version: 1.1.2667              # Operator version 1.1.2667
+
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  9.2.x-feature: 9.2.0-pre.stable_2456 # Updated
+  9.1.x: 9.1.5         # Updated
+  9.0.x: 9.0.16        # Updated
+  8.10.x: 8.10.30      # Updated
+  8.11.x: 8.11.27      # Updated
+mas_assist_version:
+  9.1.x: 9.1.4     # Updated
+  9.0.x: 9.0.10    # Updated
+  8.10.x: 8.7.8   # No Update
+  8.11.x: 8.8.7   # No Update
+mas_hputilities_version:
+  9.1.x: ""       # Not Supported
+  9.0.x: ""       # Not Supported
+  8.10.x: 8.6.7   # No Update
+  8.11.x: ""      # Not Supported
+mas_iot_version:
+  9.1.x: 9.1.4     # Updated
+  9.0.x: 9.0.13    # Updated
+  8.10.x: 8.7.27   # Updated
+  8.11.x: 8.8.23   # Updated
+mas_manage_version:
+  9.2.x-feature: 9.2.0-pre.stable_14287 # Updated
+  9.1.x: 9.1.5         # Updated
+  9.0.x: 9.0.18        # Updated
+  8.10.x: 8.6.31       # Updated
+  8.11.x: 8.7.25       # Updated
+mas_monitor_version:
+  9.1.x: 9.1.4    # Updated
+  9.0.x: 9.0.14   # Updated
+  8.10.x: 8.10.24 # Updated
+  8.11.x: 8.11.22 # Updated
+mas_optimizer_version:
+  9.2.x-feature: 9.2.0-pre.stable_2382 # Updated
+  9.1.x: 9.1.5         # Updated
+  9.0.x: 9.0.16        # Updated
+  8.10.x: 8.4.23       # Updated
+  8.11.x: 8.5.22       # Updated
+mas_predict_version:
+  9.1.x: 9.1.3     # Updated
+  9.0.x: 9.0.10    # Updated
+  8.10.x: 8.8.11   # Updated
+  8.11.x: 8.9.13   # Updated
+mas_visualinspection_version:
+  9.1.x: 9.1.3         # No update for v9-251030
+  9.0.x: 9.0.13        # Updated
+  8.10.x: 8.8.4        # No Update
+  8.11.x: 8.9.16       # Updated
+mas_facilities_version:
+  9.1.x: 9.1.4    # Updated
+  9.0.x: ""       # Not Supported
+  8.10.x: ""      # Not Supported
+  8.11.x: ""      # Not Supported
+
+
+# Maximo AI Service
+# ------------------------------------------------------------------------------
+aiservice_version:
+  9.1.x: 9.1.7  # No Update
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.5.0
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version_default: 8.0.13
+
+# Variables used to mirror additional mongo image versions
+mongo_extras_version_4: 4.4.21
+mongo_extras_version_5: 5.0.23
+mongo_extras_version_6: 6.0.12
+mongo_extras_version_7: 7.0.23
+mongo_extras_version_8: 8.0.13
+
+# Extra Images for Db2u
+# ------------------------------------------------------------------------------
+db2u_extras_version: 1.0.6 # No Update
+db2u_filter: db2
+
+# Extra Images for IBM Watson Discovery
+# ------------------------------------------------------------------------------
+#wd_extras_version: 1.0.4
+
+# Extra Images for Amlen
+# ------------------------------------------------------------------------------
+amlen_extras_version: 1.1.3
+
+# Default Cloud Pak for Data version
+# ------------------------------------------------------------------------------
+cpd_product_version_default: 5.1.3
+
+# Extra Images for kmodels
+# ------------------------------------------------------------------------------
+kmodels_extras_version_default: 1.0.14
+

--- a/src/mas/devops/templates/pipelinerun-update.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-update.yml.j2
@@ -69,6 +69,10 @@ spec:
     - name: mongodb_v7_upgrade
       value: "{{ mongodb_v7_upgrade }}"
 {%- endif %}
+{%- if mongodb_v8_upgrade is defined and mongodb_v8_upgrade != "" %}
+    - name: mongodb_v8_upgrade
+      value: "{{ mongodb_v8_upgrade }}"
+{%- endif %}
 {%- endif %}
 {%- if kafka_namespace is defined and kafka_namespace != "" %}
 

--- a/test/src/test_data.py
+++ b/test/src/test_data.py
@@ -26,7 +26,7 @@ def test_list_catalogs():
 def test_get_newest_catalog_tag():
     catalogTag = getNewestCatalogTag("amd64")
     # Reminder: update this test when adding a new catalog each month!
-    assert catalogTag == "v9-251030-amd64"
+    assert catalogTag == "v9-251127-amd64"
 
 
 def test_get_newest_catalog_tag_fail():


### PR DESCRIPTION
This PR introduces support for MongoDB Community Edition (CE) v8.0 deployments.

Changes applicable wrt Mongo upgrade to version 8 is included.
This is tested and tracked in https://jsw.ibm.com/browse/MASCORE-9741