### PR TITLE
[minor] Add new ocp and editorial metadata

### DIFF
--- a/src/mas/devops/data/__init__.py
+++ b/src/mas/devops/data/__init__.py
@@ -103,14 +103,6 @@ def getOCPLifecycleData() -> dict | None:
     Returns:
         dict: The OCP lifecycle data dictionary with version information.
               Returns None if the ocp.yaml file doesn't exist.
-
-    Example:
-        >>> data = getOCPLifecycleData()
-        >>> if data:
-        ...     versions = data.get('ocp_versions', {})
-        ...     ocp_416 = versions.get('4.16', {})
-        ...     print(ocp_416.get('ga_date'))
-        'June 27, 2024'
     """
     moduleFile = path.abspath(__file__)
     modulePath = path.dirname(moduleFile)
@@ -137,16 +129,6 @@ def getOCPVersion(version: str) -> dict | None:
     Returns:
         dict: Dictionary containing 'ga_date', 'standard_support', and 'extended_support'.
               Returns None if the version is not found or OCP data doesn't exist.
-
-    Example:
-        >>> version_info = getOCPVersion("4.16")
-        >>> if version_info:
-        ...     print(f"GA: {version_info['ga_date']}")
-        ...     print(f"Standard Support: {version_info['standard_support']}")
-        ...     print(f"Extended Support: {version_info['extended_support']}")
-        GA: June 27, 2024
-        Standard Support: December 27, 2025
-        Extended Support: June 27, 2027
     """
     ocp_data = getOCPLifecycleData()
     if not ocp_data:
@@ -166,11 +148,6 @@ def listOCPVersions() -> list:
     Returns:
         list: Sorted list of OCP version strings (e.g., ["4.12", "4.13", "4.14", ...]).
               Returns empty list if OCP data doesn't exist.
-
-    Example:
-        >>> versions = listOCPVersions()
-        >>> print(versions)
-        ['4.12', '4.13', '4.14', '4.15', '4.16', '4.17', '4.18', '4.19']
     """
     ocp_data = getOCPLifecycleData()
     if not ocp_data:
@@ -193,14 +170,8 @@ def getCatalogEditorial(catalog_tag: str) -> dict | None:
 
     Returns:
         dict: Dictionary with 'whats_new' and 'known_issues' keys containing
-              markdown-formatted strings. Returns None if catalog doesn't exist
+              structured lists. Returns None if catalog doesn't exist
               or has no editorial content.
-
-    Example:
-        >>> editorial = getCatalogEditorial("v9-251231-amd64")
-        >>> if editorial:
-        ...     print(editorial['whats_new'])
-        ...     print(editorial['known_issues'])
     """
     catalog = getCatalog(catalog_tag)
     if not catalog:

--- a/src/mas/devops/data/__init__.py
+++ b/src/mas/devops/data/__init__.py
@@ -90,3 +90,92 @@ def getNewestCatalogTag(arch="amd64") -> str | None:
         return None
     else:
         return catalogs[-1]
+
+
+def getOCPLifecycleData() -> dict | None:
+    """
+    Load OpenShift Container Platform lifecycle data.
+
+    This function reads the OCP lifecycle YAML file containing General Availability dates,
+    Standard Support end dates, and Extended Update Support (EUS) end dates for various
+    OCP versions.
+
+    Returns:
+        dict: The OCP lifecycle data dictionary with version information.
+              Returns None if the ocp.yaml file doesn't exist.
+
+    Example:
+        >>> data = getOCPLifecycleData()
+        >>> if data:
+        ...     versions = data.get('ocp_versions', {})
+        ...     ocp_416 = versions.get('4.16', {})
+        ...     print(ocp_416.get('ga_date'))
+        'June 27, 2024'
+    """
+    moduleFile = path.abspath(__file__)
+    modulePath = path.dirname(moduleFile)
+    ocpFileName = "ocp.yaml"
+
+    pathToOCP = path.join(modulePath, ocpFileName)
+    if not path.exists(pathToOCP):
+        return None
+
+    with open(pathToOCP) as stream:
+        return yaml.safe_load(stream)
+
+
+def getOCPVersion(version: str) -> dict | None:
+    """
+    Get lifecycle information for a specific OCP version.
+
+    This function retrieves the General Availability date, Standard Support end date,
+    and Extended Update Support (EUS) end date for a specific OpenShift version.
+
+    Args:
+        version (str): The OCP version (e.g., "4.16", "4.17").
+
+    Returns:
+        dict: Dictionary containing 'ga_date', 'standard_support', and 'extended_support'.
+              Returns None if the version is not found or OCP data doesn't exist.
+
+    Example:
+        >>> version_info = getOCPVersion("4.16")
+        >>> if version_info:
+        ...     print(f"GA: {version_info['ga_date']}")
+        ...     print(f"Standard Support: {version_info['standard_support']}")
+        ...     print(f"Extended Support: {version_info['extended_support']}")
+        GA: June 27, 2024
+        Standard Support: December 27, 2025
+        Extended Support: June 27, 2027
+    """
+    ocp_data = getOCPLifecycleData()
+    if not ocp_data:
+        return None
+
+    ocp_versions = ocp_data.get("ocp_versions", {})
+    return ocp_versions.get(version)
+
+
+def listOCPVersions() -> list:
+    """
+    List all OCP versions with lifecycle data available.
+
+    This function returns a sorted list of all OpenShift Container Platform versions
+    that have lifecycle information defined.
+
+    Returns:
+        list: Sorted list of OCP version strings (e.g., ["4.12", "4.13", "4.14", ...]).
+              Returns empty list if OCP data doesn't exist.
+
+    Example:
+        >>> versions = listOCPVersions()
+        >>> print(versions)
+        ['4.12', '4.13', '4.14', '4.15', '4.16', '4.17', '4.18', '4.19']
+    """
+    ocp_data = getOCPLifecycleData()
+    if not ocp_data:
+        return []
+
+    ocp_versions = ocp_data.get("ocp_versions", {})
+    # Sort versions numerically (4.12, 4.13, etc.)
+    return sorted(ocp_versions.keys(), key=lambda v: [int(x) for x in v.split(".")])

--- a/src/mas/devops/data/__init__.py
+++ b/src/mas/devops/data/__init__.py
@@ -130,12 +130,12 @@ def getOCPVersion(version: str) -> dict | None:
         dict: Dictionary containing 'ga_date', 'standard_support', and 'extended_support'.
               Returns None if the version is not found or OCP data doesn't exist.
     """
-    ocp_data = getOCPLifecycleData()
-    if not ocp_data:
+    ocpData = getOCPLifecycleData()
+    if not ocpData:
         return None
 
-    ocp_versions = ocp_data.get("ocp_versions", {})
-    return ocp_versions.get(version)
+    ocpVersions = ocpData.get("ocp_versions", {})
+    return ocpVersions.get(version)
 
 
 def listOCPVersions() -> list:
@@ -149,16 +149,16 @@ def listOCPVersions() -> list:
         list: Sorted list of OCP version strings (e.g., ["4.12", "4.13", "4.14", ...]).
               Returns empty list if OCP data doesn't exist.
     """
-    ocp_data = getOCPLifecycleData()
-    if not ocp_data:
+    ocpData = getOCPLifecycleData()
+    if not ocpData:
         return []
 
-    ocp_versions = ocp_data.get("ocp_versions", {})
+    ocpVersions = ocpData.get("ocp_versions", {})
     # Sort versions numerically (4.12, 4.13, etc.)
-    return sorted(ocp_versions.keys(), key=lambda v: [int(x) for x in v.split(".")])
+    return sorted(ocpVersions.keys(), key=lambda v: [int(x) for x in v.split(".")])
 
 
-def getCatalogEditorial(catalog_tag: str) -> dict | None:
+def getCatalogEditorial(catalogTag: str) -> dict | None:
     """
     Get editorial content (What's New and Known Issues) for a specific catalog.
 
@@ -166,14 +166,14 @@ def getCatalogEditorial(catalog_tag: str) -> dict | None:
     which includes "What's New" highlights and "Known Issues" information.
 
     Args:
-        catalog_tag (str): The catalog tag (e.g., "v9-251231-amd64").
+        catalogTag (str): The catalog tag (e.g., "v9-251231-amd64").
 
     Returns:
         dict: Dictionary with 'whats_new' and 'known_issues' keys containing
               structured lists. Returns None if catalog doesn't exist
               or has no editorial content.
     """
-    catalog = getCatalog(catalog_tag)
+    catalog = getCatalog(catalogTag)
     if not catalog:
         return None
 

--- a/src/mas/devops/data/__init__.py
+++ b/src/mas/devops/data/__init__.py
@@ -179,3 +179,31 @@ def listOCPVersions() -> list:
     ocp_versions = ocp_data.get("ocp_versions", {})
     # Sort versions numerically (4.12, 4.13, etc.)
     return sorted(ocp_versions.keys(), key=lambda v: [int(x) for x in v.split(".")])
+
+
+def getCatalogEditorial(catalog_tag: str) -> dict | None:
+    """
+    Get editorial content (What's New and Known Issues) for a specific catalog.
+
+    This function retrieves the editorial metadata from a catalog definition,
+    which includes "What's New" highlights and "Known Issues" information.
+
+    Args:
+        catalog_tag (str): The catalog tag (e.g., "v9-251231-amd64").
+
+    Returns:
+        dict: Dictionary with 'whats_new' and 'known_issues' keys containing
+              markdown-formatted strings. Returns None if catalog doesn't exist
+              or has no editorial content.
+
+    Example:
+        >>> editorial = getCatalogEditorial("v9-251231-amd64")
+        >>> if editorial:
+        ...     print(editorial['whats_new'])
+        ...     print(editorial['known_issues'])
+    """
+    catalog = getCatalog(catalog_tag)
+    if not catalog:
+        return None
+
+    return catalog.get("editorial")

--- a/src/mas/devops/data/catalogs/v9-250109-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250109-amd64.yaml
@@ -114,15 +114,16 @@ amlen_extras_version: 1.1.2
 cpd_product_version_default: 5.0.0
 
 editorial:
-  whats_new: |
-    - **Security updates and bug fixes**
-        - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0, v9.1
-        - IBM Maximo Manage v8.7, v8.6, v9.0 and v9.1
-        - IBM Maximo Monitor v8.11, v8.10 and v9.0
-        - IBM Maximo Optimizer v8.5, v8.4, v9.0 and v9.1
-        - IBM Maximo Predict v9.0
-        - IBM Data Dictionary v1.1
-        - IBM SLS v3.0
-  known_issues: |
-    - Customers using Maximo Assist v8.7 or v8.8 should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
-    - Disconnected environments with Manage Civil, Aviation and ICD should not be updated at this time due to a known bug.
+  whats_new:
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0, v9.1
+    - IBM Maximo Manage v8.7, v8.6, v9.0 and v9.1
+    - IBM Maximo Monitor v8.11, v8.10 and v9.0
+    - IBM Maximo Optimizer v8.5, v8.4, v9.0 and v9.1
+    - IBM Maximo Predict v9.0
+    - IBM Data Dictionary v1.1
+    - IBM SLS v3.0
+  known_issues:
+  - title: Customers using Maximo Assist v8.7 or v8.8 should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
+  - title: Disconnected environments with Manage Civil, Aviation and ICD should not be updated at this time due to a known bug.

--- a/src/mas/devops/data/catalogs/v9-250109-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250109-amd64.yaml
@@ -112,3 +112,17 @@ amlen_extras_version: 1.1.2
 # Default Cloud Pak for Data version
 # ------------------------------------------------------------------------------
 cpd_product_version_default: 5.0.0
+
+editorial:
+  whats_new: |
+    - **Security updates and bug fixes**
+        - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0, v9.1
+        - IBM Maximo Manage v8.7, v8.6, v9.0 and v9.1
+        - IBM Maximo Monitor v8.11, v8.10 and v9.0
+        - IBM Maximo Optimizer v8.5, v8.4, v9.0 and v9.1
+        - IBM Maximo Predict v9.0
+        - IBM Data Dictionary v1.1
+        - IBM SLS v3.0
+  known_issues: |
+    - Customers using Maximo Assist v8.7 or v8.8 should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
+    - Disconnected environments with Manage Civil, Aviation and ICD should not be updated at this time due to a known bug.

--- a/src/mas/devops/data/catalogs/v9-250109-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-250109-s390x.yaml
@@ -45,8 +45,10 @@ mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
 
 editorial:
-  whats_new: |
-    - **Security updates and bug fixes**
-        - IBM Maximo Application Suite Core Platform v9.0 & v9.1
-        - IBM Maximo Manage v9.0 & v9.1
-        - IBM SLS v3.0
+  whats_new:
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v9.0 & v9.1
+    - IBM Maximo Manage v9.0 & v9.1
+    - IBM SLS v3.0
+  known_issues: []

--- a/src/mas/devops/data/catalogs/v9-250109-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-250109-s390x.yaml
@@ -43,3 +43,10 @@ mongo_extras_version_4: 4.4.21
 mongo_extras_version_5: 5.0.23
 mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
+
+editorial:
+  whats_new: |
+    - **Security updates and bug fixes**
+        - IBM Maximo Application Suite Core Platform v9.0 & v9.1
+        - IBM Maximo Manage v9.0 & v9.1
+        - IBM SLS v3.0

--- a/src/mas/devops/data/catalogs/v9-250206-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250206-amd64.yaml
@@ -114,15 +114,16 @@ amlen_extras_version: 1.1.2
 cpd_product_version_default: 5.0.0
 
 editorial:
-  whats_new: |
-    - **Security updates and bug fixes**
-        - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0, v9.1
-        - IBM Maximo IoT v8.7, v8.8 and v9.0
-        - IBM Maximo Manage v8.7, v8.6, v9.0 and v9.1
-        - IBM Maximo Monitor v8.11, v8.10 and v9.0
-        - IBM Maximo Optimizer v8.5, v8.4, v9.0 and v9.1
-        - IBM Data Dictionary v1.1
-        - IBM SLS v3.0
-        - IBM Maximo Visual Inspection v8.9, v9.0 and v9.1
-  known_issues: |
-    - Customers using Maximo Assist v8.7 or v8.8 should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
+  whats_new:
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0, v9.1
+    - IBM Maximo IoT v8.7, v8.8 and v9.0
+    - IBM Maximo Manage v8.7, v8.6, v9.0 and v9.1
+    - IBM Maximo Monitor v8.11, v8.10 and v9.0
+    - IBM Maximo Optimizer v8.5, v8.4, v9.0 and v9.1
+    - IBM Data Dictionary v1.1
+    - IBM SLS v3.0
+    - IBM Maximo Visual Inspection v8.9, v9.0 and v9.1
+  known_issues:
+  - title: Customers using Maximo Assist v8.7 or v8.8 should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0

--- a/src/mas/devops/data/catalogs/v9-250206-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250206-amd64.yaml
@@ -112,3 +112,17 @@ amlen_extras_version: 1.1.2
 # Default Cloud Pak for Data version
 # ------------------------------------------------------------------------------
 cpd_product_version_default: 5.0.0
+
+editorial:
+  whats_new: |
+    - **Security updates and bug fixes**
+        - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0, v9.1
+        - IBM Maximo IoT v8.7, v8.8 and v9.0
+        - IBM Maximo Manage v8.7, v8.6, v9.0 and v9.1
+        - IBM Maximo Monitor v8.11, v8.10 and v9.0
+        - IBM Maximo Optimizer v8.5, v8.4, v9.0 and v9.1
+        - IBM Data Dictionary v1.1
+        - IBM SLS v3.0
+        - IBM Maximo Visual Inspection v8.9, v9.0 and v9.1
+  known_issues: |
+    - Customers using Maximo Assist v8.7 or v8.8 should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0

--- a/src/mas/devops/data/catalogs/v9-250206-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-250206-s390x.yaml
@@ -45,8 +45,10 @@ mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
 
 editorial:
-  whats_new: |
-    - **Security updates and bug fixes**
-        - IBM Maximo Application Suite Core Platform v9.0 & v9.1
-        - IBM Maximo Manage v9.0 & v9.1
-        - IBM SLS v3.0
+  whats_new:
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v9.0 & v9.1
+    - IBM Maximo Manage v9.0 & v9.1
+    - IBM SLS v3.0
+  known_issues: []

--- a/src/mas/devops/data/catalogs/v9-250206-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-250206-s390x.yaml
@@ -43,3 +43,10 @@ mongo_extras_version_4: 4.4.21
 mongo_extras_version_5: 5.0.23
 mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
+
+editorial:
+  whats_new: |
+    - **Security updates and bug fixes**
+        - IBM Maximo Application Suite Core Platform v9.0 & v9.1
+        - IBM Maximo Manage v9.0 & v9.1
+        - IBM SLS v3.0

--- a/src/mas/devops/data/catalogs/v9-250306-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250306-amd64.yaml
@@ -115,17 +115,18 @@ amlen_extras_version: 1.1.2
 cpd_product_version_default: 5.0.0
 
 editorial:
-  whats_new: |
-    - **Security updates and bug fixes**
-        - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0, v9.1
-        - IBM Maximo Assist v9.0
-        - IBM Maximo IoT v8.7, v8.8 and v9.0
-        - IBM Maximo Manage v8.7, v8.6, v9.0 and v9.1
-        - IBM Maximo Monitor v8.11, v8.10 and v9.0
-        - IBM Maximo Optimizer v8.5, v8.4, v9.0 and v9.1
-        - IBM Maximo Predict v9.0, v8.9, v8.8
-        - IBM Maximo Visual Inspection v8.9, v9.0 and v9.1
-        - IBM Data Dictionary v1.1
-        - IBM SLS v3.11
-  known_issues: |
-    - Customers using Maximo Assist v8.7 or v8.8 should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
+  whats_new:
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0, v9.1
+    - IBM Maximo Assist v9.0
+    - IBM Maximo IoT v8.7, v8.8 and v9.0
+    - IBM Maximo Manage v8.7, v8.6, v9.0 and v9.1
+    - IBM Maximo Monitor v8.11, v8.10 and v9.0
+    - IBM Maximo Optimizer v8.5, v8.4, v9.0 and v9.1
+    - IBM Maximo Predict v9.0, v8.9, v8.8
+    - IBM Maximo Visual Inspection v8.9, v9.0 and v9.1
+    - IBM Data Dictionary v1.1
+    - IBM SLS v3.11
+  known_issues:
+  - title: Customers using Maximo Assist v8.7 or v8.8 should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0

--- a/src/mas/devops/data/catalogs/v9-250306-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250306-amd64.yaml
@@ -113,3 +113,19 @@ amlen_extras_version: 1.1.2
 # Default Cloud Pak for Data version
 # ------------------------------------------------------------------------------
 cpd_product_version_default: 5.0.0
+
+editorial:
+  whats_new: |
+    - **Security updates and bug fixes**
+        - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0, v9.1
+        - IBM Maximo Assist v9.0
+        - IBM Maximo IoT v8.7, v8.8 and v9.0
+        - IBM Maximo Manage v8.7, v8.6, v9.0 and v9.1
+        - IBM Maximo Monitor v8.11, v8.10 and v9.0
+        - IBM Maximo Optimizer v8.5, v8.4, v9.0 and v9.1
+        - IBM Maximo Predict v9.0, v8.9, v8.8
+        - IBM Maximo Visual Inspection v8.9, v9.0 and v9.1
+        - IBM Data Dictionary v1.1
+        - IBM SLS v3.11
+  known_issues: |
+    - Customers using Maximo Assist v8.7 or v8.8 should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0

--- a/src/mas/devops/data/catalogs/v9-250306-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-250306-s390x.yaml
@@ -45,8 +45,10 @@ mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
 
 editorial:
-  whats_new: |
-    - **Security updates and bug fixes**
-        - IBM Maximo Application Suite Core Platform v9.0 & v9.1
-        - IBM Maximo Manage v9.0 & v9.1
-        - IBM SLS v3.0
+  whats_new:
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v9.0 & v9.1
+    - IBM Maximo Manage v9.0 & v9.1
+    - IBM SLS v3.0
+  known_issues: []

--- a/src/mas/devops/data/catalogs/v9-250306-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-250306-s390x.yaml
@@ -43,3 +43,10 @@ mongo_extras_version_4: 4.4.21
 mongo_extras_version_5: 5.0.23
 mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
+
+editorial:
+  whats_new: |
+    - **Security updates and bug fixes**
+        - IBM Maximo Application Suite Core Platform v9.0 & v9.1
+        - IBM Maximo Manage v9.0 & v9.1
+        - IBM SLS v3.0

--- a/src/mas/devops/data/catalogs/v9-250403-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250403-amd64.yaml
@@ -113,3 +113,19 @@ amlen_extras_version: 1.1.2
 # Default Cloud Pak for Data version
 # ------------------------------------------------------------------------------
 cpd_product_version_default: 5.0.0
+
+editorial:
+  whats_new: |
+    - **Security updates and bug fixes**
+        - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0
+        - IBM Maximo IoT v8.7, v8.8 and v9.0
+        - IBM Maximo Manage v8.7, v8.6, v9.0
+        - IBM Maximo Monitor v8.11, v8.10 and v9.0
+        - IBM Maximo Optimizer v8.5, v8.4, v9.0
+        - IBM Maximo Predict v9.0, v8.9, v8.8
+        - IBM Maximo Visual Inspection v8.9, v9.0
+        - IBM Data Dictionary v1.1
+  known_issues: |
+    - Customers using Maximo Assist v8.7 or v8.8 should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
+    - If your Maximo usage is significantly reliant on Maximo Mobile / Maximo's Role Based Applications, it is advised to bypass this Patch 9.0.11 release and await the subsequent patch release for 9.0.12 . Due to the recently encountered issue, this particular patch may not function as intended for Maximo Mobile/Role Based Applications' work order Change Status feature if you have industry solutions layered on top of the core Manage. However, if you still need to apply this patch, we can offer a Limited Availability Fix (LA Fix) in the event you encounter this issue. Please note that you will need to submit a LA Fix request for this
+    - You can click the link below for further details. <a href="https://www.ibm.com/support/pages/bmxaa9238e-when-changing-status-wo-after-applying-managemobile-9011"> www.ibm.com/support/pages/bmxaa9238e-when-changing-status-wo-after-applying-managemobile-9011 </a>

--- a/src/mas/devops/data/catalogs/v9-250403-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250403-amd64.yaml
@@ -115,17 +115,18 @@ amlen_extras_version: 1.1.2
 cpd_product_version_default: 5.0.0
 
 editorial:
-  whats_new: |
-    - **Security updates and bug fixes**
-        - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0
-        - IBM Maximo IoT v8.7, v8.8 and v9.0
-        - IBM Maximo Manage v8.7, v8.6, v9.0
-        - IBM Maximo Monitor v8.11, v8.10 and v9.0
-        - IBM Maximo Optimizer v8.5, v8.4, v9.0
-        - IBM Maximo Predict v9.0, v8.9, v8.8
-        - IBM Maximo Visual Inspection v8.9, v9.0
-        - IBM Data Dictionary v1.1
-  known_issues: |
-    - Customers using Maximo Assist v8.7 or v8.8 should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
-    - If your Maximo usage is significantly reliant on Maximo Mobile / Maximo's Role Based Applications, it is advised to bypass this Patch 9.0.11 release and await the subsequent patch release for 9.0.12 . Due to the recently encountered issue, this particular patch may not function as intended for Maximo Mobile/Role Based Applications' work order Change Status feature if you have industry solutions layered on top of the core Manage. However, if you still need to apply this patch, we can offer a Limited Availability Fix (LA Fix) in the event you encounter this issue. Please note that you will need to submit a LA Fix request for this
-    - You can click the link below for further details. <a href="https://www.ibm.com/support/pages/bmxaa9238e-when-changing-status-wo-after-applying-managemobile-9011"> www.ibm.com/support/pages/bmxaa9238e-when-changing-status-wo-after-applying-managemobile-9011 </a>
+  whats_new:
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0
+    - IBM Maximo IoT v8.7, v8.8 and v9.0
+    - IBM Maximo Manage v8.7, v8.6, v9.0
+    - IBM Maximo Monitor v8.11, v8.10 and v9.0
+    - IBM Maximo Optimizer v8.5, v8.4, v9.0
+    - IBM Maximo Predict v9.0, v8.9, v8.8
+    - IBM Maximo Visual Inspection v8.9, v9.0
+    - IBM Data Dictionary v1.1
+  known_issues:
+  - title: Customers using Maximo Assist v8.7 or v8.8 should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
+  - title: If your Maximo usage is significantly reliant on Maximo Mobile / Maximo's Role Based Applications, it is advised to bypass this Patch 9.0.11 release and await the subsequent patch release for 9.0.12 . Due to the recently encountered issue, this particular patch may not function as intended for Maximo Mobile/Role Based Applications' work order Change Status feature if you have industry solutions layered on top of the core Manage. However, if you still need to apply this patch, we can offer a Limited Availability Fix (LA Fix) in the event you encounter this issue. Please note that you will need to submit a LA Fix request for this
+  - title: You can click the link below for further details. <a href="https://www.ibm.com/support/pages/bmxaa9238e-when-changing-status-wo-after-applying-managemobile-9011"> www.ibm.com/support/pages/bmxaa9238e-when-changing-status-wo-after-applying-managemobile-9011 </a>

--- a/src/mas/devops/data/catalogs/v9-250403-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-250403-s390x.yaml
@@ -45,7 +45,9 @@ mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
 
 editorial:
-  whats_new: |
-    - **Security updates and bug fixes**
-        - IBM Maximo Application Suite Core Platform v9.0
-        - IBM Maximo Manage v9.0
+  whats_new:
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v9.0
+    - IBM Maximo Manage v9.0
+  known_issues: []

--- a/src/mas/devops/data/catalogs/v9-250403-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-250403-s390x.yaml
@@ -43,3 +43,9 @@ mongo_extras_version_4: 4.4.21
 mongo_extras_version_5: 5.0.23
 mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
+
+editorial:
+  whats_new: |
+    - **Security updates and bug fixes**
+        - IBM Maximo Application Suite Core Platform v9.0
+        - IBM Maximo Manage v9.0

--- a/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
@@ -113,3 +113,18 @@ amlen_extras_version: 1.1.2
 # Default Cloud Pak for Data version
 # ------------------------------------------------------------------------------
 cpd_product_version_default: 5.0.0
+
+editorial:
+  whats_new: |
+    - **Security updates and bug fixes**
+        - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0 and v9.1
+        - IBM Maximo IoT v8.7, v8.8 and v9.0
+        - IBM Maximo Manage v8.7, v8.6, v9.0 and v9.1
+        - IBM Maximo Monitor v8.11, v8.10 and v9.0
+        - IBM Maximo Optimizer v8.5, v8.4, v9.0 and v9.1
+        - IBM Maximo Predict v9.0, v8.9, v8.8
+        - IBM Maximo Visual Inspection v8.9, v9.0 and v9.1
+        - IBM Data Dictionary v1.1
+  known_issues: |
+    - Customers using Maximo Assist v8.7 or v8.8 should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
+    - For Airgap users, please review the [technote regarding a known Multi-Arch limitation](https://www.ibm.com/support/pages/node/7232093) before attempting installation.

--- a/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-amd64.yaml
@@ -115,16 +115,17 @@ amlen_extras_version: 1.1.2
 cpd_product_version_default: 5.0.0
 
 editorial:
-  whats_new: |
-    - **Security updates and bug fixes**
-        - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0 and v9.1
-        - IBM Maximo IoT v8.7, v8.8 and v9.0
-        - IBM Maximo Manage v8.7, v8.6, v9.0 and v9.1
-        - IBM Maximo Monitor v8.11, v8.10 and v9.0
-        - IBM Maximo Optimizer v8.5, v8.4, v9.0 and v9.1
-        - IBM Maximo Predict v9.0, v8.9, v8.8
-        - IBM Maximo Visual Inspection v8.9, v9.0 and v9.1
-        - IBM Data Dictionary v1.1
-  known_issues: |
-    - Customers using Maximo Assist v8.7 or v8.8 should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
-    - For Airgap users, please review the [technote regarding a known Multi-Arch limitation](https://www.ibm.com/support/pages/node/7232093) before attempting installation.
+  whats_new:
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0 and v9.1
+    - IBM Maximo IoT v8.7, v8.8 and v9.0
+    - IBM Maximo Manage v8.7, v8.6, v9.0 and v9.1
+    - IBM Maximo Monitor v8.11, v8.10 and v9.0
+    - IBM Maximo Optimizer v8.5, v8.4, v9.0 and v9.1
+    - IBM Maximo Predict v9.0, v8.9, v8.8
+    - IBM Maximo Visual Inspection v8.9, v9.0 and v9.1
+    - IBM Data Dictionary v1.1
+  known_issues:
+  - title: Customers using Maximo Assist v8.7 or v8.8 should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
+  - title: For Airgap users, please review the [technote regarding a known Multi-Arch limitation](https://www.ibm.com/support/pages/node/7232093) before attempting installation.

--- a/src/mas/devops/data/catalogs/v9-250501-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-s390x.yaml
@@ -45,7 +45,9 @@ mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
 
 editorial:
-  whats_new: |
-    - **Security updates and bug fixes**
-        - IBM Maximo Application Suite Core Platform v9.0
-        - IBM Maximo Manage v9.0
+  whats_new:
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v9.0
+    - IBM Maximo Manage v9.0
+  known_issues: []

--- a/src/mas/devops/data/catalogs/v9-250501-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-250501-s390x.yaml
@@ -43,3 +43,9 @@ mongo_extras_version_4: 4.4.21
 mongo_extras_version_5: 5.0.23
 mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
+
+editorial:
+  whats_new: |
+    - **Security updates and bug fixes**
+        - IBM Maximo Application Suite Core Platform v9.0
+        - IBM Maximo Manage v9.0

--- a/src/mas/devops/data/catalogs/v9-250624-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250624-amd64.yaml
@@ -142,33 +142,33 @@ cpd_product_version_default: 5.1.3
 kmodels_extras_version_default: 1.0.11
 
 editorial:
-  whats_new: |
-    - **New feature release**
-        - IBM Maximo Application Suite Core Platform v9.1
-        - IBM Maximo Manage v9.1
-        - IBM Maximo IoT v9.1
-        - IBM Maximo Monitor v9.1
-        - IBM Maximo Optimizer v9.1
-        - IBM Maximo Predict v9.1
-        - IBM Maximo Visual Inspection v9.1
-        - IBM MAS Assist v9.1
-        - IBM Maximo Real Estate and Facilities v9.1
-        - IBM Maximo Location Service for Esri v9.1
-    - **Security updates and bug fixes**
-        - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0
-        - IBM Maximo IoT v8.7, v8.8, v9.0
-        - IBM Maximo Manage v8.6, v8.7, v9.0
-        - IBM Maximo Monitor v8.10, v8.11, v9.0
-        - IBM Maximo Optimizer v8.4, v8.5, v9.0
-        - IBM MAS Assist v9.0
-        - IBM Data Dictionary v1.1
-        - IBM Suite License Service v3
-        - IBM Truststore Manager v1.7
-    
-    - **Openshift 4.18 support** Openshift Container Platform 4.18 support has been added. Refer OCP 4.18 release notes [here](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/release_notes/index)
-    
-    Reminder
-    -------------------------------------------------------------------------------
-    - MAS 8.10 and 8.11 standard support and software updates end in March 2026, to ensure you are able to continue to receive monthly security updates and bug fixes we advise all customers to begin making upgrade plans to get to MAS 9.0 if you have not already done so.
-  known_issues: |
-    - Customers using Maximo Assist v8.7 or v8.8 should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
+  whats_new:
+  - title: '**New feature release**'
+    details:
+    - IBM Maximo Application Suite Core Platform v9.1
+    - IBM Maximo Manage v9.1
+    - IBM Maximo IoT v9.1
+    - IBM Maximo Monitor v9.1
+    - IBM Maximo Optimizer v9.1
+    - IBM Maximo Predict v9.1
+    - IBM Maximo Visual Inspection v9.1
+    - IBM MAS Assist v9.1
+    - IBM Maximo Real Estate and Facilities v9.1
+    - IBM Maximo Location Service for Esri v9.1
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0
+    - IBM Maximo IoT v8.7, v8.8, v9.0
+    - IBM Maximo Manage v8.6, v8.7, v9.0
+    - IBM Maximo Monitor v8.10, v8.11, v9.0
+    - IBM Maximo Optimizer v8.4, v8.5, v9.0
+    - IBM MAS Assist v9.0
+    - IBM Data Dictionary v1.1
+    - IBM Suite License Service v3
+    - IBM Truststore Manager v1.7
+  - title: '**Openshift 4.18 support** Openshift Container Platform 4.18 support has been added. Refer OCP 4.18 release notes [here](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/release_notes/index)'
+    details: []
+  - title: MAS 8.10 and 8.11 standard support and software updates end in March 2026, to ensure you are able to continue to receive monthly security updates and bug fixes we advise all customers to begin making upgrade plans to get to MAS 9.0 if you have not already done so.
+    details: []
+  known_issues:
+  - title: Customers using Maximo Assist v8.7 or v8.8 should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0

--- a/src/mas/devops/data/catalogs/v9-250624-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250624-amd64.yaml
@@ -140,3 +140,35 @@ cpd_product_version_default: 5.1.3
 # Extra Images for kmodels
 # ------------------------------------------------------------------------------
 kmodels_extras_version_default: 1.0.11
+
+editorial:
+  whats_new: |
+    - **New feature release**
+        - IBM Maximo Application Suite Core Platform v9.1
+        - IBM Maximo Manage v9.1
+        - IBM Maximo IoT v9.1
+        - IBM Maximo Monitor v9.1
+        - IBM Maximo Optimizer v9.1
+        - IBM Maximo Predict v9.1
+        - IBM Maximo Visual Inspection v9.1
+        - IBM MAS Assist v9.1
+        - IBM Maximo Real Estate and Facilities v9.1
+        - IBM Maximo Location Service for Esri v9.1
+    - **Security updates and bug fixes**
+        - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0
+        - IBM Maximo IoT v8.7, v8.8, v9.0
+        - IBM Maximo Manage v8.6, v8.7, v9.0
+        - IBM Maximo Monitor v8.10, v8.11, v9.0
+        - IBM Maximo Optimizer v8.4, v8.5, v9.0
+        - IBM MAS Assist v9.0
+        - IBM Data Dictionary v1.1
+        - IBM Suite License Service v3
+        - IBM Truststore Manager v1.7
+    
+    - **Openshift 4.18 support** Openshift Container Platform 4.18 support has been added. Refer OCP 4.18 release notes [here](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/release_notes/index)
+    
+    Reminder
+    -------------------------------------------------------------------------------
+    - MAS 8.10 and 8.11 standard support and software updates end in March 2026, to ensure you are able to continue to receive monthly security updates and bug fixes we advise all customers to begin making upgrade plans to get to MAS 9.0 if you have not already done so.
+  known_issues: |
+    - Customers using Maximo Assist v8.7 or v8.8 should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0

--- a/src/mas/devops/data/catalogs/v9-250624-ppc64le.yaml
+++ b/src/mas/devops/data/catalogs/v9-250624-ppc64le.yaml
@@ -48,14 +48,17 @@ mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
 
 editorial:
-  whats_new: |
-    - **New feature release**
-        - IBM Maximo Application Suite Core Platform v9.1
-        - IBM Maximo Manage v9.1
-    - **Security updates and bug fixes**
-        - IBM Maximo Application Suite Core Platform v9.0
-        - IBM Maximo Manage v9.0
-        - IBM Suite License Service v3
-        - IBM Truststore Manager v1.7
-    
-    - **Openshift 4.18 support** Openshift Container Platform 4.18 support has been added. Refer OCP 4.18 release notes [here](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/release_notes/index)
+  whats_new:
+  - title: '**New feature release**'
+    details:
+    - IBM Maximo Application Suite Core Platform v9.1
+    - IBM Maximo Manage v9.1
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v9.0
+    - IBM Maximo Manage v9.0
+    - IBM Suite License Service v3
+    - IBM Truststore Manager v1.7
+  - title: '**Openshift 4.18 support** Openshift Container Platform 4.18 support has been added. Refer OCP 4.18 release notes [here](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/release_notes/index)'
+    details: []
+  known_issues: []

--- a/src/mas/devops/data/catalogs/v9-250624-ppc64le.yaml
+++ b/src/mas/devops/data/catalogs/v9-250624-ppc64le.yaml
@@ -46,3 +46,16 @@ mongo_extras_version_4: 4.4.21
 mongo_extras_version_5: 5.0.23
 mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
+
+editorial:
+  whats_new: |
+    - **New feature release**
+        - IBM Maximo Application Suite Core Platform v9.1
+        - IBM Maximo Manage v9.1
+    - **Security updates and bug fixes**
+        - IBM Maximo Application Suite Core Platform v9.0
+        - IBM Maximo Manage v9.0
+        - IBM Suite License Service v3
+        - IBM Truststore Manager v1.7
+    
+    - **Openshift 4.18 support** Openshift Container Platform 4.18 support has been added. Refer OCP 4.18 release notes [here](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/release_notes/index)

--- a/src/mas/devops/data/catalogs/v9-250624-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-250624-s390x.yaml
@@ -48,14 +48,17 @@ mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
 
 editorial:
-  whats_new: |
-    - **New feature release**
-        - IBM Maximo Application Suite Core Platform v9.1
-        - IBM Maximo Manage v9.1
-    - **Security updates and bug fixes**
-        - IBM Maximo Application Suite Core Platform v9.0
-        - IBM Maximo Manage v9.0
-        - IBM Suite License Service v3
-        - IBM Truststore Manager v1.7
-    
-    - **Openshift 4.18 support** Openshift Container Platform 4.18 support has been added. Refer OCP 4.18 release notes [here](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/release_notes/index)
+  whats_new:
+  - title: '**New feature release**'
+    details:
+    - IBM Maximo Application Suite Core Platform v9.1
+    - IBM Maximo Manage v9.1
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v9.0
+    - IBM Maximo Manage v9.0
+    - IBM Suite License Service v3
+    - IBM Truststore Manager v1.7
+  - title: '**Openshift 4.18 support** Openshift Container Platform 4.18 support has been added. Refer OCP 4.18 release notes [here](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/release_notes/index)'
+    details: []
+  known_issues: []

--- a/src/mas/devops/data/catalogs/v9-250624-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-250624-s390x.yaml
@@ -46,3 +46,16 @@ mongo_extras_version_4: 4.4.21
 mongo_extras_version_5: 5.0.23
 mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
+
+editorial:
+  whats_new: |
+    - **New feature release**
+        - IBM Maximo Application Suite Core Platform v9.1
+        - IBM Maximo Manage v9.1
+    - **Security updates and bug fixes**
+        - IBM Maximo Application Suite Core Platform v9.0
+        - IBM Maximo Manage v9.0
+        - IBM Suite License Service v3
+        - IBM Truststore Manager v1.7
+    
+    - **Openshift 4.18 support** Openshift Container Platform 4.18 support has been added. Refer OCP 4.18 release notes [here](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/release_notes/index)

--- a/src/mas/devops/data/catalogs/v9-250731-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250731-amd64.yaml
@@ -129,3 +129,25 @@ amlen_extras_version: 1.1.3
 # Default Cloud Pak for Data version
 # ------------------------------------------------------------------------------
 cpd_product_version_default: 5.1.3
+
+editorial:
+  whats_new: |
+    - **Support for MongoDb v7.0.22**
+    - **Security updates and bug fixes**
+        - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0 and v9.1
+        - IBM Maximo IoT v8.7, v8.8, v9.0 and v9.1
+        - IBM Maximo Manage v8.6, v8.7, v9.0 and v9.1
+        - IBM Maximo Monitor v8.10, v8.11, v9.0 and v9.1
+        - IBM Maximo Optimizer v8.4, v8.5, v9.0 and v9.1
+        - IBM Maximo Assist v9.0
+        - IBM Maximo Predict v8.9, v8.8, v9.0 and v9.1
+        - IBM Maximo Visual Inspection v9.0
+        - IBM Maximo Real Estate and Facilities v9.1
+        - IBM Maximo AiBroker v9.1
+        - IBM Suite License Service v3.12
+    
+    Reminder
+    -------------------------------------------------------------------------------
+    - MAS 8.10 and 8.11 standard support and software updates end in March 2026, to ensure you are able to continue to receive monthly security updates and bug fixes we advise all customers to begin making upgrade plans to get to MAS 9.0 if you have not already done so.
+  known_issues: |
+    - Customers using Maximo Assist v8.7 or v8.8 should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0

--- a/src/mas/devops/data/catalogs/v9-250731-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250731-amd64.yaml
@@ -131,23 +131,23 @@ amlen_extras_version: 1.1.3
 cpd_product_version_default: 5.1.3
 
 editorial:
-  whats_new: |
-    - **Support for MongoDb v7.0.22**
-    - **Security updates and bug fixes**
-        - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0 and v9.1
-        - IBM Maximo IoT v8.7, v8.8, v9.0 and v9.1
-        - IBM Maximo Manage v8.6, v8.7, v9.0 and v9.1
-        - IBM Maximo Monitor v8.10, v8.11, v9.0 and v9.1
-        - IBM Maximo Optimizer v8.4, v8.5, v9.0 and v9.1
-        - IBM Maximo Assist v9.0
-        - IBM Maximo Predict v8.9, v8.8, v9.0 and v9.1
-        - IBM Maximo Visual Inspection v9.0
-        - IBM Maximo Real Estate and Facilities v9.1
-        - IBM Maximo AiBroker v9.1
-        - IBM Suite License Service v3.12
-    
-    Reminder
-    -------------------------------------------------------------------------------
-    - MAS 8.10 and 8.11 standard support and software updates end in March 2026, to ensure you are able to continue to receive monthly security updates and bug fixes we advise all customers to begin making upgrade plans to get to MAS 9.0 if you have not already done so.
-  known_issues: |
-    - Customers using Maximo Assist v8.7 or v8.8 should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
+  whats_new:
+  - title: '**Support for MongoDb v7.0.22**'
+    details: []
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0 and v9.1
+    - IBM Maximo IoT v8.7, v8.8, v9.0 and v9.1
+    - IBM Maximo Manage v8.6, v8.7, v9.0 and v9.1
+    - IBM Maximo Monitor v8.10, v8.11, v9.0 and v9.1
+    - IBM Maximo Optimizer v8.4, v8.5, v9.0 and v9.1
+    - IBM Maximo Assist v9.0
+    - IBM Maximo Predict v8.9, v8.8, v9.0 and v9.1
+    - IBM Maximo Visual Inspection v9.0
+    - IBM Maximo Real Estate and Facilities v9.1
+    - IBM Maximo AiBroker v9.1
+    - IBM Suite License Service v3.12
+  - title: MAS 8.10 and 8.11 standard support and software updates end in March 2026, to ensure you are able to continue to receive monthly security updates and bug fixes we advise all customers to begin making upgrade plans to get to MAS 9.0 if you have not already done so.
+    details: []
+  known_issues:
+  - title: Customers using Maximo Assist v8.7 or v8.8 should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0

--- a/src/mas/devops/data/catalogs/v9-250731-ppc64le.yaml
+++ b/src/mas/devops/data/catalogs/v9-250731-ppc64le.yaml
@@ -40,3 +40,10 @@ mongo_extras_version_4: 4.4.21
 mongo_extras_version_5: 5.0.23
 mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
+
+editorial:
+  whats_new: |
+    - **Security updates and bug fixes**
+        - IBM Maximo Application Suite Core Platform v9.0 and 9.1
+        - IBM Maximo Manage v9.0 and 9.1
+        - IBM Suite License Service v3.12

--- a/src/mas/devops/data/catalogs/v9-250731-ppc64le.yaml
+++ b/src/mas/devops/data/catalogs/v9-250731-ppc64le.yaml
@@ -42,8 +42,10 @@ mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
 
 editorial:
-  whats_new: |
-    - **Security updates and bug fixes**
-        - IBM Maximo Application Suite Core Platform v9.0 and 9.1
-        - IBM Maximo Manage v9.0 and 9.1
-        - IBM Suite License Service v3.12
+  whats_new:
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v9.0 and 9.1
+    - IBM Maximo Manage v9.0 and 9.1
+    - IBM Suite License Service v3.12
+  known_issues: []

--- a/src/mas/devops/data/catalogs/v9-250731-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-250731-s390x.yaml
@@ -42,8 +42,10 @@ mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
 
 editorial:
-  whats_new: |
-    - **Security updates and bug fixes**
-        - IBM Maximo Application Suite Core Platform v9.0 and v9.1
-        - IBM Maximo Manage v9.0 and 9.1
-        - IBM Suite License Service v3.12
+  whats_new:
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v9.0 and v9.1
+    - IBM Maximo Manage v9.0 and 9.1
+    - IBM Suite License Service v3.12
+  known_issues: []

--- a/src/mas/devops/data/catalogs/v9-250731-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-250731-s390x.yaml
@@ -40,3 +40,10 @@ mongo_extras_version_4: 4.4.21
 mongo_extras_version_5: 5.0.23
 mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
+
+editorial:
+  whats_new: |
+    - **Security updates and bug fixes**
+        - IBM Maximo Application Suite Core Platform v9.0 and v9.1
+        - IBM Maximo Manage v9.0 and 9.1
+        - IBM Suite License Service v3.12

--- a/src/mas/devops/data/catalogs/v9-250828-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250828-amd64.yaml
@@ -142,3 +142,24 @@ cpd_product_version_default: 5.1.3
 # ------------------------------------------------------------------------------
 kmodels_extras_version_default: 1.0.14
 
+
+editorial:
+  whats_new: |
+    - **New Release**
+        - IBM Maximo AI Service v9.1
+    - **Security updates and bug fixes**
+        - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0 and v9.1
+        - IBM Maximo IoT v8.7, v8.8, v9.0 and v9.1
+        - IBM Maximo Manage v8.6, v8.7, v9.0 and v9.1
+        - IBM Maximo Monitor v8.10, v8.11, v9.0 and v9.1
+        - IBM Maximo Optimizer v8.4, v8.5, v9.0 and v9.1
+        - IBM Maximo Assist v9.1 and v9.0
+        - IBM Maximo Predict v8.9, v8.8, v9.0 and v9.1
+        - IBM Maximo Visual Inspection  v8.9, v9.0 and v9.1
+        - IBM Maximo Real Estate and Facilities v9.1
+        - IBM Suite License Service v3.12
+  known_issues: |
+    - Customers using **Maximo Assist v8.7 or v8.8** should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
+    - Customers running **Maximo Manage v8.7** with the Civil application in a disconnected environment are advised to skip this update due to a packaging error which will result in a failure to pull the `extension-civil` container image
+    - Customers are advised not to use the catalog `v9-250828` for AIService due to an issue with AIService `9.1.5`.
+      Please use the 2nd Sep catalog `v9-250902` with AIService `9.1.6`.

--- a/src/mas/devops/data/catalogs/v9-250828-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250828-amd64.yaml
@@ -144,22 +144,23 @@ kmodels_extras_version_default: 1.0.14
 
 
 editorial:
-  whats_new: |
-    - **New Release**
-        - IBM Maximo AI Service v9.1
-    - **Security updates and bug fixes**
-        - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0 and v9.1
-        - IBM Maximo IoT v8.7, v8.8, v9.0 and v9.1
-        - IBM Maximo Manage v8.6, v8.7, v9.0 and v9.1
-        - IBM Maximo Monitor v8.10, v8.11, v9.0 and v9.1
-        - IBM Maximo Optimizer v8.4, v8.5, v9.0 and v9.1
-        - IBM Maximo Assist v9.1 and v9.0
-        - IBM Maximo Predict v8.9, v8.8, v9.0 and v9.1
-        - IBM Maximo Visual Inspection  v8.9, v9.0 and v9.1
-        - IBM Maximo Real Estate and Facilities v9.1
-        - IBM Suite License Service v3.12
-  known_issues: |
-    - Customers using **Maximo Assist v8.7 or v8.8** should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
-    - Customers running **Maximo Manage v8.7** with the Civil application in a disconnected environment are advised to skip this update due to a packaging error which will result in a failure to pull the `extension-civil` container image
-    - Customers are advised not to use the catalog `v9-250828` for AIService due to an issue with AIService `9.1.5`.
-      Please use the 2nd Sep catalog `v9-250902` with AIService `9.1.6`.
+  whats_new:
+  - title: '**New Release**'
+    details:
+    - IBM Maximo AI Service v9.1
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0 and v9.1
+    - IBM Maximo IoT v8.7, v8.8, v9.0 and v9.1
+    - IBM Maximo Manage v8.6, v8.7, v9.0 and v9.1
+    - IBM Maximo Monitor v8.10, v8.11, v9.0 and v9.1
+    - IBM Maximo Optimizer v8.4, v8.5, v9.0 and v9.1
+    - IBM Maximo Assist v9.1 and v9.0
+    - IBM Maximo Predict v8.9, v8.8, v9.0 and v9.1
+    - IBM Maximo Visual Inspection  v8.9, v9.0 and v9.1
+    - IBM Maximo Real Estate and Facilities v9.1
+    - IBM Suite License Service v3.12
+  known_issues:
+  - title: Customers using **Maximo Assist v8.7 or v8.8** should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
+  - title: Customers running **Maximo Manage v8.7** with the Civil application in a disconnected environment are advised to skip this update due to a packaging error which will result in a failure to pull the `extension-civil` container image
+  - title: Customers are advised not to use the catalog `v9-250828` for AIService due to an issue with AIService `9.1.5`. Please use the 2nd Sep catalog `v9-250902` with AIService `9.1.6`.

--- a/src/mas/devops/data/catalogs/v9-250828-ppc64le.yaml
+++ b/src/mas/devops/data/catalogs/v9-250828-ppc64le.yaml
@@ -49,8 +49,10 @@ mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
 
 editorial:
-  whats_new: |
-    - **Security updates and bug fixes**
-        - IBM Maximo Application Suite Core Platform v9.0 and 9.1
-        - IBM Maximo Manage v9.0 and 9.1
-        - IBM Suite License Service v3.12
+  whats_new:
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v9.0 and 9.1
+    - IBM Maximo Manage v9.0 and 9.1
+    - IBM Suite License Service v3.12
+  known_issues: []

--- a/src/mas/devops/data/catalogs/v9-250828-ppc64le.yaml
+++ b/src/mas/devops/data/catalogs/v9-250828-ppc64le.yaml
@@ -47,3 +47,10 @@ mongo_extras_version_4: 4.4.21
 mongo_extras_version_5: 5.0.23
 mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
+
+editorial:
+  whats_new: |
+    - **Security updates and bug fixes**
+        - IBM Maximo Application Suite Core Platform v9.0 and 9.1
+        - IBM Maximo Manage v9.0 and 9.1
+        - IBM Suite License Service v3.12

--- a/src/mas/devops/data/catalogs/v9-250828-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-250828-s390x.yaml
@@ -49,8 +49,10 @@ mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
 
 editorial:
-  whats_new: |
-    - **Security updates and bug fixes**
-        - IBM Maximo Application Suite Core Platform v9.0 and v9.1
-        - IBM Maximo Manage v9.0 and 9.1
-        - IBM Suite License Service v3.12
+  whats_new:
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v9.0 and v9.1
+    - IBM Maximo Manage v9.0 and 9.1
+    - IBM Suite License Service v3.12
+  known_issues: []

--- a/src/mas/devops/data/catalogs/v9-250828-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-250828-s390x.yaml
@@ -47,3 +47,10 @@ mongo_extras_version_4: 4.4.21
 mongo_extras_version_5: 5.0.23
 mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
+
+editorial:
+  whats_new: |
+    - **Security updates and bug fixes**
+        - IBM Maximo Application Suite Core Platform v9.0 and v9.1
+        - IBM Maximo Manage v9.0 and 9.1
+        - IBM Suite License Service v3.12

--- a/src/mas/devops/data/catalogs/v9-250902-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250902-amd64.yaml
@@ -143,3 +143,11 @@ cpd_product_version_default: 5.1.3
 kmodels_extras_version_default: 1.0.14
 minio_version: RELEASE.2025-06-13T11-33-47Z
 
+
+editorial:
+  whats_new: |
+    - **Security updates and bug fixes**
+        - IBM Maximo AI Service v9.1
+  known_issues: |
+    - Customers using **Maximo Assist v8.7 or v8.8** should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
+    - Customers running **Maximo Manage v8.7** with the Civil application in a disconnected environment are advised to skip this update due to a packaging error which will result in a failure to pull the `extension-civil` container image

--- a/src/mas/devops/data/catalogs/v9-250902-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250902-amd64.yaml
@@ -145,9 +145,10 @@ minio_version: RELEASE.2025-06-13T11-33-47Z
 
 
 editorial:
-  whats_new: |
-    - **Security updates and bug fixes**
-        - IBM Maximo AI Service v9.1
-  known_issues: |
-    - Customers using **Maximo Assist v8.7 or v8.8** should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
-    - Customers running **Maximo Manage v8.7** with the Civil application in a disconnected environment are advised to skip this update due to a packaging error which will result in a failure to pull the `extension-civil` container image
+  whats_new:
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo AI Service v9.1
+  known_issues:
+  - title: Customers using **Maximo Assist v8.7 or v8.8** should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
+  - title: Customers running **Maximo Manage v8.7** with the Civil application in a disconnected environment are advised to skip this update due to a packaging error which will result in a failure to pull the `extension-civil` container image

--- a/src/mas/devops/data/catalogs/v9-250902-ppc64le.yaml
+++ b/src/mas/devops/data/catalogs/v9-250902-ppc64le.yaml
@@ -49,5 +49,7 @@ mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
 
 editorial:
-  whats_new: |
-    - NA
+  whats_new:
+  - title: NA
+    details: []
+  known_issues: []

--- a/src/mas/devops/data/catalogs/v9-250902-ppc64le.yaml
+++ b/src/mas/devops/data/catalogs/v9-250902-ppc64le.yaml
@@ -47,3 +47,7 @@ mongo_extras_version_4: 4.4.21
 mongo_extras_version_5: 5.0.23
 mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
+
+editorial:
+  whats_new: |
+    - NA

--- a/src/mas/devops/data/catalogs/v9-250902-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-250902-s390x.yaml
@@ -49,5 +49,7 @@ mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
 
 editorial:
-  whats_new: |
-    - NA
+  whats_new:
+  - title: NA
+    details: []
+  known_issues: []

--- a/src/mas/devops/data/catalogs/v9-250902-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-250902-s390x.yaml
@@ -47,3 +47,7 @@ mongo_extras_version_4: 4.4.21
 mongo_extras_version_5: 5.0.23
 mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
+
+editorial:
+  whats_new: |
+    - NA

--- a/src/mas/devops/data/catalogs/v9-250925-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250925-amd64.yaml
@@ -149,19 +149,21 @@ minio_version: RELEASE.2025-06-13T11-33-47Z
 manage_extras_913: 9.1.3
 
 editorial:
-  whats_new: |
-    - New **MAS 9.2 feature channels** for Core, Manage and Optimizer offering early access to some of the new features that will be included in the upcoming 9.2 release next year
-    - **Security updates and bug fixes**
-        - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0 and v9.1
-        - IBM Maximo IoT v8.7, v8.8, v9.0 and v9.1
-        - IBM Maximo Manage v8.6, v8.7, v9.0 and v9.1
-        - IBM Maximo Monitor v8.10, v8.11, v9.0 and v9.1
-        - IBM Maximo Optimizer v8.4, v8.5, v9.0 and v9.1
-        - IBM Maximo Assist v9.1 and v9.0
-        - IBM Maximo Predict v8.9, v8.8, v9.0 and v9.1
-        - IBM Maximo Visual Inspection  v8.9, v9.0 and v9.1
-        - IBM Maximo Real Estate and Facilities v9.1
-        - IBM Suite License Service v3.12
-  known_issues: |
-    - Customers using **Maximo Assist v8.7 or v8.8** should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
-    - If you have the Workday Connector installed and are upgrading from Manage 8.7.24 Multi-IS to Manage 9.0.17 (Online/Offline mode), it is advised to bypass this Patch 9.0.17 release due to a recently encountered error on build and await the subsequent patch release for 9.0.18. If you need to apply this patch, we can offer a Limited Availability Fix (LA Fix) in the event you encounter this issue. Please note that you will need to submit a LA Fix request for this.
+  whats_new:
+  - title: New **MAS 9.2 feature channels** for Core, Manage and Optimizer offering early access to some of the new features that will be included in the upcoming 9.2 release next year
+    details: []
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0 and v9.1
+    - IBM Maximo IoT v8.7, v8.8, v9.0 and v9.1
+    - IBM Maximo Manage v8.6, v8.7, v9.0 and v9.1
+    - IBM Maximo Monitor v8.10, v8.11, v9.0 and v9.1
+    - IBM Maximo Optimizer v8.4, v8.5, v9.0 and v9.1
+    - IBM Maximo Assist v9.1 and v9.0
+    - IBM Maximo Predict v8.9, v8.8, v9.0 and v9.1
+    - IBM Maximo Visual Inspection  v8.9, v9.0 and v9.1
+    - IBM Maximo Real Estate and Facilities v9.1
+    - IBM Suite License Service v3.12
+  known_issues:
+  - title: Customers using **Maximo Assist v8.7 or v8.8** should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
+  - title: If you have the Workday Connector installed and are upgrading from Manage 8.7.24 Multi-IS to Manage 9.0.17 (Online/Offline mode), it is advised to bypass this Patch 9.0.17 release due to a recently encountered error on build and await the subsequent patch release for 9.0.18. If you need to apply this patch, we can offer a Limited Availability Fix (LA Fix) in the event you encounter this issue. Please note that you will need to submit a LA Fix request for this.

--- a/src/mas/devops/data/catalogs/v9-250925-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-250925-amd64.yaml
@@ -147,3 +147,21 @@ kmodels_extras_version_default: 1.0.14
 minio_version: RELEASE.2025-06-13T11-33-47Z
 
 manage_extras_913: 9.1.3
+
+editorial:
+  whats_new: |
+    - New **MAS 9.2 feature channels** for Core, Manage and Optimizer offering early access to some of the new features that will be included in the upcoming 9.2 release next year
+    - **Security updates and bug fixes**
+        - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0 and v9.1
+        - IBM Maximo IoT v8.7, v8.8, v9.0 and v9.1
+        - IBM Maximo Manage v8.6, v8.7, v9.0 and v9.1
+        - IBM Maximo Monitor v8.10, v8.11, v9.0 and v9.1
+        - IBM Maximo Optimizer v8.4, v8.5, v9.0 and v9.1
+        - IBM Maximo Assist v9.1 and v9.0
+        - IBM Maximo Predict v8.9, v8.8, v9.0 and v9.1
+        - IBM Maximo Visual Inspection  v8.9, v9.0 and v9.1
+        - IBM Maximo Real Estate and Facilities v9.1
+        - IBM Suite License Service v3.12
+  known_issues: |
+    - Customers using **Maximo Assist v8.7 or v8.8** should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
+    - If you have the Workday Connector installed and are upgrading from Manage 8.7.24 Multi-IS to Manage 9.0.17 (Online/Offline mode), it is advised to bypass this Patch 9.0.17 release due to a recently encountered error on build and await the subsequent patch release for 9.0.18. If you need to apply this patch, we can offer a Limited Availability Fix (LA Fix) in the event you encounter this issue. Please note that you will need to submit a LA Fix request for this.

--- a/src/mas/devops/data/catalogs/v9-251010-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-251010-amd64.yaml
@@ -145,10 +145,11 @@ minio_version: RELEASE.2025-06-13T11-33-47Z
 manage_extras_913: 9.1.3
 
 editorial:
-  whats_new: |
-    - **Security updates and bug fixes**
-        - IBM Maximo Manage v9.1
-        - IBM Maximo Visual Inspection v9.1
-  known_issues: |
-    - Customers using **Maximo Assist v8.7 or v8.8** should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
-    - If you have the Workday Connector installed and are upgrading from Manage 8.7.24 Multi-IS to Manage 9.0.17 (Online/Offline mode), it is advised to bypass this Patch 9.0.17 release due to a recently encountered error on build and await the subsequent patch release for 9.0.18. If you need to apply this patch, we can offer a Limited Availability Fix (LA Fix) in the event you encounter this issue. Please note that you will need to submit a LA Fix request for this.
+  whats_new:
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Manage v9.1
+    - IBM Maximo Visual Inspection v9.1
+  known_issues:
+  - title: Customers using **Maximo Assist v8.7 or v8.8** should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
+  - title: If you have the Workday Connector installed and are upgrading from Manage 8.7.24 Multi-IS to Manage 9.0.17 (Online/Offline mode), it is advised to bypass this Patch 9.0.17 release due to a recently encountered error on build and await the subsequent patch release for 9.0.18. If you need to apply this patch, we can offer a Limited Availability Fix (LA Fix) in the event you encounter this issue. Please note that you will need to submit a LA Fix request for this.

--- a/src/mas/devops/data/catalogs/v9-251010-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-251010-amd64.yaml
@@ -143,3 +143,12 @@ kmodels_extras_version_default: 1.0.14
 minio_version: RELEASE.2025-06-13T11-33-47Z
 
 manage_extras_913: 9.1.3
+
+editorial:
+  whats_new: |
+    - **Security updates and bug fixes**
+        - IBM Maximo Manage v9.1
+        - IBM Maximo Visual Inspection v9.1
+  known_issues: |
+    - Customers using **Maximo Assist v8.7 or v8.8** should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
+    - If you have the Workday Connector installed and are upgrading from Manage 8.7.24 Multi-IS to Manage 9.0.17 (Online/Offline mode), it is advised to bypass this Patch 9.0.17 release due to a recently encountered error on build and await the subsequent patch release for 9.0.18. If you need to apply this patch, we can offer a Limited Availability Fix (LA Fix) in the event you encounter this issue. Please note that you will need to submit a LA Fix request for this.

--- a/src/mas/devops/data/catalogs/v9-251030-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-251030-amd64.yaml
@@ -142,18 +142,20 @@ manage_extras_913: 9.1.3
 minio_version: RELEASE.2025-06-13T11-33-47Z
 
 editorial:
-  whats_new: |
-    - OCP **4.19** Support
-    - **Security updates and bug fixes**
-        - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0 and v9.1
-        - IBM Maximo IoT v8.7, v8.8, v9.0 and v9.1
-        - IBM Maximo Manage v8.6, v8.7, v9.0 and v9.1
-        - IBM Maximo Monitor v8.10, v8.11, v9.0 and v9.1
-        - IBM Maximo Optimizer v8.4, v8.5, v9.0 and v9.1
-        - IBM Maximo Assist v9.1 and v9.0
-        - IBM Maximo Predict v8.9, v8.8, v9.0 and v9.1
-        - IBM Maximo Visual Inspection  v8.9 and v9.0
-        - IBM Maximo Real Estate and Facilities v9.1
-  known_issues: |
-    - Customers using **Maximo Assist v8.7 or v8.8** should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
-    - If you have the Workday Connector installed and are upgrading from Manage 8.7.24 Multi-IS to Manage 9.0.17 (Online/Offline mode), it is advised to bypass this Patch 9.0.17 release due to a recently encountered error on build and await the subsequent patch release for 9.0.18. If you need to apply this patch, we can offer a Limited Availability Fix (LA Fix) in the event you encounter this issue. Please note that you will need to submit a LA Fix request for this.
+  whats_new:
+  - title: OCP **4.19** Support
+    details: []
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0 and v9.1
+    - IBM Maximo IoT v8.7, v8.8, v9.0 and v9.1
+    - IBM Maximo Manage v8.6, v8.7, v9.0 and v9.1
+    - IBM Maximo Monitor v8.10, v8.11, v9.0 and v9.1
+    - IBM Maximo Optimizer v8.4, v8.5, v9.0 and v9.1
+    - IBM Maximo Assist v9.1 and v9.0
+    - IBM Maximo Predict v8.9, v8.8, v9.0 and v9.1
+    - IBM Maximo Visual Inspection  v8.9 and v9.0
+    - IBM Maximo Real Estate and Facilities v9.1
+  known_issues:
+  - title: Customers using **Maximo Assist v8.7 or v8.8** should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
+  - title: If you have the Workday Connector installed and are upgrading from Manage 8.7.24 Multi-IS to Manage 9.0.17 (Online/Offline mode), it is advised to bypass this Patch 9.0.17 release due to a recently encountered error on build and await the subsequent patch release for 9.0.18. If you need to apply this patch, we can offer a Limited Availability Fix (LA Fix) in the event you encounter this issue. Please note that you will need to submit a LA Fix request for this.

--- a/src/mas/devops/data/catalogs/v9-251030-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-251030-amd64.yaml
@@ -140,3 +140,20 @@ cpd_product_version_default: 5.1.3
 
 manage_extras_913: 9.1.3
 minio_version: RELEASE.2025-06-13T11-33-47Z
+
+editorial:
+  whats_new: |
+    - OCP **4.19** Support
+    - **Security updates and bug fixes**
+        - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0 and v9.1
+        - IBM Maximo IoT v8.7, v8.8, v9.0 and v9.1
+        - IBM Maximo Manage v8.6, v8.7, v9.0 and v9.1
+        - IBM Maximo Monitor v8.10, v8.11, v9.0 and v9.1
+        - IBM Maximo Optimizer v8.4, v8.5, v9.0 and v9.1
+        - IBM Maximo Assist v9.1 and v9.0
+        - IBM Maximo Predict v8.9, v8.8, v9.0 and v9.1
+        - IBM Maximo Visual Inspection  v8.9 and v9.0
+        - IBM Maximo Real Estate and Facilities v9.1
+  known_issues: |
+    - Customers using **Maximo Assist v8.7 or v8.8** should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
+    - If you have the Workday Connector installed and are upgrading from Manage 8.7.24 Multi-IS to Manage 9.0.17 (Online/Offline mode), it is advised to bypass this Patch 9.0.17 release due to a recently encountered error on build and await the subsequent patch release for 9.0.18. If you need to apply this patch, we can offer a Limited Availability Fix (LA Fix) in the event you encounter this issue. Please note that you will need to submit a LA Fix request for this.

--- a/src/mas/devops/data/catalogs/v9-251030-ppc64le.yaml
+++ b/src/mas/devops/data/catalogs/v9-251030-ppc64le.yaml
@@ -50,8 +50,11 @@ mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
 
 editorial:
-  whats_new: |
-    - OCP **4.19** Support
-    - **Security updates and bug fixes**
-        - IBM Maximo Application Suite Core Platform v9.0 and v9.1
-        - IBM Maximo Manage v9.0 and v9.1
+  whats_new:
+  - title: OCP **4.19** Support
+    details: []
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v9.0 and v9.1
+    - IBM Maximo Manage v9.0 and v9.1
+  known_issues: []

--- a/src/mas/devops/data/catalogs/v9-251030-ppc64le.yaml
+++ b/src/mas/devops/data/catalogs/v9-251030-ppc64le.yaml
@@ -48,3 +48,10 @@ mongo_extras_version_4: 4.4.21
 mongo_extras_version_5: 5.0.23
 mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
+
+editorial:
+  whats_new: |
+    - OCP **4.19** Support
+    - **Security updates and bug fixes**
+        - IBM Maximo Application Suite Core Platform v9.0 and v9.1
+        - IBM Maximo Manage v9.0 and v9.1

--- a/src/mas/devops/data/catalogs/v9-251030-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-251030-s390x.yaml
@@ -52,8 +52,11 @@ mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
 
 editorial:
-  whats_new: |
-    - OCP **4.19** Support
-    - **Security updates and bug fixes**
-        - IBM Maximo Application Suite Core Platform v9.0 and v9.1
-        - IBM Maximo Manage v9.0 and v9.1
+  whats_new:
+  - title: OCP **4.19** Support
+    details: []
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v9.0 and v9.1
+    - IBM Maximo Manage v9.0 and v9.1
+  known_issues: []

--- a/src/mas/devops/data/catalogs/v9-251030-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-251030-s390x.yaml
@@ -50,3 +50,10 @@ mongo_extras_version_4: 4.4.21
 mongo_extras_version_5: 5.0.23
 mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
+
+editorial:
+  whats_new: |
+    - OCP **4.19** Support
+    - **Security updates and bug fixes**
+        - IBM Maximo Application Suite Core Platform v9.0 and v9.1
+        - IBM Maximo Manage v9.0 and v9.1

--- a/src/mas/devops/data/catalogs/v9-251127-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-251127-amd64.yaml
@@ -141,20 +141,23 @@ manage_extras_913: 9.1.3
 minio_version: RELEASE.2025-06-13T11-33-47Z
 
 editorial:
-  whats_new: |
-    - MongoDb v8 support Running mas update will automatically upgrade existing MongoDbCommunity instances to MongoDb version 8. This upgrade is compatible with all MAS versions included in this catalog.
-    - End of support for Openshift Container Platform 4.14 and 4.15, which are both now out of support (Since May 1 2025 and August 27 2025 respectively).
-    - **Security updates and bug fixes**
-        - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0 and v9.1
-        - IBM Maximo Manage v8.6, v8.7, v9.0 and v9.1
-        - IBM Maximo IoT v8.7, v8.8, v9.0 and v9.1
-        - IBM Maximo Monitor v8.10, v8.11, v9.0 and v9.1
-        - IBM Maximo Optimizer v9.1
-        - IBM Maximo Assist v9.1 and v9.0
-        - IBM Maximo Visual Inspection v8.9, v9.0 and v9.1
-        - IBM Maximo Real Estate and Facilities v9.1
-        - IBM Maximo AI Service v9.1
-  known_issues: |
-    - Customers using **Maximo Assist v8.7 or v8.8** should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
-    - If you have the Workday Connector installed and are upgrading from Manage 8.7.24 Multi-IS to Manage 9.0.17 (Online/Offline mode), it is advised to bypass this Patch 9.0.17 release due to a recently encountered error on build and await the subsequent patch release for 9.0.18. If you need to apply this patch, we can offer a Limited Availability Fix (LA Fix) in the event you encounter this issue. Please note that you will need to submit a LA Fix request for this.
-    - Customers using FIPS should not upgrade their MREF to 9.1.5, since it has problems during initialization.
+  whats_new:
+  - title: MongoDb v8 support Running mas update will automatically upgrade existing MongoDbCommunity instances to MongoDb version 8. This upgrade is compatible with all MAS versions included in this catalog.
+    details: []
+  - title: End of support for Openshift Container Platform 4.14 and 4.15, which are both now out of support (Since May 1 2025 and August 27 2025 respectively).
+    details: []
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0 and v9.1
+    - IBM Maximo Manage v8.6, v8.7, v9.0 and v9.1
+    - IBM Maximo IoT v8.7, v8.8, v9.0 and v9.1
+    - IBM Maximo Monitor v8.10, v8.11, v9.0 and v9.1
+    - IBM Maximo Optimizer v9.1
+    - IBM Maximo Assist v9.1 and v9.0
+    - IBM Maximo Visual Inspection v8.9, v9.0 and v9.1
+    - IBM Maximo Real Estate and Facilities v9.1
+    - IBM Maximo AI Service v9.1
+  known_issues:
+  - title: Customers using **Maximo Assist v8.7 or v8.8** should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
+  - title: If you have the Workday Connector installed and are upgrading from Manage 8.7.24 Multi-IS to Manage 9.0.17 (Online/Offline mode), it is advised to bypass this Patch 9.0.17 release due to a recently encountered error on build and await the subsequent patch release for 9.0.18. If you need to apply this patch, we can offer a Limited Availability Fix (LA Fix) in the event you encounter this issue. Please note that you will need to submit a LA Fix request for this.
+  - title: Customers using FIPS should not upgrade their MREF to 9.1.5, since it has problems during initialization.

--- a/src/mas/devops/data/catalogs/v9-251127-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-251127-amd64.yaml
@@ -139,3 +139,22 @@ cpd_product_version_default: 5.1.3
 
 manage_extras_913: 9.1.3
 minio_version: RELEASE.2025-06-13T11-33-47Z
+
+editorial:
+  whats_new: |
+    - MongoDb v8 support Running mas update will automatically upgrade existing MongoDbCommunity instances to MongoDb version 8. This upgrade is compatible with all MAS versions included in this catalog.
+    - End of support for Openshift Container Platform 4.14 and 4.15, which are both now out of support (Since May 1 2025 and August 27 2025 respectively).
+    - **Security updates and bug fixes**
+        - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0 and v9.1
+        - IBM Maximo Manage v8.6, v8.7, v9.0 and v9.1
+        - IBM Maximo IoT v8.7, v8.8, v9.0 and v9.1
+        - IBM Maximo Monitor v8.10, v8.11, v9.0 and v9.1
+        - IBM Maximo Optimizer v9.1
+        - IBM Maximo Assist v9.1 and v9.0
+        - IBM Maximo Visual Inspection v8.9, v9.0 and v9.1
+        - IBM Maximo Real Estate and Facilities v9.1
+        - IBM Maximo AI Service v9.1
+  known_issues: |
+    - Customers using **Maximo Assist v8.7 or v8.8** should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
+    - If you have the Workday Connector installed and are upgrading from Manage 8.7.24 Multi-IS to Manage 9.0.17 (Online/Offline mode), it is advised to bypass this Patch 9.0.17 release due to a recently encountered error on build and await the subsequent patch release for 9.0.18. If you need to apply this patch, we can offer a Limited Availability Fix (LA Fix) in the event you encounter this issue. Please note that you will need to submit a LA Fix request for this.
+    - Customers using FIPS should not upgrade their MREF to 9.1.5, since it has problems during initialization.

--- a/src/mas/devops/data/catalogs/v9-251127-ppc64le.yaml
+++ b/src/mas/devops/data/catalogs/v9-251127-ppc64le.yaml
@@ -47,3 +47,10 @@ mongo_extras_version_5: 5.0.23
 mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
 mongo_extras_version_8: 8.0.13
+
+editorial:
+  whats_new: |
+    - End of support for Openshift Container Platform 4.14 and 4.15, which are both now out of support (Since May 1 2025 and August 27 2025 respectively).
+    - **Security updates and bug fixes**
+        - IBM Maximo Application Suite Core Platform v9.0 and v9.1
+        - IBM Maximo Manage v9.0 and v9.1

--- a/src/mas/devops/data/catalogs/v9-251127-ppc64le.yaml
+++ b/src/mas/devops/data/catalogs/v9-251127-ppc64le.yaml
@@ -49,8 +49,11 @@ mongo_extras_version_7: 7.0.12
 mongo_extras_version_8: 8.0.13
 
 editorial:
-  whats_new: |
-    - End of support for Openshift Container Platform 4.14 and 4.15, which are both now out of support (Since May 1 2025 and August 27 2025 respectively).
-    - **Security updates and bug fixes**
-        - IBM Maximo Application Suite Core Platform v9.0 and v9.1
-        - IBM Maximo Manage v9.0 and v9.1
+  whats_new:
+  - title: End of support for Openshift Container Platform 4.14 and 4.15, which are both now out of support (Since May 1 2025 and August 27 2025 respectively).
+    details: []
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v9.0 and v9.1
+    - IBM Maximo Manage v9.0 and v9.1
+  known_issues: []

--- a/src/mas/devops/data/catalogs/v9-251127-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-251127-s390x.yaml
@@ -47,3 +47,10 @@ mongo_extras_version_5: 5.0.23
 mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
 mongo_extras_version_8: 8.0.13
+
+editorial:
+  whats_new: |
+    - End of support for Openshift Container Platform 4.14 and 4.15, which are both now out of support (Since May 1 2025 and August 27 2025 respectively).
+    - **Security updates and bug fixes**
+        - IBM Maximo Application Suite Core Platform v9.0 and v9.1
+        - IBM Maximo Manage v9.0 and v9.1

--- a/src/mas/devops/data/catalogs/v9-251127-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-251127-s390x.yaml
@@ -49,8 +49,11 @@ mongo_extras_version_7: 7.0.12
 mongo_extras_version_8: 8.0.13
 
 editorial:
-  whats_new: |
-    - End of support for Openshift Container Platform 4.14 and 4.15, which are both now out of support (Since May 1 2025 and August 27 2025 respectively).
-    - **Security updates and bug fixes**
-        - IBM Maximo Application Suite Core Platform v9.0 and v9.1
-        - IBM Maximo Manage v9.0 and v9.1
+  whats_new:
+  - title: End of support for Openshift Container Platform 4.14 and 4.15, which are both now out of support (Since May 1 2025 and August 27 2025 respectively).
+    details: []
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v9.0 and v9.1
+    - IBM Maximo Manage v9.0 and v9.1
+  known_issues: []

--- a/src/mas/devops/data/catalogs/v9-251224-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-251224-amd64.yaml
@@ -143,3 +143,24 @@ cpd_product_version_default: 5.2.0
 manage_extras_913: 9.1.3
 minio_version: RELEASE.2025-06-13T11-33-47Z
 
+
+editorial:
+  whats_new: |
+    - **Cloud Pak For Data 5.2 support** Running 'mas update' will automatically upgrade existing Cloud Pak For Data instances to version 5.2.0 this requires Cloud Pak For Data to be on version 5.1.3. If Cloud Pak For Data is on an earlier version then an update to an intermediary catalog is required. Refer CPD v5.2 release notes [here](https://www.ibm.com/docs/en/software-hub/5.2.x?topic=overview-version-52-release-notes)
+    - New **MAS 9.2 feature channels** for AI Service and Visual Inspection offering early access to some of the new features that will be included in the upcoming 9.2 release next year
+    - **Security updates and bug fixes**
+        - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0 and v9.1
+        - IBM Maximo Manage v8.6, v8.7, v9.0 and v9.1
+        - IBM Maximo IoT v8.7, v8.8, v9.0 and v9.1
+        - IBM Maximo Monitor v8.10, v8.11, v9.0 and v9.1
+        - IBM Maximo Optimizer v8.4, 8.5 and v9.1
+        - IBM Maximo Assist v9.1 and v9.0
+        - IBM Maximo Predict v8.8, v8.9, v9.0 and v9.1
+        - IBM Maximo Visual Inspection v8.9, v9.0 and v9.1
+        - IBM Maximo Real Estate and Facilities v9.1
+        - IBM Maximo AI Service v9.1
+        - IBM Maximo Location Service for Esri v9.0 and v9.1
+        - IBM Suite License Service v3.12
+  known_issues: |
+    - Customers using **Maximo Assist v8.7 or v8.8** should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
+    - If you have the Workday Connector installed and are upgrading from Manage 8.7.24 Multi-IS to Manage 9.0.17 (Online/Offline mode), it is advised to bypass this Patch 9.0.17 release due to a recently encountered error on build and await the subsequent patch release for 9.0.18. If you need to apply this patch, we can offer a Limited Availability Fix (LA Fix) in the event you encounter this issue. Please note that you will need to submit a LA Fix request for this.

--- a/src/mas/devops/data/catalogs/v9-251224-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-251224-amd64.yaml
@@ -145,22 +145,25 @@ minio_version: RELEASE.2025-06-13T11-33-47Z
 
 
 editorial:
-  whats_new: |
-    - **Cloud Pak For Data 5.2 support** Running 'mas update' will automatically upgrade existing Cloud Pak For Data instances to version 5.2.0 this requires Cloud Pak For Data to be on version 5.1.3. If Cloud Pak For Data is on an earlier version then an update to an intermediary catalog is required. Refer CPD v5.2 release notes [here](https://www.ibm.com/docs/en/software-hub/5.2.x?topic=overview-version-52-release-notes)
-    - New **MAS 9.2 feature channels** for AI Service and Visual Inspection offering early access to some of the new features that will be included in the upcoming 9.2 release next year
-    - **Security updates and bug fixes**
-        - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0 and v9.1
-        - IBM Maximo Manage v8.6, v8.7, v9.0 and v9.1
-        - IBM Maximo IoT v8.7, v8.8, v9.0 and v9.1
-        - IBM Maximo Monitor v8.10, v8.11, v9.0 and v9.1
-        - IBM Maximo Optimizer v8.4, 8.5 and v9.1
-        - IBM Maximo Assist v9.1 and v9.0
-        - IBM Maximo Predict v8.8, v8.9, v9.0 and v9.1
-        - IBM Maximo Visual Inspection v8.9, v9.0 and v9.1
-        - IBM Maximo Real Estate and Facilities v9.1
-        - IBM Maximo AI Service v9.1
-        - IBM Maximo Location Service for Esri v9.0 and v9.1
-        - IBM Suite License Service v3.12
-  known_issues: |
-    - Customers using **Maximo Assist v8.7 or v8.8** should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
-    - If you have the Workday Connector installed and are upgrading from Manage 8.7.24 Multi-IS to Manage 9.0.17 (Online/Offline mode), it is advised to bypass this Patch 9.0.17 release due to a recently encountered error on build and await the subsequent patch release for 9.0.18. If you need to apply this patch, we can offer a Limited Availability Fix (LA Fix) in the event you encounter this issue. Please note that you will need to submit a LA Fix request for this.
+  whats_new:
+  - title: '**Cloud Pak For Data 5.2 support** Running ''mas update'' will automatically upgrade existing Cloud Pak For Data instances to version 5.2.0 this requires Cloud Pak For Data to be on version 5.1.3. If Cloud Pak For Data is on an earlier version then an update to an intermediary catalog is required. Refer CPD v5.2 release notes [here](https://www.ibm.com/docs/en/software-hub/5.2.x?topic=overview-version-52-release-notes)'
+    details: []
+  - title: New **MAS 9.2 feature channels** for AI Service and Visual Inspection offering early access to some of the new features that will be included in the upcoming 9.2 release next year
+    details: []
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0 and v9.1
+    - IBM Maximo Manage v8.6, v8.7, v9.0 and v9.1
+    - IBM Maximo IoT v8.7, v8.8, v9.0 and v9.1
+    - IBM Maximo Monitor v8.10, v8.11, v9.0 and v9.1
+    - IBM Maximo Optimizer v8.4, 8.5 and v9.1
+    - IBM Maximo Assist v9.1 and v9.0
+    - IBM Maximo Predict v8.8, v8.9, v9.0 and v9.1
+    - IBM Maximo Visual Inspection v8.9, v9.0 and v9.1
+    - IBM Maximo Real Estate and Facilities v9.1
+    - IBM Maximo AI Service v9.1
+    - IBM Maximo Location Service for Esri v9.0 and v9.1
+    - IBM Suite License Service v3.12
+  known_issues:
+  - title: Customers using **Maximo Assist v8.7 or v8.8** should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
+  - title: If you have the Workday Connector installed and are upgrading from Manage 8.7.24 Multi-IS to Manage 9.0.17 (Online/Offline mode), it is advised to bypass this Patch 9.0.17 release due to a recently encountered error on build and await the subsequent patch release for 9.0.18. If you need to apply this patch, we can offer a Limited Availability Fix (LA Fix) in the event you encounter this issue. Please note that you will need to submit a LA Fix request for this.

--- a/src/mas/devops/data/catalogs/v9-251224-ppc64le.yaml
+++ b/src/mas/devops/data/catalogs/v9-251224-ppc64le.yaml
@@ -47,3 +47,10 @@ mongo_extras_version_5: 5.0.23
 mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
 mongo_extras_version_8: 8.0.13
+
+editorial:
+  whats_new: |
+    - **Security updates and bug fixes**
+        - IBM Maximo Application Suite Core Platform v9.0 and v9.1
+        - IBM Maximo Manage v9.0 and v9.1
+        - IBM Suite License Service v3.12

--- a/src/mas/devops/data/catalogs/v9-251224-ppc64le.yaml
+++ b/src/mas/devops/data/catalogs/v9-251224-ppc64le.yaml
@@ -49,8 +49,10 @@ mongo_extras_version_7: 7.0.12
 mongo_extras_version_8: 8.0.13
 
 editorial:
-  whats_new: |
-    - **Security updates and bug fixes**
-        - IBM Maximo Application Suite Core Platform v9.0 and v9.1
-        - IBM Maximo Manage v9.0 and v9.1
-        - IBM Suite License Service v3.12
+  whats_new:
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v9.0 and v9.1
+    - IBM Maximo Manage v9.0 and v9.1
+    - IBM Suite License Service v3.12
+  known_issues: []

--- a/src/mas/devops/data/catalogs/v9-251224-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-251224-s390x.yaml
@@ -47,3 +47,10 @@ mongo_extras_version_5: 5.0.23
 mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
 mongo_extras_version_8: 8.0.13
+
+editorial:
+  whats_new: |
+    - **Security updates and bug fixes**
+        - IBM Maximo Application Suite Core Platform v9.0 and v9.1
+        - IBM Maximo Manage v9.0 and v9.1
+        - IBM Suite License Service v3.12

--- a/src/mas/devops/data/catalogs/v9-251224-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-251224-s390x.yaml
@@ -49,8 +49,10 @@ mongo_extras_version_7: 7.0.12
 mongo_extras_version_8: 8.0.13
 
 editorial:
-  whats_new: |
-    - **Security updates and bug fixes**
-        - IBM Maximo Application Suite Core Platform v9.0 and v9.1
-        - IBM Maximo Manage v9.0 and v9.1
-        - IBM Suite License Service v3.12
+  whats_new:
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v9.0 and v9.1
+    - IBM Maximo Manage v9.0 and v9.1
+    - IBM Suite License Service v3.12
+  known_issues: []

--- a/src/mas/devops/data/catalogs/v9-251231-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-251231-amd64.yaml
@@ -145,23 +145,27 @@ minio_version: RELEASE.2025-06-13T11-33-47Z
 
 
 editorial:
-  whats_new: |
-    - **MongoDb v8.0.17** support Running `mas update` will automatically upgrade existing MongoDbCommunity instances to MongoDb version v8.0.17 this requires MongoDb version to be on v7 or later.
-    - **Cloud Pak For Data 5.2 support** Running 'mas update' will automatically upgrade existing Cloud Pak For Data instances to version 5.2.0 this requires Cloud Pak For Data to be on version 5.1.3. If Cloud Pak For Data is on an earlier version then an update to an intermediary catalog is required. Refer CPD v5.2 release notes [here](https://www.ibm.com/docs/en/software-hub/5.2.x?topic=overview-version-52-release-notes)
-    - New **MAS 9.2 feature channels** for AI Service and Visual Inspection offering early access to some of the new features that will be included in the upcoming 9.2 release next year
-    - **Security updates and bug fixes**
-        - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0 and v9.1
-        - IBM Maximo Manage v8.6, v8.7, v9.0 and v9.1
-        - IBM Maximo IoT v8.7, v8.8, v9.0 and v9.1
-        - IBM Maximo Monitor v8.10, v8.11, v9.0 and v9.1
-        - IBM Maximo Optimizer v8.4, 8.5 and v9.1
-        - IBM Maximo Assist v9.1 and v9.0
-        - IBM Maximo Predict v8.8, v8.9, v9.0 and v9.1
-        - IBM Maximo Visual Inspection v8.9, v9.0 and v9.1
-        - IBM Maximo Real Estate and Facilities v9.1
-        - IBM Maximo AI Service v9.1
-        - IBM Maximo Location Service for Esri v9.0 and v9.1
-        - IBM Suite License Service v3.12
-  known_issues: |
-    - Customers using **Maximo Assist v8.7 or v8.8** should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
-    - If you have the Workday Connector installed and are upgrading from Manage 8.7.24 Multi-IS to Manage 9.0.17 (Online/Offline mode), it is advised to bypass this Patch 9.0.17 release due to a recently encountered error on build and await the subsequent patch release for 9.0.18. If you need to apply this patch, we can offer a Limited Availability Fix (LA Fix) in the event you encounter this issue. Please note that you will need to submit a LA Fix request for this.
+  whats_new:
+  - title: '**MongoDb v8.0.17** support Running `mas update` will automatically upgrade existing MongoDbCommunity instances to MongoDb version v8.0.17 this requires MongoDb version to be on v7 or later.'
+    details: []
+  - title: '**Cloud Pak For Data 5.2 support** Running ''mas update'' will automatically upgrade existing Cloud Pak For Data instances to version 5.2.0 this requires Cloud Pak For Data to be on version 5.1.3. If Cloud Pak For Data is on an earlier version then an update to an intermediary catalog is required. Refer CPD v5.2 release notes [here](https://www.ibm.com/docs/en/software-hub/5.2.x?topic=overview-version-52-release-notes)'
+    details: []
+  - title: New **MAS 9.2 feature channels** for AI Service and Visual Inspection offering early access to some of the new features that will be included in the upcoming 9.2 release next year
+    details: []
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0 and v9.1
+    - IBM Maximo Manage v8.6, v8.7, v9.0 and v9.1
+    - IBM Maximo IoT v8.7, v8.8, v9.0 and v9.1
+    - IBM Maximo Monitor v8.10, v8.11, v9.0 and v9.1
+    - IBM Maximo Optimizer v8.4, 8.5 and v9.1
+    - IBM Maximo Assist v9.1 and v9.0
+    - IBM Maximo Predict v8.8, v8.9, v9.0 and v9.1
+    - IBM Maximo Visual Inspection v8.9, v9.0 and v9.1
+    - IBM Maximo Real Estate and Facilities v9.1
+    - IBM Maximo AI Service v9.1
+    - IBM Maximo Location Service for Esri v9.0 and v9.1
+    - IBM Suite License Service v3.12
+  known_issues:
+  - title: Customers using **Maximo Assist v8.7 or v8.8** should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
+  - title: If you have the Workday Connector installed and are upgrading from Manage 8.7.24 Multi-IS to Manage 9.0.17 (Online/Offline mode), it is advised to bypass this Patch 9.0.17 release due to a recently encountered error on build and await the subsequent patch release for 9.0.18. If you need to apply this patch, we can offer a Limited Availability Fix (LA Fix) in the event you encounter this issue. Please note that you will need to submit a LA Fix request for this.

--- a/src/mas/devops/data/catalogs/v9-251231-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-251231-amd64.yaml
@@ -143,3 +143,25 @@ cpd_product_version_default: 5.2.0
 manage_extras_913: 9.1.3
 minio_version: RELEASE.2025-06-13T11-33-47Z
 
+
+editorial:
+  whats_new: |
+    - **MongoDb v8.0.17** support Running `mas update` will automatically upgrade existing MongoDbCommunity instances to MongoDb version v8.0.17 this requires MongoDb version to be on v7 or later.
+    - **Cloud Pak For Data 5.2 support** Running 'mas update' will automatically upgrade existing Cloud Pak For Data instances to version 5.2.0 this requires Cloud Pak For Data to be on version 5.1.3. If Cloud Pak For Data is on an earlier version then an update to an intermediary catalog is required. Refer CPD v5.2 release notes [here](https://www.ibm.com/docs/en/software-hub/5.2.x?topic=overview-version-52-release-notes)
+    - New **MAS 9.2 feature channels** for AI Service and Visual Inspection offering early access to some of the new features that will be included in the upcoming 9.2 release next year
+    - **Security updates and bug fixes**
+        - IBM Maximo Application Suite Core Platform v8.10, v8.11, v9.0 and v9.1
+        - IBM Maximo Manage v8.6, v8.7, v9.0 and v9.1
+        - IBM Maximo IoT v8.7, v8.8, v9.0 and v9.1
+        - IBM Maximo Monitor v8.10, v8.11, v9.0 and v9.1
+        - IBM Maximo Optimizer v8.4, 8.5 and v9.1
+        - IBM Maximo Assist v9.1 and v9.0
+        - IBM Maximo Predict v8.8, v8.9, v9.0 and v9.1
+        - IBM Maximo Visual Inspection v8.9, v9.0 and v9.1
+        - IBM Maximo Real Estate and Facilities v9.1
+        - IBM Maximo AI Service v9.1
+        - IBM Maximo Location Service for Esri v9.0 and v9.1
+        - IBM Suite License Service v3.12
+  known_issues: |
+    - Customers using **Maximo Assist v8.7 or v8.8** should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
+    - If you have the Workday Connector installed and are upgrading from Manage 8.7.24 Multi-IS to Manage 9.0.17 (Online/Offline mode), it is advised to bypass this Patch 9.0.17 release due to a recently encountered error on build and await the subsequent patch release for 9.0.18. If you need to apply this patch, we can offer a Limited Availability Fix (LA Fix) in the event you encounter this issue. Please note that you will need to submit a LA Fix request for this.

--- a/src/mas/devops/data/catalogs/v9-251231-ppc64le.yaml
+++ b/src/mas/devops/data/catalogs/v9-251231-ppc64le.yaml
@@ -49,9 +49,12 @@ mongo_extras_version_7: 7.0.12
 mongo_extras_version_8: 8.0.17
 
 editorial:
-  whats_new: |
-    - **MongoDb v8.0.17** support Running `mas update` will automatically upgrade existing MongoDbCommunity instances to MongoDb version v8.0.17 this requires MongoDb version to be on v7 or later.
-    - **Security updates and bug fixes**
-        - IBM Maximo Application Suite Core Platform v9.0 and v9.1
-        - IBM Maximo Manage v9.0 and v9.1
-        - IBM Suite License Service v3.12
+  whats_new:
+  - title: '**MongoDb v8.0.17** support Running `mas update` will automatically upgrade existing MongoDbCommunity instances to MongoDb version v8.0.17 this requires MongoDb version to be on v7 or later.'
+    details: []
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v9.0 and v9.1
+    - IBM Maximo Manage v9.0 and v9.1
+    - IBM Suite License Service v3.12
+  known_issues: []

--- a/src/mas/devops/data/catalogs/v9-251231-ppc64le.yaml
+++ b/src/mas/devops/data/catalogs/v9-251231-ppc64le.yaml
@@ -47,3 +47,11 @@ mongo_extras_version_5: 5.0.23
 mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
 mongo_extras_version_8: 8.0.17
+
+editorial:
+  whats_new: |
+    - **MongoDb v8.0.17** support Running `mas update` will automatically upgrade existing MongoDbCommunity instances to MongoDb version v8.0.17 this requires MongoDb version to be on v7 or later.
+    - **Security updates and bug fixes**
+        - IBM Maximo Application Suite Core Platform v9.0 and v9.1
+        - IBM Maximo Manage v9.0 and v9.1
+        - IBM Suite License Service v3.12

--- a/src/mas/devops/data/catalogs/v9-251231-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-251231-s390x.yaml
@@ -49,9 +49,12 @@ mongo_extras_version_7: 7.0.12
 mongo_extras_version_8: 8.0.17
 
 editorial:
-  whats_new: |
-    - **MongoDb v8.0.17** support Running `mas update` will automatically upgrade existing MongoDbCommunity instances to MongoDb version v8.0.17 this requires MongoDb version to be on v7 or later.
-    - **Security updates and bug fixes**
-        - IBM Maximo Application Suite Core Platform v9.0 and v9.1
-        - IBM Maximo Manage v9.0 and v9.1
-        - IBM Suite License Service v3.12
+  whats_new:
+  - title: '**MongoDb v8.0.17** support Running `mas update` will automatically upgrade existing MongoDbCommunity instances to MongoDb version v8.0.17 this requires MongoDb version to be on v7 or later.'
+    details: []
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v9.0 and v9.1
+    - IBM Maximo Manage v9.0 and v9.1
+    - IBM Suite License Service v3.12
+  known_issues: []

--- a/src/mas/devops/data/catalogs/v9-251231-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-251231-s390x.yaml
@@ -47,3 +47,11 @@ mongo_extras_version_5: 5.0.23
 mongo_extras_version_6: 6.0.12
 mongo_extras_version_7: 7.0.12
 mongo_extras_version_8: 8.0.17
+
+editorial:
+  whats_new: |
+    - **MongoDb v8.0.17** support Running `mas update` will automatically upgrade existing MongoDbCommunity instances to MongoDb version v8.0.17 this requires MongoDb version to be on v7 or later.
+    - **Security updates and bug fixes**
+        - IBM Maximo Application Suite Core Platform v9.0 and v9.1
+        - IBM Maximo Manage v9.0 and v9.1
+        - IBM Suite License Service v3.12

--- a/src/mas/devops/data/ocp.yaml
+++ b/src/mas/devops/data/ocp.yaml
@@ -1,0 +1,58 @@
+---
+# OpenShift Container Platform Lifecycle Data
+# -----------------------------------------------------------------------------
+# This file contains the lifecycle information for OpenShift Container Platform
+# versions, including General Availability dates, Standard Support end dates,
+# and Extended Update Support (EUS) end dates.
+#
+# Data source: Red Hat OpenShift Container Platform Life Cycle Policy
+# https://access.redhat.com/support/policy/updates/openshift/
+
+ocp_versions:
+  "4.19":
+    ga_date: "June 17, 2025"
+    standard_support: "December 17, 2026"
+    extended_support: "N/A"
+
+  "4.18":
+    ga_date: "February 25, 2025"
+    standard_support: "GA of 4.19 + 3 Months"
+    extended_support: "August 25, 2026"
+
+  "4.17":
+    ga_date: "October 1, 2024"
+    standard_support: "May 25, 2025"
+    extended_support: "April 1, 2026"
+
+  "4.16":
+    ga_date: "June 27, 2024"
+    standard_support: "December 27, 2025"
+    extended_support: "June 27, 2027"
+
+  "4.15":
+    ga_date: "February 27, 2024"
+    standard_support: "August 27, 2025"
+    extended_support: "N/A"
+
+  "4.14":
+    ga_date: "October 31, 2023"
+    standard_support: "May 1, 2025"
+    extended_support: "October 31, 2026"
+
+  "4.13":
+    ga_date: "May 17, 2023"
+    standard_support: "November 17, 2024"
+    extended_support: "N/A"
+
+  "4.12":
+    ga_date: "January 17, 2023"
+    standard_support: "July 17, 2024"
+    extended_support: "January 17, 2025"
+
+# Notes:
+# - Standard Support: 18 months from GA date
+# - Extended Support (EUS): Additional 6 months available for purchase
+# - EUS is included with Premium subscriptions
+# - Not all versions have EUS available
+
+# Made with Bob


### PR DESCRIPTION
This update expands the metadata available from the `mas.devops.data` package, moving us closer towards a single source of truth around key data for MAS devops processes.