### PR TITLE
[patch] Remove deprecated install_arcgis parameter : MASCORE-10768

### DIFF
--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -555,12 +555,10 @@ spec:
     - name: mas_app_settings_iot_mqttbroker_pvc_storage_class
       value: "{{ mas_app_settings_iot_mqttbroker_pvc_storage_class }}"
 {%- endif %}
-{%- if install_arcgis is defined and install_arcgis != "" %}
+{%- if mas_arcgis_channel is defined and mas_arcgis_channel != "" and mas_arcgis_channel %}
 
     # IBM Maximo Location Services for Esri (arcgis)
     # -------------------------------------------------------------------------
-    - name: install_arcgis
-      value: "{{ install_arcgis }}"
     - name: mas_arcgis_channel
       value: "{{ mas_arcgis_channel }}"
 {%- endif %}


### PR DESCRIPTION
## Summary

Removes the deprecated `install_arcgis` parameter from the pipeline run template and updates the conditional logic to use `mas_arcgis_channel` instead.

## Changes

- Removed `install_arcgis` parameter from pipelinerun template
- Updated conditional logic to check `mas_arcgis_channel` directly
- Simplified ArcGIS installation trigger logic

## Related Issues

- MASCORE-10768: Update dependencies on Tekton for ArcGIS installation
- MASCORE-10767: Update installation of ArcGIS on CLI
- MASCORE-10766: Update ansible-devops to detect Manage and MREF during installation of ArcGIS

## Related PRs

- CLI PR: https://github.com/ibm-mas/cli/pull/2011

## Files Modified

- `src/mas/devops/templates/pipelinerun-install.yml.j2` - Removed deprecated parameter and updated conditional logic