### PR TITLE
[minor] Support aiserivce airgap install

### DIFF
--- a/src/mas/devops/data/catalogs/v9-250828-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250828-amd64.yaml
@@ -42,7 +42,7 @@ spark_version: 10.2.0                        # Operator version 7.3.0
 cognos_version: 27.2.0                       # Operator version 25.0.0
 couchdb_version: 1.0.13                      # Operator version 2.2.1 (1.0.13) sticking with 1.0.13 # (This is required for Assist 9.0, https://github.com/IBM/cloud-pak/blob/master/repo/case/ibm-couchdb/index.yaml)
 elasticsearch_version: 1.1.2667              # Operator version 1.1.2667
-
+minio_version: RELEASE.2025-06-13T11-33-47Z
 
 # Maximo Application Suite
 # -----------------------------------------------------------------------------

--- a/src/mas/devops/data/catalogs/v9-250902-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250902-amd64.yaml
@@ -141,4 +141,5 @@ cpd_product_version_default: 5.1.3
 # Extra Images for kmodels
 # ------------------------------------------------------------------------------
 kmodels_extras_version_default: 1.0.14
+minio_version: RELEASE.2025-06-13T11-33-47Z
 

--- a/src/mas/devops/data/catalogs/v9-250925-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250925-amd64.yaml
@@ -144,5 +144,6 @@ cpd_product_version_default: 5.1.3
 # Extra Images for kmodels
 # ------------------------------------------------------------------------------
 kmodels_extras_version_default: 1.0.14
+minio_version: RELEASE.2025-06-13T11-33-47Z
 
 manage_extras_913: 9.1.3

--- a/src/mas/devops/data/catalogs/v9-251010-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-251010-amd64.yaml
@@ -140,5 +140,6 @@ cpd_product_version_default: 5.1.3
 # Extra Images for kmodels
 # ------------------------------------------------------------------------------
 kmodels_extras_version_default: 1.0.14
+minio_version: RELEASE.2025-06-13T11-33-47Z
 
 manage_extras_913: 9.1.3

--- a/src/mas/devops/data/catalogs/v9-251030-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-251030-amd64.yaml
@@ -138,8 +138,5 @@ amlen_extras_version: 1.1.3
 # ------------------------------------------------------------------------------
 cpd_product_version_default: 5.1.3
 
-# Extra Images for kmodels
-# ------------------------------------------------------------------------------
-kmodels_extras_version_default: 1.0.14
-
 manage_extras_913: 9.1.3
+minio_version: RELEASE.2025-06-13T11-33-47Z

--- a/src/mas/devops/data/catalogs/v9-251127-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-251127-amd64.yaml
@@ -137,7 +137,5 @@ amlen_extras_version: 1.1.3
 # ------------------------------------------------------------------------------
 cpd_product_version_default: 5.1.3
 
-# Extra Images for kmodels
-# ------------------------------------------------------------------------------
-kmodels_extras_version_default: 1.0.14
-
+manage_extras_913: 9.1.3
+minio_version: RELEASE.2025-06-13T11-33-47Z

--- a/src/mas/devops/mas.py
+++ b/src/mas/devops/mas.py
@@ -37,7 +37,8 @@ def isAirgapInstall(dynClient: DynamicClient, checkICSP: bool = False) -> bool:
     else:
         IDMSApi = dynClient.resources.get(api_version="config.openshift.io/v1", kind="ImageDigestMirrorSet")
         masIDMS = IDMSApi.get(label_selector="mas.ibm.com/idmsContent=ibm")
-        return len(masIDMS.items) > 0
+        aiserviceIDMS = IDMSApi.get(label_selector="aiservice.ibm.com/idmsContent=ibm")
+        return len(masIDMS.items) + len(aiserviceIDMS.items) > 0
 
 
 def getDefaultStorageClasses(dynClient: DynamicClient) -> dict:


### PR DESCRIPTION
moved the minio version into the catalog and changed the isAirgap query to take into account aiservice idms