### PR TITLE
[patch] Increase timeout for pvc bind wait

### DIFF
--- a/src/mas/devops/ocp.py
+++ b/src/mas/devops/ocp.py
@@ -259,8 +259,12 @@ def listInstances(dynClient: DynamicClient, apiVersion: str, kind: str) -> list:
 
 
 def waitForPVC(dynClient: DynamicClient, namespace: str, pvcName: str) -> bool:
+    """
+    We will allow up to 10 minutes for a PVC to report a successful binding
+    """
     pvcAPI = dynClient.resources.get(api_version="v1", kind="PersistentVolumeClaim")
-    maxRetries = 60
+    maxRetries = 20
+    retryDelaySeconds = 30
     foundReadyPVC = False
     retries = 0
     while not foundReadyPVC and retries < maxRetries:
@@ -270,11 +274,11 @@ def waitForPVC(dynClient: DynamicClient, namespace: str, pvcName: str) -> bool:
             if pvc.status.phase == "Bound":
                 foundReadyPVC = True
             else:
-                logger.debug(f"Waiting 5s for PVC {pvcName} to be ready before checking again ...")
-                sleep(5)
+                logger.debug(f"Waiting {retryDelaySeconds}s for PVC {pvcName} to be bound before checking again ...")
+                sleep(retryDelaySeconds)
         except NotFoundError:
-            logger.debug(f"Waiting 5s for PVC {pvcName} to be created before checking again ...")
-            sleep(5)
+            logger.debug(f"Waiting {retryDelaySeconds}s for PVC {pvcName} to be created before checking again ...")
+            sleep(retryDelaySeconds)
 
     return foundReadyPVC
 


### PR DESCRIPTION
We have unnecessarily aggressive polling/timeout when waiting for a PVC to be ready:

```
19 Dec, 03:13:25 2025-12-19 03:08:24,177   DEBUG    Waiting for postgredb-tekton-results-postgres-0 PVC to be ready
19 Dec, 03:13:25 2025-12-19 03:08:24,195   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be created before checking again ...
19 Dec, 03:13:25 2025-12-19 03:08:29,214   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be created before checking again ...
19 Dec, 03:13:25 2025-12-19 03:08:34,235   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be created before checking again ...
19 Dec, 03:13:25 2025-12-19 03:08:39,257   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be created before checking again ...
19 Dec, 03:13:25 2025-12-19 03:08:44,278   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be created before checking again ...
19 Dec, 03:13:25 2025-12-19 03:08:49,330   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be created before checking again ...
19 Dec, 03:13:25 2025-12-19 03:08:54,350   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be created before checking again ...
19 Dec, 03:13:25 2025-12-19 03:08:59,368   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:09:04,388   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:09:09,408   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:09:14,445   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:09:19,464   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:09:24,484   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:09:29,502   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:09:34,522   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:09:39,541   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:09:44,561   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:09:49,578   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:09:54,603   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:09:59,622   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:10:04,641   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:10:09,659   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:10:14,680   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:10:19,702   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:10:24,722   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:10:29,744   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:10:34,764   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:10:39,786   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:10:44,806   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:10:49,826   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:10:54,846   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:10:59,866   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:11:04,885   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:11:09,905   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:11:14,926   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:11:19,948   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:11:24,967   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:11:29,989   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:11:35,010   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:11:40,029   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:11:45,052   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:11:50,073   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:11:55,091   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:12:00,110   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:12:05,131   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:12:10,150   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:12:15,172   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:12:20,191   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:12:25,211   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:12:30,230   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:12:35,255   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:12:40,275   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:12:45,295   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:12:50,315   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:12:55,333   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:13:00,366   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:13:05,391   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:13:10,414   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:13:15,435   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:13:20,458   DEBUG    Waiting 5s for PVC postgredb-tekton-results-postgres-0 to be ready before checking again ...
19 Dec, 03:13:25 2025-12-19 03:13:25,484   ERROR    OpenShift Pipelines postgres PVC is NOT ready
```

We can see that had we waited a little longer the PVC would have bound successfully.  This update gives 10 minutes rather than 5, and reduces the poll interval to every 30s.