### PR TITLE
[patch] Clean up catalog metadata file & type hint fixes

### DIFF
--- a/src/mas/devops/data/catalogs/v9-260129-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260129-amd64.yaml
@@ -28,11 +28,17 @@ cognos_version: 28.0.0+20250515.175459.10054     # Operator version 25.0.0
 
 postgress_version: 5.16.0+20250827.110911.2626   # ibm-cpd-cloud-native-postgresql-operator 5.2.0
 ccs_build: 11.0.0+20250605.130237.468            # cpd 5.2.0
+
+# TODO: If this is only used in CPD 5.1.3, we shouldn't need this in this catalog metadata file
 elasticsearch_version: 1.1.2667                  # Operator version 1.1.2667 - used in cpd 5.1.3 only
 opensearch_version: 1.1.2494                     # Operator version 1.1.2494
 
 # TODO: Why is this here, but commented out?
 # datarefinery_build: +20240517.202103.146
+
+# I have added this as a guess as to the actual version used, we are currently using the wsl_version, but that does not exist for datarefinery
+# See: https://ibm-mas.slack.com/archives/C02PUHKQB5L/p1770849370378689
+datarefinery_version: 11.0.0+20250513.203727.232
 
 # TODO: Why is this here, there is no evidence that it is being used in image mirroring?
 events_version: 5.0.1  # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)

--- a/src/mas/devops/data/catalogs/v9-260129-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260129-amd64.yaml
@@ -1,9 +1,6 @@
 ---
-# Case bundle configuration for IBM Maximo Operator Catalog 260129 (AMD64)
+# Catalog metadata for IBM Maximo Operator Catalog v9-260129-amd64
 # -----------------------------------------------------------------------------
-# In the future this won't be necessary as we'll be able to mirror from the
-# catalog itself, but not everything in the catalog supports this yet (including MAS)
-# so we need to use the CASE bundle mirror process still.
 
 catalog_digest: sha256:54bcab31205bf3a5e0e0769158127b70b514e3a965ddd8f02785afe53171f0ee
 
@@ -13,55 +10,105 @@ ocp_compatibility:
 - 4.18
 - 4.19
 
-# Dependencies
+
+# Dependencies - Cloud Pak for Data
 # -----------------------------------------------------------------------------
-ibm_licensing_version: 4.2.17                # Operator version 4.2.14 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-licensing)
-common_svcs_version: 4.13.0                  # Operator version 4.13.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
-common_svcs_version_1: 4.11.0                  # Additional version 4.11.0
+cpd_product_version_default: 5.2.0
 
-cp4d_platform_version: 5.2.0+20250709.170324               # Operator version 5.2.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-datacore/)
-ibm_zen_version: 6.2.0+20250530.152516.232                     # For CPD5 ibm-zen has to be explicitily mirrored
+ibm_licensing_version: 4.2.17                    # Operator version 4.2.14 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-licensing)
+common_svcs_version: 4.13.0                      # Operator version 4.13.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+common_svcs_version_1: 4.11.0                    # TODO: Do we really still need to mirror two different versions of common services?  If so, why?
+cp4d_platform_version: 5.2.0+20250709.170324     # Operator version 5.2.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-datacore/)
+ibm_zen_version: 6.2.0+20250530.152516.232       # For CPD5 ibm-zen has to be explicitily mirrored
+wsl_version: 11.0.0+20250521.202913.73
+wsl_runtimes_version: 11.0.0+20250515.090949.21
+wml_version: 11.0.0+20250530.193146.282          # Operator version 5.2.0
+spark_version: 11.0.0+20250604.163055.2097       # Operator version 5.2.0
+cognos_version: 28.0.0+20250515.175459.10054     # Operator version 25.0.0
 
-db2u_version: 7.3.1+20250821.161005.16793    # Operator version 110509.0.7 to find the version 7.3.1+20250821.161005.16793, search db2u-operator digest on repo (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
-db2_channel_default: v110509.0               # Default Channel version for db2u-operator
-events_version: 5.0.1                        # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
-uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
-sls_version: 3.12.5                          # Operator version 3.12.5 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
-tsm_version: 1.7.2                           # Operator version 1.7.2 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
-dd_version: 1.1.21                           # Operator version 1.1.21 (https://github.ibm.com/maximoappsuite/ibm-data-dictionary/releases)
-appconnect_version: 6.2.0                    # Operator version 6.2.0 # sticking to 6.2.0 version # Please do Not Change
-wsl_version: 11.0.0+20250521.202913.73                      # used for wsl and wsl_runtimes unless wsl_runtimes_version also specified
-wsl_runtimes_version: 11.0.0+20250515.090949.21               # cpd 5.1.3 uses version 10.3.0 of wsl runtimes but only 10.2.0 for wsl itself
-wml_version: 11.0.0+20250530.193146.282                             # Operator version 5.2.0
-postgress_version: 5.16.0+20250827.110911.2626                # ibm-cpd-cloud-native-postgresql-operator 5.2.0 cp4d 
+postgress_version: 5.16.0+20250827.110911.2626   # ibm-cpd-cloud-native-postgresql-operator 5.2.0
+ccs_build: 11.0.0+20250605.130237.468            # cpd 5.2.0
+elasticsearch_version: 1.1.2667                  # Operator version 1.1.2667 - used in cpd 5.1.3 only
+opensearch_version: 1.1.2494                     # Operator version 1.1.2494
 
-ccs_build: 11.0.0+20250605.130237.468       # cpd 5.2.0 using ccs build
+# TODO: Why is this here, but commented out?
 # datarefinery_build: +20240517.202103.146
 
-spark_version: 11.0.0+20250604.163055.2097                      # Operator version 5.2.0
-cognos_version: 28.0.0+20250515.175459.10054                     # Operator version 25.0.0
-couchdb_version: 1.0.13                     # Operator version 2.2.1 (1.0.13) sticking with 1.0.13 # (This is required for Assist 9.0, https://github.com/IBM/cloud-pak/blob/master/repo/case/ibm-couchdb/index.yaml)
-elasticsearch_version: 1.1.2667           # Operator version 1.1.2667 # used in cpd 5.1.3 only
-opensearch_version: 1.1.2494                # Operator version 1.1.2494
+# TODO: Why is this here, there is no evidence that it is being used in image mirroring?
+events_version: 5.0.1  # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
+
+# Dependencies - Db2u
+# -----------------------------------------------------------------------------
+db2u_version: 7.3.1+20250821.161005.16793    # Operator version 110509.0.7 to find the version 7.3.1+20250821.161005.16793, search db2u-operator digest on repo (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+db2u_extras_version: 1.0.6 # No Update
+db2u_filter: db2
+
+db2_channel_default: v110509.0               # Default Channel version for db2u-operator
+
+
+# Dependencies - CouchDb
+# -----------------------------------------------------------------------------
+# Note: This is required for Assist 9.0 (https://github.com/IBM/cloud-pak/blob/master/repo/case/ibm-couchdb/index.yaml)
+couchdb_version: 1.0.13  # Operator version 2.2.1 (1.0.13) sticking with 1.0.13
+
+
+# Dependencies - Minio
+# -----------------------------------------------------------------------------
+minio_version: RELEASE.2025-06-13T11-33-47Z
+
+
+# Dependencies - MongoDB
+# -----------------------------------------------------------------------------
+mongo_extras_version_default: 8.0.17
+# TODO: We probably don't need to keep carrying forward the now unsupported versions
+mongo_extras_version_4: 4.4.21
+mongo_extras_version_5: 5.0.23
+mongo_extras_version_6: 6.0.12
+mongo_extras_version_7: 7.0.23
+mongo_extras_version_8: 8.0.17
+
+
+# Dependencies - Amlen
+# -----------------------------------------------------------------------------
+amlen_extras_version: 1.1.3
+
+
+# Dependencies - Suite License Service
+# -----------------------------------------------------------------------------
+# https://github.ibm.com/maximoappsuite/ibm-sls/releases
+sls_version: 3.12.5
+
+
+# Dependencies - Truststore Manager
+# -----------------------------------------------------------------------------
+# https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases
+tsm_version: 1.7.2
+
+
+# Dependencies - Data Dictionary
+# -----------------------------------------------------------------------------
+# https://github.ibm.com/maximoappsuite/ibm-data-dictionary/releases
+dd_version: 1.1.21
+
 
 # Maximo Application Suite
 # -----------------------------------------------------------------------------
 mas_core_version:
   9.2.x-feature: 9.2.0-pre.stable_9887 # Updated
-  9.1.x: 9.1.8         # Updated 
+  9.1.x: 9.1.8         # Updated
   9.0.x: 9.0.19        # Updated
   8.10.x: 8.10.33      # Updated
   8.11.x: 8.11.30      # Updated
 mas_assist_version:
   9.1.x: 9.1.7     # Updated
   9.0.x: 9.0.13    # Updated
-  8.10.x: 8.7.8   # No Update
-  8.11.x: 8.8.7   # No Update
+  8.10.x: 8.7.8    # No Update
+  8.11.x: 8.8.7    # No Update
 mas_hputilities_version:
-  9.1.x: ""       # Not Supported
-  9.0.x: ""       # Not Supported
-  8.10.x: 8.6.7   # No Update
-  8.11.x: ""      # Not Supported
+  9.1.x: ""        # Not Supported
+  9.0.x: ""        # Not Supported
+  8.10.x: 8.6.7    # No Update
+  8.11.x: ""       # Not Supported
 mas_iot_version:
   9.1.x: 9.1.7     # Updated
   9.0.x: 9.0.16    # Updated
@@ -69,21 +116,21 @@ mas_iot_version:
   8.11.x: 8.8.26   # Updated
 mas_manage_version:
   9.2.x-feature: 9.2.0-pre.stable_10282 # Updated
-  9.1.x: 9.1.8         # Updated
-  9.0.x: 9.0.21        # Updated 
-  8.10.x: 8.6.34       # Updated
-  8.11.x: 8.7.28       # Updated
+  9.1.x: 9.1.8     # Updated
+  9.0.x: 9.0.21    # Updated
+  8.10.x: 8.6.34   # Updated
+  8.11.x: 8.7.28   # Updated
 mas_monitor_version:
-  9.1.x: 9.1.7    # Updated
-  9.0.x: 9.0.17   # Updated
-  8.10.x: 8.10.27 # Updated
-  8.11.x: 8.11.25 # Updated
+  9.1.x: 9.1.7     # Updated
+  9.0.x: 9.0.17    # Updated
+  8.10.x: 8.10.27  # Updated
+  8.11.x: 8.11.25  # Updated
 mas_optimizer_version:
   9.2.x-feature: 9.2.0-pre.stable_9869 # Updated
-  9.1.x: 9.1.8         # Updated
-  9.0.x: 9.0.19        # Updated
-  8.10.x: 8.4.26       # Updated
-  8.11.x: 8.5.25       # Updated
+  9.1.x: 9.1.8     # Updated
+  9.0.x: 9.0.19    # Updated
+  8.10.x: 8.4.26   # Updated
+  8.11.x: 8.5.25   # Updated
 mas_predict_version:
   9.1.x: 9.1.4     # Need to update
   9.0.x: 9.0.11    # Need to update
@@ -91,15 +138,18 @@ mas_predict_version:
   8.11.x: 8.9.14   # Need to update
 mas_visualinspection_version:
   9.2.x-feature: 9.2.0-pre.stable_6198 # Need to update
-  9.1.x: 9.1.7         # Updated
-  9.0.x: 9.0.16        # Updated
-  8.10.x: 8.8.4        # No Update
-  8.11.x: 8.9.19       # Updated
+  9.1.x: 9.1.7     # Updated
+  9.0.x: 9.0.16    # Updated
+  8.10.x: 8.8.4    # No Update
+  8.11.x: 8.9.19   # Updated
 mas_facilities_version:
   9.1.x: 9.1.7    # Updated
   9.0.x: ""       # Not Supported
   8.10.x: ""      # Not Supported
   8.11.x: ""      # Not Supported
+
+# TODO: What is this?  It almost certainly should not be here.
+manage_extras_913: 9.1.3
 
 
 # Maximo AI Service
@@ -107,47 +157,10 @@ mas_facilities_version:
 aiservice_version:
   9.2.x-feature: 9.2.0-pre.stable_9768 # Updated
   9.1.x: 9.1.11  # Updated
- 
 
-# Extra Images for UDS
+
+# Editorial
 # ------------------------------------------------------------------------------
-uds_extras_version: 1.5.0
-
-# Extra Images for Mongo
-# ------------------------------------------------------------------------------
-mongo_extras_version_default: 8.0.17
-
-# Variables used to mirror additional mongo image versions
-mongo_extras_version_4: 4.4.21
-mongo_extras_version_5: 5.0.23
-mongo_extras_version_6: 6.0.12
-mongo_extras_version_7: 7.0.23
-mongo_extras_version_8: 8.0.17
-
-# Extra Images for Db2u
-# ------------------------------------------------------------------------------
-db2u_extras_version: 1.0.6 # No Update
-db2u_filter: db2
-
-# Extra Images for CCS used for PCD 5.2.0 Hotfix
-# ------------------------------------------------------------------------------
-ccs_extras_version: 11.0.0
-
-# Extra Images for IBM Watson Discovery
-# ------------------------------------------------------------------------------
-#wd_extras_version: 1.0.4
-
-# Extra Images for Amlen
-# ------------------------------------------------------------------------------
-amlen_extras_version: 1.1.3
-
-# Default Cloud Pak for Data version
-# ------------------------------------------------------------------------------
-cpd_product_version_default: 5.2.0
-
-manage_extras_913: 9.1.3
-minio_version: RELEASE.2025-06-13T11-33-47Z
-
 editorial:
   whats_new:
   - title: '**Security updates and bug fixes**'

--- a/src/mas/devops/mas/suite.py
+++ b/src/mas/devops/mas/suite.py
@@ -54,7 +54,7 @@ def isAirgapInstall(dynClient: DynamicClient, checkICSP: bool = False) -> bool:
         return len(masIDMS.items) + len(aiserviceIDMS.items) > 0
 
 
-def getDefaultStorageClasses(dynClient: DynamicClient) -> dict:
+def getDefaultStorageClasses(dynClient: DynamicClient) -> SimpleNamespace:
     """
     Detect and return default storage classes for the cluster environment.
 

--- a/src/mas/devops/ocp.py
+++ b/src/mas/devops/ocp.py
@@ -318,7 +318,7 @@ def getConsoleURL(dynClient: DynamicClient) -> str:
     return f"https://{consoleRoute.spec.host}"
 
 
-def getNodes(dynClient: DynamicClient) -> str:
+def getNodes(dynClient: DynamicClient) -> dict:
     """
     Get all nodes in the cluster.
 
@@ -336,7 +336,7 @@ def getNodes(dynClient: DynamicClient) -> str:
     return nodes
 
 
-def getStorageClass(dynClient: DynamicClient, name: str) -> str:
+def getStorageClass(dynClient: DynamicClient, name: str) -> dict | None:
     """
     Get a specific StorageClass by name.
 


### PR DESCRIPTION
The catalog metadata file has grown quite messy over time, this update brings some order to the file, and notes some `TODOs` for us to investigate at a later date.

The file has been restructured for better organization with NO value changes. All version numbers and configuration values remain identical.

- Header Simplified
- Dependencies Reorganized into Logical Sections
- New Variables Added:
    - `datarefinery_version`
    - `db2_channel_default`
- Variables Removed:
    - `uds_version`: We no longer use UDS
    - `appconnect_version`: We no longer use AppConnect, and this version is ancient
    - `uds_extras_version`: We no longer use UDS
