### PR TITLE
[patch] update mongo version 8.0.17

### DIFF
--- a/src/mas/devops/data/catalogs/v9-251224-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-251224-amd64.yaml
@@ -114,14 +114,14 @@ uds_extras_version: 1.5.0
 
 # Extra Images for Mongo
 # ------------------------------------------------------------------------------
-mongo_extras_version_default: 8.0.13
+mongo_extras_version_default: 8.0.17
 
 # Variables used to mirror additional mongo image versions
 mongo_extras_version_4: 4.4.21
 mongo_extras_version_5: 5.0.23
 mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.23
-mongo_extras_version_8: 8.0.13
+mongo_extras_version_8: 8.0.17
 
 # Extra Images for Db2u
 # ------------------------------------------------------------------------------

--- a/src/mas/devops/data/catalogs/v9-251224-ppc64le.yaml
+++ b/src/mas/devops/data/catalogs/v9-251224-ppc64le.yaml
@@ -39,11 +39,11 @@ uds_extras_version: 1.5.0
 
 # Extra Images for Mongo
 # ------------------------------------------------------------------------------
-mongo_extras_version_default: 8.0.13
+mongo_extras_version_default: 8.0.17
 
 # Variables used to mirror additional mongo image versions
 mongo_extras_version_4: 4.4.21
 mongo_extras_version_5: 5.0.23
 mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
-mongo_extras_version_8: 8.0.13
+mongo_extras_version_8: 8.0.17

--- a/src/mas/devops/data/catalogs/v9-251224-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-251224-s390x.yaml
@@ -39,11 +39,11 @@ uds_extras_version: 1.5.0
 
 # Extra Images for Mongo
 # ------------------------------------------------------------------------------
-mongo_extras_version_default: 8.0.13
+mongo_extras_version_default: 8.0.17
 
 # Variables used to mirror additional mongo image versions
 mongo_extras_version_4: 4.4.21
 mongo_extras_version_5: 5.0.23
 mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
-mongo_extras_version_8: 8.0.13
+mongo_extras_version_8: 8.0.17


### PR DESCRIPTION
- Updated mongo to 8.0.17 from 8.0.13 to fix the [Mongo CVE (mongodb-cve-2025-14847)](https://w3.ibm.com/w3publisher/ciso-vulnerability-management/ciso-override-notifications/2025/mongodb-cve-2025-14847)

- FVT result: https://dashboard.ibmmas.com/tests/mng8017