### PR TITLE
[patch] added db2_channel param to aiservice pipeline

### DIFF
--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -787,6 +787,8 @@ spec:
       value: "{{ aiservice_channel }}"
     - name: db2_action_aiservice
       value: "{{ db2_action_aiservice }}"
+    - name: db2_channel
+      value: "{{ db2_channel }}"
 
     - name: environment_type
       value: "{{ environment_type }}"


### PR DESCRIPTION
Change needed to trigger install db2 v12 version for AI Service
https://jsw.ibm.com/browse/MASAIB-1699

it is part of this PR: https://github.com/ibm-mas/cli/pull/2001