### PR TITLE
[patch] Fix initial user creation facilities support

### DIFF
--- a/src/mas/devops/users.py
+++ b/src/mas/devops/users.py
@@ -817,7 +817,7 @@ class MASUserUtils():
         for primary_user in primary_users:
             self.logger.info("")
             try:
-                self.logger.info(f"Syncing primary user {primary_user['email']}")
+                self.logger.info(f"Syncing primary user with email {primary_user['email']}")
                 self.create_initial_user_for_saas(primary_user, "PRIMARY")
                 completed.append(primary_user)
                 self.logger.info(f"Completed sync of primary user {primary_user['email']}")
@@ -829,7 +829,7 @@ class MASUserUtils():
             self.logger.info("")
             try:
                 self.logger.info("")
-                self.logger.info(f"Syncing secondary user {secondary_user['email']}")
+                self.logger.info(f"Syncing secondary user with email {secondary_user['email']}")
                 self.create_initial_user_for_saas(secondary_user, "SECONDARY")
                 completed.append(secondary_user)
                 self.logger.info(f"Completed sync of secondary user {secondary_user['email']}")
@@ -855,8 +855,13 @@ class MASUserUtils():
         user_given_name = user["given_name"]
         user_family_name = user["family_name"]
 
-        user_id = user_email
-        username = user_email
+        if "id" in user:
+            user_id = user["id"]
+        else:
+            # default to email if no id provided
+            user_id = user_email
+
+        username = user_id
         # display_name = re.search('^([^@]+)@', user_email).group(1) # local part of the email
         display_name = f"{user_given_name} {user_family_name}"
 
@@ -874,6 +879,7 @@ class MASUserUtils():
             }
             is_workspace_admin = True
             application_role = "ADMIN"
+            facilities_role = "PREMIUM"
             # TODO: check which security groups primary users should be members of
             manage_security_groups = ["MAXADMIN"]
         elif user_type == "SECONDARY":
@@ -889,6 +895,7 @@ class MASUserUtils():
             }
             is_workspace_admin = False
             application_role = "USER"
+            facilities_role = "BASE"
             # TODO: check which security groups secondary users should be members of
             manage_security_groups = []
         else:
@@ -906,6 +913,8 @@ class MASUserUtils():
                     "primary": True
                 }
             ],
+            "phoneNumbers": [],
+            "addresses": [],
             "displayName": display_name,
             "issuer": "local",
             "permissions": permissions,
@@ -923,6 +932,8 @@ class MASUserUtils():
             if mas_application_id == "manage":
                 # special case for manage; role is always "MANAGEUSER"
                 role = "MANAGEUSER"
+            if mas_application_id == "facilities":
+                role = facilities_role
             else:
                 # otherwise grant the user the appropriate role for their user_type
                 role = application_role

--- a/src/mas/devops/users.py
+++ b/src/mas/devops/users.py
@@ -759,17 +759,23 @@ class MASUserUtils():
         for (email, csv) in secret_json.items():
             values = csv.split(",")
 
-            if len(values) != 3:
-                raise Exception(f"Wrong number of CSV values for {email} (expected 3 but got {len(values)})")
+            if len(values) != 3 and len(values) != 4:
+                raise Exception(f"Wrong number of CSV values for {email} (expected 3 or 4 but got {len(values)})")
 
             user_type = values[0].strip()
             given_name = values[1].strip()
             family_name = values[2].strip()
 
+            if len(values) == 4:
+                id = values[3].strip()
+            else:
+                id = email
+
             user = {
                 "email": email,
                 "given_name": given_name,
-                "family_name": family_name
+                "family_name": family_name,
+                "id": id
             }
             if user_type == "primary":
                 primary.append(user)
@@ -880,6 +886,7 @@ class MASUserUtils():
             is_workspace_admin = True
             application_role = "ADMIN"
             facilities_role = "PREMIUM"
+            manage_role = "MANAGEUSER"
             # TODO: check which security groups primary users should be members of
             manage_security_groups = ["MAXADMIN"]
         elif user_type == "SECONDARY":
@@ -896,6 +903,7 @@ class MASUserUtils():
             is_workspace_admin = False
             application_role = "USER"
             facilities_role = "BASE"
+            manage_role = "MANAGEUSER"
             # TODO: check which security groups secondary users should be members of
             manage_security_groups = []
         else:
@@ -930,9 +938,8 @@ class MASUserUtils():
         for mas_application_id in self.mas_workspace_application_ids:
             self.await_mas_application_availability(mas_application_id)
             if mas_application_id == "manage":
-                # special case for manage; role is always "MANAGEUSER"
-                role = "MANAGEUSER"
-            if mas_application_id == "facilities":
+                role = manage_role
+            elif mas_application_id == "facilities":
                 role = facilities_role
             else:
                 # otherwise grant the user the appropriate role for their user_type

--- a/test/src/test_users.py
+++ b/test/src/test_users.py
@@ -1573,7 +1573,8 @@ def test_parse_initial_users_from_aws_secret_json(user_utils):
         {
             "user1@example.com": "primary,joe,bloggs",
             "user2@example.com": "  primary     ,   ben     ,   bob  ",
-            "user3@example.com": "secondary     ,bill,  bibb"
+            "user3@example.com": "secondary     ,bill,  bibb",
+            "user4@example.com": "primary     ,bab,  bub,user4"
         }
     )
 
@@ -1583,19 +1584,28 @@ def test_parse_initial_users_from_aws_secret_json(user_utils):
                 {
                     "email": "user1@example.com",
                     "given_name": "joe",
-                    "family_name": "bloggs"
+                    "family_name": "bloggs",
+                    "id": "user1@example.com",
                 },
                 {
                     "email": "user2@example.com",
                     "given_name": "ben",
-                    "family_name": "bob"
+                    "family_name": "bob",
+                    "id": "user2@example.com",
+                },
+                {
+                    "email": "user4@example.com",
+                    "given_name": "bab",
+                    "family_name": "bub",
+                    "id": "user4",
                 }
             ],
             "secondary": [
                 {
                     "email": "user3@example.com",
                     "given_name": "bill",
-                    "family_name": "bibb"
+                    "family_name": "bibb",
+                    "id": "user3@example.com",
                 }
             ]
         }
@@ -1607,7 +1617,7 @@ def test_parse_initial_users_from_aws_secret_json(user_utils):
         user_utils.parse_initial_users_from_aws_secret_json({
             "user1@example.com": "primary"
         })
-    assert "Wrong number of CSV values for user1@example.com (expected 3 but got 1)" == str(excinfo.value)
+    assert "Wrong number of CSV values for user1@example.com (expected 3 or 4 but got 1)" == str(excinfo.value)
 
     with pytest.raises(Exception) as excinfo:
         user_utils.parse_initial_users_from_aws_secret_json({
@@ -1642,32 +1652,64 @@ def test_create_initial_user_for_saas_unsupported_type(user_utils):
 # Assisted by watsonx Code Assistant
 
 
-@pytest.mark.parametrize("user_type, permissions, entitlement, is_workspace_admin, application_role, manage_security_groups", [
+@pytest.mark.parametrize("user_type, user_id, user_email, permissions, entitlement, is_workspace_admin, application_role, manage_role, facilities_role, manage_security_groups", [
     (
         "PRIMARY",
+        None,
+        "bill.bob@acme.com",
         {"systemAdmin": False, "userAdmin": True, "apikeyAdmin": False},
         {"application": "PREMIUM", "admin": "ADMIN_BASE", "alwaysReserveLicense": True},
         True,
         "ADMIN",
+        "MANAGEUSER",
+        "PREMIUM",
+        ["MAXADMIN"]
+    ),
+    (
+        "PRIMARY",
+        "billbob",
+        "bill.bob@acme.com",
+        {"systemAdmin": False, "userAdmin": True, "apikeyAdmin": False},
+        {"application": "PREMIUM", "admin": "ADMIN_BASE", "alwaysReserveLicense": True},
+        True,
+        "ADMIN",
+        "MANAGEUSER",
+        "PREMIUM",
         ["MAXADMIN"]
     ),
     (
         "SECONDARY",
+        None,
+        "bab.bon@acme.com",
         {"systemAdmin": False, "userAdmin": False, "apikeyAdmin": False},
         {"application": "BASE", "admin": "NONE", "alwaysReserveLicense": True},
         False,
         "USER",
+        "MANAGEUSER",
+        "BASE",
+        []
+    ),
+    (
+        "SECONDARY",
+        "babbon",
+        "bab.bon@acme.com",
+        {"systemAdmin": False, "userAdmin": False, "apikeyAdmin": False},
+        {"application": "BASE", "admin": "NONE", "alwaysReserveLicense": True},
+        False,
+        "USER",
+        "MANAGEUSER",
+        "BASE",
         []
     )
 ])
 def test_create_initial_user_for_saas(
-    user_type, permissions, entitlement, is_workspace_admin, application_role, manage_security_groups,
+    user_type, user_id, user_email, permissions, entitlement, is_workspace_admin, application_role, manage_role, facilities_role, manage_security_groups,
     user_utils, requests_mock
 ):
     user_utils.get_or_create_user = MagicMock()
     user_utils.link_user_to_local_idp = MagicMock()
     user_utils.add_user_to_workspace = MagicMock()
-    mas_workspace_application_ids = ["manage", "iot"]
+    mas_workspace_application_ids = ["manage", "iot", "facilities"]
     user_utils.get_mas_applications_in_workspace = MagicMock(return_value=map(lambda x: {"id": x}, mas_workspace_application_ids))
     user_utils.await_mas_application_availability = MagicMock()
     user_utils.set_user_application_permission = MagicMock()
@@ -1676,20 +1718,24 @@ def test_create_initial_user_for_saas(
     user_utils.create_or_get_manage_api_key_for_user = MagicMock(return_value=manage_api_key)
     user_utils.add_user_to_manage_group = MagicMock()
 
-    user_email = "bill.bob@acme.com"
     user_given_name = "billy"
     user_family_name = "bobby"
-    user_id = user_email
-    username = user_email
     display_name = f"{user_given_name} {user_family_name}"
 
-    user_utils.create_initial_user_for_saas({
+    initial_users = {
         "email": user_email,
         "given_name": user_given_name,
         "family_name": user_family_name
-    },
-        user_type
-    )
+    }
+
+    if user_id is None:
+        user_id = user_email
+    else:
+        initial_users["id"] = user_id
+
+    username = user_id
+
+    user_utils.create_initial_user_for_saas(initial_users, user_type)
 
     user_utils.get_or_create_user.assert_called_once_with({
         "id": user_id,
@@ -1703,6 +1749,8 @@ def test_create_initial_user_for_saas(
                 "primary": True
             }
         ],
+        "phoneNumbers": [],
+        "addresses": [],
         "displayName": display_name,
         "issuer": "local",
         "permissions": permissions,
@@ -1714,12 +1762,14 @@ def test_create_initial_user_for_saas(
     user_utils.add_user_to_workspace.assert_called_once_with(user_id, is_workspace_admin=is_workspace_admin)
     user_utils.await_mas_application_availability.assert_has_calls([call("manage"), call("iot")])
     user_utils.set_user_application_permission.assert_has_calls([
-        call(user_id, "manage", "MANAGEUSER"),
+        call(user_id, "manage", manage_role),
         call(user_id, "iot", application_role),
+        call(user_id, "facilities", facilities_role),
     ])
     user_utils.check_user_sync.assert_has_calls([
         call(user_id, "manage"),
-        call(user_id, "iot")
+        call(user_id, "iot"),
+        call(user_id, "facilities")
     ])
 
     if len(manage_security_groups) > 0:


### PR DESCRIPTION
## Description


Fixes support for facilities in the `mas-devops-create-initial-users-for-saas` script run  by the [ibm-create-initial-users.](https://github.com/ibm-mas/gitops/blob/main/instance-applications/600-ibm-post-sync-jobs/templates/001-ibm-create-initial-users.yaml) Gitops Job. See [walkthrough](https://pages.github.ibm.com/maximoappsuite/saas/walkthrough/#automated-creation-of-initial-users) for details.


### Fix issues causing the script to fail when facilities app is installed

When facilities app installed, users created by the script would fail to sync with facilities due to:
```
AIUI1101E: Internal user agent error. Details: [main <email>] synched: status_code: 500 r.text {"message":"Cannot invoke \"com.ibm.tririga.platform.usf.mascore.model.MasCoreUserData.getPhoneNumbers()\" because \"userData\" is null"}
```

```
AIUI1101E: Internal user agent error. Details: [main <email>] synched: status_code: 500 r.text {"message":"Cannot invoke \"com.ibm.tririga.platform.usf.mascore.model.MasCoreUserData.getAddresses()\" because \"userData\" is null"}
```

and with manage due to:
```
AIUI1101E: Internal user agent error. Details: [main <email>] synched: status_code: 400 r.text Error 400: BMXAA4190E - Real estate and facilities ADMIN is not in the value list.
```

This PR fixes these issues by ensuring:
 -  `addresses` and `phoneNumbers` are set (to an empty list) when the user is created. 
 - a valid role is used when assigning user access to facilities (`PREMIUM` for primary users and `BASE` for secondary users)


### Allow user_id to be (optionally) specified, otherwise default to using email (as before)

There is also a need to be able to use this script to create the special `FACILITIESADMIN` user. To support this, the assumption that created user emails and ids are always the same has been removed by adding an additional `id` field to the inputs. This field is optional. If absent, email will continue to be used as the id for backwards compatibility.

In the initial users secret JSON, the new `id` field is a fourth optional element, e.g.:

```
{
  "user1@email.com": "primary,john,smith"
}
```
Will use `user1@email.com` as the user's ID and email (as before)

```
{
  "facilitiesadmin@email.com": "primary,john,smith, facilitiesadmin"
}
```

Will use `facilitiesadmin@email.com` as the user's email, but `facilitiesadmin` as their ID.

## Testing

Unit tests updated

Verified manually by running the script from my laptop against a MAS 9.1.5 (Manage 9.1.5, Facilities 9.1.4) instance:

initial user secret:
```
{
   "initialusertest1@suite.maximo.com":"primary,f1,l1",
   "initialusertest2@suite.maximo.com":"primary,f2,l2,initialusertest2"
}
```


```bash
$ mas-devops-create-initial-users-for-saas \
    --mas-instance-id masaudit \
    --mas-workspace-id main \
    --log-level INFO \
    --initial-users-secret-name initialusertest \
    --manage-api-port 8443 \
    --coreapi-port 8444 \
    --admin-dashboard-port 8445

2025-12-16 16:01:32,221   root                                               [MainThread] INFO     Configuration:
2025-12-16 16:01:32,221   root                                               [MainThread] INFO     --------------
2025-12-16 16:01:32,221   root                                               [MainThread] INFO     mas_instance_id:           masaudit
2025-12-16 16:01:32,221   root                                               [MainThread] INFO     mas_workspace_id:          main
2025-12-16 16:01:32,221   root                                               [MainThread] INFO     initial_users_yaml_file:   None
2025-12-16 16:01:32,221   root                                               [MainThread] INFO     initial_users_secret_name: initialusertest
2025-12-16 16:01:32,221   root                                               [MainThread] INFO     log_level:                 20
2025-12-16 16:01:32,221   root                                               [MainThread] INFO     coreapi_port:              8444
2025-12-16 16:01:32,221   root                                               [MainThread] INFO     admin_dashboard_port:      8445
2025-12-16 16:01:32,221   root                                               [MainThread] INFO     manage_api_port:           8443
2025-12-16 16:01:32,221   root                                               [MainThread] INFO
2025-12-16 16:01:32,226   root                                               [MainThread] INFO     Loading initial_users configuration from secret initialusertest
2025-12-16 16:01:32,233   botocore.credentials                               [MainThread] INFO     Found credentials in environment variables.
2025-12-16 16:01:37,529   mas.devops.users.MASUserUtils                      [MainThread] INFO     Waiting for manage to become ready and available: 600.00 seconds remaining
2025-12-16 16:01:39,019   mas.devops.users.MASUserUtils                      [MainThread] INFO     Waiting for facilities to become ready and available: 600.00 seconds remaining
2025-12-16 16:01:40,306   mas.devops.users.MASUserUtils                      [MainThread] INFO
2025-12-16 16:01:40,307   mas.devops.users.MASUserUtils                      [MainThread] INFO     Syncing primary user with email initialusertest1@suite.maximo.com
2025-12-16 16:01:41,756   mas.devops.users.MASUserUtils                      [MainThread] INFO     Creating new user initialusertest1@suite.maximo.com
2025-12-16 16:01:47,411   mas.devops.users.MASUserUtils                      [MainThread] INFO     Linking user initialusertest1@suite.maximo.com to local IDP (email_password: True)
2025-12-16 16:01:50,266   mas.devops.users.MASUserUtils                      [MainThread] INFO     Adding user initialusertest1@suite.maximo.com to main (is_workspace_admin: True)
2025-12-16 16:01:51,560   mas.devops.users.MASUserUtils                      [MainThread] INFO     Waiting for manage to become ready and available: 600.00 seconds remaining
2025-12-16 16:02:03,460   mas.devops.users.MASUserUtils                      [MainThread] INFO     Setting user initialusertest1@suite.maximo.com role for manage to MANAGEUSER
2025-12-16 16:02:05,093   mas.devops.users.MASUserUtils                      [MainThread] INFO     Waiting for facilities to become ready and available: 600.00 seconds remaining
2025-12-16 16:02:08,235   mas.devops.users.MASUserUtils                      [MainThread] INFO     Setting user initialusertest1@suite.maximo.com role for facilities to PREMIUM
2025-12-16 16:02:09,499   mas.devops.users.MASUserUtils                      [MainThread] INFO     Awaiting user initialusertest1@suite.maximo.com sync status "SUCCESS" for app manage: 600.00 seconds remaining
2025-12-16 16:02:35,599   mas.devops.users.MASUserUtils                      [MainThread] INFO     User initialusertest1@suite.maximo.com sync has not been completed yet for app manage (currrently PENDING): 573.90 seconds remaining
2025-12-16 16:02:41,757   mas.devops.users.MASUserUtils                      [MainThread] INFO     Awaiting user initialusertest1@suite.maximo.com sync status "SUCCESS" for app facilities: 600.00 seconds remaining
2025-12-16 16:02:45,265   mas.devops.users.MASUserUtils                      [MainThread] INFO     Reusing existing Manage API Key for user MAXADMIN
2025-12-16 16:02:52,203   mas.devops.users.MASUserUtils                      [MainThread] INFO     Adding user initialusertest1@suite.maximo.com to Manage group MAXADMIN
2025-12-16 16:02:55,422   mas.devops.users.MASUserUtils                      [MainThread] INFO     Completed sync of primary user initialusertest1@suite.maximo.com
2025-12-16 16:02:55,423   mas.devops.users.MASUserUtils                      [MainThread] INFO
2025-12-16 16:02:55,423   mas.devops.users.MASUserUtils                      [MainThread] INFO     Syncing primary user with email initialusertest2@suite.maximo.com
2025-12-16 16:02:56,727   mas.devops.users.MASUserUtils                      [MainThread] INFO     Creating new user initialusertest2
2025-12-16 16:03:01,765   mas.devops.users.MASUserUtils                      [MainThread] INFO     Linking user initialusertest2 to local IDP (email_password: True)
2025-12-16 16:03:04,814   mas.devops.users.MASUserUtils                      [MainThread] INFO     Adding user initialusertest2 to main (is_workspace_admin: True)
2025-12-16 16:03:05,997   mas.devops.users.MASUserUtils                      [MainThread] INFO     Waiting for manage to become ready and available: 600.00 seconds remaining
2025-12-16 16:03:17,487   mas.devops.users.MASUserUtils                      [MainThread] INFO     Setting user initialusertest2 role for manage to MANAGEUSER
2025-12-16 16:03:19,074   mas.devops.users.MASUserUtils                      [MainThread] INFO     Waiting for facilities to become ready and available: 600.00 seconds remaining
2025-12-16 16:03:21,940   mas.devops.users.MASUserUtils                      [MainThread] INFO     Setting user initialusertest2 role for facilities to PREMIUM
2025-12-16 16:03:23,326   mas.devops.users.MASUserUtils                      [MainThread] INFO     Awaiting user initialusertest2 sync status "SUCCESS" for app manage: 600.00 seconds remaining
2025-12-16 16:03:50,054   mas.devops.users.MASUserUtils                      [MainThread] INFO     User initialusertest2 sync has not been completed yet for app manage (currrently PENDING): 573.27 seconds remaining
2025-12-16 16:03:56,466   mas.devops.users.MASUserUtils                      [MainThread] INFO     Awaiting user initialusertest2 sync status "SUCCESS" for app facilities: 600.00 seconds remaining
2025-12-16 16:03:59,804   mas.devops.users.MASUserUtils                      [MainThread] INFO     Reusing existing Manage API Key for user MAXADMIN
2025-12-16 16:04:04,530   mas.devops.users.MASUserUtils                      [MainThread] INFO     Adding user initialusertest2 to Manage group MAXADMIN
2025-12-16 16:04:07,186   mas.devops.users.MASUserUtils                      [MainThread] INFO     Completed sync of primary user initialusertest2@suite.maximo.com
2025-12-16 16:04:07,186   root                                               [MainThread] INFO     Removing synced user initialusertest1@suite.maximo.com from initialusertest secret
2025-12-16 16:04:07,186   root                                               [MainThread] INFO     Removing synced user initialusertest2@suite.maximo.com from initialusertest secret
2025-12-16 16:04:07,186   root                                               [MainThread] INFO     Updating secret initialusertest
```

Both users were created successfully with expected access rights, and it was possible to login as them.