### PR TITLE
[patch] Add data/*.yaml to the include list

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include src/mas/devops/templates/*.json.j2
 include src/mas/devops/templates/*.yml.j2
 include src/mas/devops/data/catalogs/*.yaml
+include src/mas/devops/data/*.yaml


### PR DESCRIPTION
This fixes the issue with the catalog documentation generation when performed from a release build:

<img width="1332" height="557" alt="image" src="https://github.com/user-attachments/assets/69b1a936-dbe9-412a-940c-56c5d4a387a6" />

```
>>> from mas.devops.data import getOCPLifecycleData
>>> print(getOCPLifecycleData())
None
```