### PR TITLE
[patch] Add known issue for v9-260129-amd64 catalog

### DIFF
--- a/src/mas/devops/data/catalogs/v9-260129-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260129-amd64.yaml
@@ -188,3 +188,4 @@ editorial:
   known_issues:
     - title: Customers using **Maximo Assist v8.7 or v8.8** should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
     - title: A known issue exists in the January 29, 2026 release affecting HSE and Oil & Gas (9.0.23 / 9.1.64). Customers with HSE installed should avoid upgrading to the January release. Installation of HSE or Oil & Gas on Manage 9.0.x / 9.1.x should be deferred until the February 2026 patch.
+    - title: A known issue has been identified in catalog version v9-260129-amd64.If you are using MAS 8.11.x with IoT 8.8.x, please do not use the v9-260129-amd64 catalog. Instead, use v9-260216-amd64.


### PR DESCRIPTION
Insert a new known-issues entry in src/mas/devops/data/catalogs/v9-260129-amd64.yaml warning that MAS 8.11.x with IoT 8.8.x is incompatible with the v9-260129-amd64 catalog and advising use of v9-260216-amd64 instead. This documents a compatibility problem to prevent incorrect catalog usage.