### PR TITLE
[patch] Update supported python version to 3.12

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,10 +26,10 @@ jobs:
 
       # 2. Python Package Build
       # -------------------------------------------------------------------------------------------
-      - name: Set up Python 3.11
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: 3.12
 
       - name: Build the Python package
         env:

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -25,10 +25,10 @@ jobs:
 
       # 2. Python Package Build
       # -------------------------------------------------------------------------------------------
-      - name: Set up Python 3.11
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: 3.12
 
       - name: Build the Python package
         env:

--- a/setup.py
+++ b/setup.py
@@ -67,12 +67,12 @@ setup(
     ],
     extras_require={
         'dev': [
-            'build',        # MIT License
-            'flake8',       # MIT License
-            'pytest',       # MIT License
-            'pytest-mock',  # MIT License
+            'build',          # MIT License
+            'flake8',         # MIT License
+            'pytest',         # MIT License
+            'pytest-mock',    # MIT License
             'requests-mock',  # Apache Software License
-            'setuptools',    # MIT License
+            'setuptools',     # MIT License
         ]
     },
     classifiers=[
@@ -81,9 +81,7 @@ setup(
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Communications',
         'Topic :: Internet',
         'Topic :: Software Development :: Libraries :: Python Modules'


### PR DESCRIPTION
Build and test with Python 3.12, and update metadata to remove Python 3.9, 3.10, 3.11 support classifiers