### PR TITLE
Backup for Manage dev

### DIFF
--- a/src/mas/devops/templates/pipelinerun-backup.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-backup.yml.j2
@@ -104,3 +104,63 @@ spec:
     - name: artifactory_repository
       value: "{{ artifactory_repository }}"
     {% endif %}
+
+    # Manage Application Backup Configuration
+    {% if backup_manage_app is defined and backup_manage_app != "" %}
+    - name: backup_manage_app
+      value: "{{ backup_manage_app }}"
+    {% endif %}
+    {% if backup_manage_db is defined and backup_manage_db != "" %}
+    - name: backup_manage_db
+      value: "{{ backup_manage_db }}"
+    {% endif %}
+    {% if mas_app_id is defined and mas_app_id != "" %}
+    - name: mas_app_id
+      value: "{{ mas_app_id }}"
+    {% endif %}
+    {% if mas_workspace_id is defined and mas_workspace_id != "" %}
+    - name: mas_workspace_id
+      value: "{{ mas_workspace_id }}"
+    {% endif %}
+    {% if mas_app_backup_version is defined and mas_app_backup_version != "" %}
+    - name: mas_app_backup_version
+      value: "{{ mas_app_backup_version }}"
+    {% endif %}
+
+    # Db2 Backup Configuration
+    {% if db2_namespace is defined and db2_namespace != "" %}
+    - name: db2_namespace
+      value: "{{ db2_namespace }}"
+    {% endif %}
+    {% if db2_instance_name is defined and db2_instance_name != "" %}
+    - name: db2_instance_name
+      value: "{{ db2_instance_name }}"
+    {% endif %}
+    {% if db2_backup_version is defined and db2_backup_version != "" %}
+    - name: db2_backup_version
+      value: "{{ db2_backup_version }}"
+    {% endif %}
+    {% if backup_type is defined and backup_type != "" %}
+    - name: backup_type
+      value: "{{ backup_type }}"
+    {% endif %}
+    {% if backup_vendor is defined and backup_vendor != "" %}
+    - name: backup_vendor
+      value: "{{ backup_vendor }}"
+    {% endif %}
+    {% if backup_s3_endpoint is defined and backup_s3_endpoint != "" %}
+    - name: backup_s3_endpoint
+      value: "{{ backup_s3_endpoint }}"
+    {% endif %}
+    {% if backup_s3_bucket is defined and backup_s3_bucket != "" %}
+    - name: backup_s3_bucket
+      value: "{{ backup_s3_bucket }}"
+    {% endif %}
+    {% if backup_s3_access_key is defined and backup_s3_access_key != "" %}
+    - name: backup_s3_access_key
+      value: "{{ backup_s3_access_key }}"
+    {% endif %}
+    {% if backup_s3_secret_key is defined and backup_s3_secret_key != "" %}
+    - name: backup_s3_secret_key
+      value: "{{ backup_s3_secret_key }}"
+    {% endif %}

--- a/src/mas/devops/templates/pipelinerun-backup.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-backup.yml.j2
@@ -122,10 +122,6 @@ spec:
     - name: mas_workspace_id
       value: "{{ mas_workspace_id }}"
     {% endif %}
-    {% if mas_app_backup_version is defined and mas_app_backup_version != "" %}
-    - name: mas_app_backup_version
-      value: "{{ mas_app_backup_version }}"
-    {% endif %}
 
     # Db2 Backup Configuration
     {% if db2_namespace is defined and db2_namespace != "" %}
@@ -135,10 +131,6 @@ spec:
     {% if db2_instance_name is defined and db2_instance_name != "" %}
     - name: db2_instance_name
       value: "{{ db2_instance_name }}"
-    {% endif %}
-    {% if db2_backup_version is defined and db2_backup_version != "" %}
-    - name: db2_backup_version
-      value: "{{ db2_backup_version }}"
     {% endif %}
     {% if backup_type is defined and backup_type != "" %}
     - name: backup_type

--- a/src/mas/devops/templates/pipelinerun-backup.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-backup.yml.j2
@@ -114,31 +114,27 @@ spec:
     - name: backup_manage_db
       value: "{{ backup_manage_db }}"
     {% endif %}
-    {% if mas_app_id is defined and mas_app_id != "" %}
-    - name: mas_app_id
-      value: "{{ mas_app_id }}"
-    {% endif %}
-    {% if mas_workspace_id is defined and mas_workspace_id != "" %}
-    - name: mas_workspace_id
-      value: "{{ mas_workspace_id }}"
+    {% if manage_workspace_id is defined and manage_workspace_id != "" %}
+    - name: manage_workspace_id
+      value: "{{ manage_workspace_id }}"
     {% endif %}
 
-    # Db2 Backup Configuration
-    {% if db2_namespace is defined and db2_namespace != "" %}
-    - name: db2_namespace
-      value: "{{ db2_namespace }}"
+    # Manage Db2 Backup Configuration
+    {% if manage_db2_namespace is defined and manage_db2_namespace != "" %}
+    - name: manage_db2_namespace
+      value: "{{ manage_db2_namespace }}"
     {% endif %}
-    {% if db2_instance_name is defined and db2_instance_name != "" %}
-    - name: db2_instance_name
-      value: "{{ db2_instance_name }}"
+    {% if manage_db2_instance_name is defined and manage_db2_instance_name != "" %}
+    - name: manage_db2_instance_name
+      value: "{{ manage_db2_instance_name }}"
     {% endif %}
-    {% if backup_type is defined and backup_type != "" %}
-    - name: backup_type
-      value: "{{ backup_type }}"
+    {% if manage_db2_backup_type is defined and manage_db2_backup_type != "" %}
+    - name: manage_db2_backup_type
+      value: "{{ manage_db2_backup_type }}"
     {% endif %}
-    {% if backup_vendor is defined and backup_vendor != "" %}
-    - name: backup_vendor
-      value: "{{ backup_vendor }}"
+    {% if manage_db2_backup_vendor is defined and manage_db2_backup_vendor != "" %}
+    - name: manage_db2_backup_vendor
+      value: "{{ manage_db2_backup_vendor }}"
     {% endif %}
     {% if backup_s3_endpoint is defined and backup_s3_endpoint != "" %}
     - name: backup_s3_endpoint


### PR DESCRIPTION
Dev -> dev PR only.

Adds the manage app and db2 for the backup pipelinerun. As we can have more than one app to backup then we have specific `backup_manage_app` flags.

Goes with the ansible-devops PR and cli PR:
https://github.com/ibm-mas/ansible-devops/pull/2104
https://github.com/ibm-mas/cli/pull/2043