### PR TITLE
[major] Remove turbonomic params from install pipelinerun template

### DIFF
--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -89,21 +89,6 @@ spec:
       value: "{{ eck_remote_es_password }}"
   {%- endif %}
 {%- endif %}
-{%- if turbonomic_server_url is defined and turbonomic_server_url != "" %}
-
-    # Dependencies - Turbonomic
-    # -------------------------------------------------------------------------
-    - name: turbonomic_server_url
-      value: "{{ turbonomic_server_url }}"
-    - name: turbonomic_server_version
-      value: "{{ turbonomic_server_version }}"
-    - name: turbonomic_target_name
-      value: "{{ turbonomic_target_name }}"
-    - name: turbonomic_username
-      value: "{{ turbonomic_username }}"
-    - name: turbonomic_password
-      value: "{{ turbonomic_password }}"
-{%- endif %}
 {%- if db2_action_system == "install" or db2_action_manage == "install" %}
 
     # Dependencies - Db2 - Actions


### PR DESCRIPTION
We have shifted the point at which Turbonomic integration is implemented away from the MAS install into the Cluster provision/setup processes to better fit with Turbonomic's role and address bloat in the install pipeline; as a result we no longer need Turbonomic-related parameters.