### PR TITLE
[patch] Add OCP 4.20 whats_new to catalogs

### DIFF
--- a/src/mas/devops/data/catalogs/v9-260226-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260226-amd64.yaml
@@ -151,6 +151,9 @@ minio_version: RELEASE.2025-06-13T11-33-47Z
 
 editorial:
   whats_new:
+
+  - title: '**Openshift 4.20 support** Openshift Container Platform 4.20 support has been added. Refer OCP 4.20 release notes [here](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/release_notes/index)'
+    details: []
   - title: '**Security updates and bug fixes**'
     details:
     - IBM Maximo Application Suite Core Platform [v8.10.35](https://www.ibm.com/support/pages/node/7261600), [v8.11.32](https://www.ibm.com/support/pages/node/7261601), [v9.0.21](https://www.ibm.com/support/pages/node/7261602) and [v9.1.10](https://www.ibm.com/support/pages/node/7261603)

--- a/src/mas/devops/data/catalogs/v9-260226-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260226-amd64.yaml
@@ -151,7 +151,6 @@ minio_version: RELEASE.2025-06-13T11-33-47Z
 
 editorial:
   whats_new:
-
   - title: '**Openshift 4.20 support** Openshift Container Platform 4.20 support has been added. Refer OCP 4.20 release notes [here](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/release_notes/index)'
     details: []
   - title: '**Security updates and bug fixes**'

--- a/src/mas/devops/data/catalogs/v9-260226-ppc64le.yaml
+++ b/src/mas/devops/data/catalogs/v9-260226-ppc64le.yaml
@@ -51,6 +51,9 @@ mongo_extras_version_8: 8.0.17
 
 editorial:
   whats_new:
+
+  - title: '**Openshift 4.20 support** Openshift Container Platform 4.20 support has been added. Refer OCP 4.20 release notes [here](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/release_notes/index)'
+    details: []
   - title: '**Security updates and bug fixes**'
     details:
     - IBM Maximo Application Suite Core Platform [v8.10.35](https://www.ibm.com/support/pages/node/7261600), [v8.11.32](https://www.ibm.com/support/pages/node/7261601), [v9.0.21](https://www.ibm.com/support/pages/node/7261602) and [v9.1.10](https://www.ibm.com/support/pages/node/7261603)

--- a/src/mas/devops/data/catalogs/v9-260226-ppc64le.yaml
+++ b/src/mas/devops/data/catalogs/v9-260226-ppc64le.yaml
@@ -51,7 +51,6 @@ mongo_extras_version_8: 8.0.17
 
 editorial:
   whats_new:
-
   - title: '**Openshift 4.20 support** Openshift Container Platform 4.20 support has been added. Refer OCP 4.20 release notes [here](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/release_notes/index)'
     details: []
   - title: '**Security updates and bug fixes**'

--- a/src/mas/devops/data/catalogs/v9-260226-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-260226-s390x.yaml
@@ -51,6 +51,9 @@ mongo_extras_version_8: 8.0.17
 
 editorial:
   whats_new:
+
+  - title: '**Openshift 4.20 support** Openshift Container Platform 4.20 support has been added. Refer OCP 4.20 release notes [here](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/release_notes/index)'
+    details: []
   - title: '**Security updates and bug fixes**'
     details:
     - IBM Maximo Application Suite Core Platform [v8.10.35](https://www.ibm.com/support/pages/node/7261600), [v8.11.32](https://www.ibm.com/support/pages/node/7261601), [v9.0.21](https://www.ibm.com/support/pages/node/7261602) and [v9.1.10](https://www.ibm.com/support/pages/node/7261603)

--- a/src/mas/devops/data/catalogs/v9-260226-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-260226-s390x.yaml
@@ -51,7 +51,6 @@ mongo_extras_version_8: 8.0.17
 
 editorial:
   whats_new:
-
   - title: '**Openshift 4.20 support** Openshift Container Platform 4.20 support has been added. Refer OCP 4.20 release notes [here](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/release_notes/index)'
     details: []
   - title: '**Security updates and bug fixes**'


### PR DESCRIPTION
Insert an 'Openshift 4.20 support' whats_new entry into the v9-260226 catalog YAMLs for amd64, ppc64le, and s390x to announce OpenShift Container Platform 4.20 support (with link to Red Hat release notes). Files modified: src/mas/devops/data/catalogs/v9-260226-amd64.yaml, src/mas/devops/data/catalogs/v9-260226-ppc64le.yaml, src/mas/devops/data/catalogs/v9-260226-s390x.yaml.