### PR TITLE
[minor] Add db2_channel_default to control Db2 operator version via catalog metadata

### DIFF
--- a/src/mas/devops/data/catalogs/v9-260129-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260129-amd64.yaml
@@ -23,7 +23,7 @@ cp4d_platform_version: 5.2.0+20250709.170324               # Operator version 5.
 ibm_zen_version: 6.2.0+20250530.152516.232                     # For CPD5 ibm-zen has to be explicitily mirrored
 
 db2u_version: 7.3.1+20250821.161005.16793    # Operator version 110509.0.6 to find the version 7.3.1+20250821.161005.16793, search db2u-operator digest on repo (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
-db2_channel_default: v120101.0               # Default Channel version for db2u-operator
+#db2_channel_default: v120101.0               # Default Channel version for db2u-operator
 events_version: 5.0.1                        # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
 uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
 sls_version: 3.12.4                          # Operator version 3.12.4 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)

--- a/src/mas/devops/data/catalogs/v9-260129-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260129-amd64.yaml
@@ -23,7 +23,7 @@ cp4d_platform_version: 5.2.0+20250709.170324               # Operator version 5.
 ibm_zen_version: 6.2.0+20250530.152516.232                     # For CPD5 ibm-zen has to be explicitily mirrored
 
 db2u_version: 7.3.1+20250821.161005.16793    # Operator version 110509.0.6 to find the version 7.3.1+20250821.161005.16793, search db2u-operator digest on repo (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
-#db2_channel_default: v120101.0               # Default Channel version for db2u-operator
+db2_channel_default: v120101.0               # Default Channel version for db2u-operator
 events_version: 5.0.1                        # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
 uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
 sls_version: 3.12.4                          # Operator version 3.12.4 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)

--- a/src/mas/devops/data/catalogs/v9-260129-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260129-amd64.yaml
@@ -23,7 +23,7 @@ cp4d_platform_version: 5.2.0+20250709.170324               # Operator version 5.
 ibm_zen_version: 6.2.0+20250530.152516.232                     # For CPD5 ibm-zen has to be explicitily mirrored
 
 db2u_version: 7.3.1+20250821.161005.16793    # Operator version 110509.0.6 to find the version 7.3.1+20250821.161005.16793, search db2u-operator digest on repo (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
-#db2_channel_default: v120101.0               # Default Channel version for db2u-operator
+db2_channel_default: v110509.0               # Default Channel version for db2u-operator
 events_version: 5.0.1                        # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
 uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
 sls_version: 3.12.4                          # Operator version 3.12.4 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)

--- a/src/mas/devops/data/catalogs/v9-260129-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260129-amd64.yaml
@@ -23,6 +23,7 @@ cp4d_platform_version: 5.2.0+20250709.170324               # Operator version 5.
 ibm_zen_version: 6.2.0+20250530.152516.232                     # For CPD5 ibm-zen has to be explicitily mirrored
 
 db2u_version: 7.3.1+20250821.161005.16793    # Operator version 110509.0.6 to find the version 7.3.1+20250821.161005.16793, search db2u-operator digest on repo (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+db2_channel_default: v120101.0               # Default Channel version for db2u-operator
 events_version: 5.0.1                        # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
 uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
 sls_version: 3.12.4                          # Operator version 3.12.4 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)


### PR DESCRIPTION
## Description

This PR adds support for a new catalog-controlled variable, db2_channel_default, to determine the Db2 operator channel/version used during installation.

Previously, the Db2 operator version was implicitly selected, with fallback behavior hardcoded in the  CLI. With this change, the default Db2 channel can now be explicitly defined in the operator catalog metadata, enabling better control over Db2 version selection across releases.

## Story
[Jira 11097](https://jsw.ibm.com/browse/MASCORE-11097)

##  What's New
- Introduced new variable db2_channel_default sourced from catalog metadata
- CLI now:
   - Reads db2_channel_default from the catalog
   - Uses it as the default Db2 channel when no explicit db2_channel is provided by the user
   - Removes dependency on hardcoded Db2 version defaults in the CLI
   
 ## Db2 channel resolution order:
1. User-provided db2_channel (CLI input)
2. db2_channel_default from catalog metadata
3. Fallback to v11 (backward compatibility)

## Benefits

- Enables catalog-driven control of Db2 operator versions
- Decouples Db2 version selection from hardcoded CLI logic
- Simplifies Db2 version management per catalog release
- Backward compatible with existing workflows

## Testing Performed
- Verified CLI picks user-provided db2_channel in dev mode, when specified
- Verified fallback to db2_channel_default from catalog metadata
- Verified fallback to v11 when db2_channel_default in catalog metadata is not set
- Logs and evidence attached in JIRA 11097

NB:
- No behavior change for users 
- Non-dev and dev workflows remain consistent with previous behavior unless catalog metadata is configured