### PR TITLE
[patch] Make sls_channel optional

### DIFF
--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -275,8 +275,10 @@ spec:
 
     # Dependencies - SLS
     # -------------------------------------------------------------------------
+{%- if sls_channel is defined and sls_channel != "" %}
     - name: sls_channel
-      value: '3.x'
+      value: "{{ sls_channel }}"
+{%- endif %}
 {%- if sls_entitlement_file is defined and sls_entitlement_file != "" %}
     - name: sls_entitlement_file
       value: "{{ sls_entitlement_file }}"


### PR DESCRIPTION
## Details

- in pipelinerun-install.yml.j2
  - Made `sls_channel` optional because by default the sls role will use `3.x`
  - Removed hardcoded `sls_channel` value because we can now pass this value in when in development mode

## Testing

- Tested various scenarios and installs via the CLI