### PR TITLE
[minor] Support March Interim Catalog Update

### DIFF
--- a/src/mas/devops/data/catalogs/v9-260313-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260313-amd64.yaml
@@ -157,7 +157,7 @@ editorial:
     - IBM Maximo Manage 9.1.12
     - IBM Truststore Manager v1.7
     - IBM Suite License Service v3.12
-    - Amlen 1.1.4
+    - Amlen v1.1
   known_issues:
     - title: Customers using **Maximo Assist v8.7 or v8.8** should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
     - title: A known issue exists in the January 29, 2026 release affecting HSE and Oil & Gas (9.0.23 / 9.1.64). Customers with HSE installed should avoid upgrading to the January release. Installation of HSE or Oil & Gas on Manage 9.0.x / 9.1.x should be deferred until the February 2026 patch.

--- a/src/mas/devops/data/catalogs/v9-260313-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260313-amd64.yaml
@@ -28,7 +28,7 @@ db2_channel_default: v110509.0               # Default Channel version for db2u-
 events_version: 5.0.1                        # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
 uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
 sls_version: 3.12.5     # No Update          # Operator version 3.12.5 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
-tsm_version: 1.7.4      # Updated            # Operator version 1.7.4 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
+tsm_version: 1.7.4      # No Update            # Operator version 1.7.4 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
 dd_version: 1.1.22                           # Operator version 1.1.22 (https://github.ibm.com/maximoappsuite/ibm-data-dictionary/releases)
 appconnect_version: 6.2.0                    # Operator version 6.2.0 # sticking to 6.2.0 version # Please do Not Change
 wsl_version: 11.0.0+20250521.202913.73                     # used for wsl and wsl_runtimes unless wsl_runtimes_version also specified
@@ -50,7 +50,7 @@ opensearch_version: 1.1.2494                # Operator version 1.1.2494
 mas_core_version:
   9.2.x-feature: 9.2.0-pre.stable_12926 # No Update
   9.1.x: 9.1.10        #  No Update
-  9.0.x: 9.0.22        #  Updated
+  9.0.x: 9.0.22        #  No Update
   8.10.x: 8.10.35      #  No Update
   8.11.x: 8.11.32      #  No Update
 mas_assist_version:

--- a/src/mas/devops/data/catalogs/v9-260313-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260313-amd64.yaml
@@ -5,7 +5,7 @@
 # catalog itself, but not everything in the catalog supports this yet (including MAS)
 # so we need to use the CASE bundle mirror process still.
 
-catalog_digest: sha256:192fdb38b135b828916fba8d77c6bee10e6c4f33b4cfd252576ca120e442784b
+catalog_digest: sha256:66da7dea7160091ed39a96862cd0046df20c2eeaeb262778dcd5d37b11a3f26b
 
 ocp_compatibility:
 - "4.16"
@@ -27,8 +27,8 @@ db2u_version: 7.3.1+20250821.161005.16793    # Operator version 110509.0.6 to fi
 db2_channel_default: v110509.0               # Default Channel version for db2u-operator
 events_version: 5.0.1                        # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
 uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
-sls_version: 3.12.5     # No Update          # Operator version 3.12.5 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
-tsm_version: 1.7.4      # No Update            # Operator version 1.7.4 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
+sls_version: 3.12.6     # Updated          # Operator version 3.12.5 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
+tsm_version: 1.7.5      # Updated            # Operator version 1.7.4 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
 dd_version: 1.1.22                           # Operator version 1.1.22 (https://github.ibm.com/maximoappsuite/ibm-data-dictionary/releases)
 appconnect_version: 6.2.0                    # Operator version 6.2.0 # sticking to 6.2.0 version # Please do Not Change
 wsl_version: 11.0.0+20250521.202913.73                     # used for wsl and wsl_runtimes unless wsl_runtimes_version also specified
@@ -49,7 +49,7 @@ opensearch_version: 1.1.2494                # Operator version 1.1.2494
 # -----------------------------------------------------------------------------
 mas_core_version:
   9.2.x-feature: 9.2.0-pre.stable_12926 # No Update
-  9.1.x: 9.1.10        #  No Update
+  9.1.x: 9.1.11        #  Updated
   9.0.x: 9.0.22        #  No Update
   8.10.x: 8.10.35      #  No Update
   8.11.x: 8.11.32      #  No Update
@@ -70,7 +70,7 @@ mas_iot_version:
   8.11.x: 8.8.28   #  No Update
 mas_manage_version:
   9.2.x-feature: 9.2.0-pre.stable_13730 #  No Update
-  9.1.x: 9.1.11        #  No Update
+  9.1.x: 9.1.12        #  Updated
   9.0.x: 9.0.23        #  No Update
   8.10.x: 8.6.36       #  No Update
   8.11.x: 8.7.30       #  No Update
@@ -158,3 +158,4 @@ editorial:
   known_issues:
     - title: Customers using **Maximo Assist v8.7 or v8.8** should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
     - title: A known issue exists in the January 29, 2026 release affecting HSE and Oil & Gas (9.0.23 / 9.1.64). Customers with HSE installed should avoid upgrading to the January release. Installation of HSE or Oil & Gas on Manage 9.0.x / 9.1.x should be deferred until the February 2026 patch.
+    - title: A known issue has been identified in Db2u warehouse operator in this catalog. Customers restoring/upgrading Db2, intermittently get db2 `SQL0290N  Table space access is not allowed.  SQLSTATE=55039` error causing connectivity issue between MAS and Db2. If you are facing this problem, please refer to the workaround provided in this [documentation](https://www.ibm.com/docs/en/cloud-paks/cp-data/5.3.x?topic=SSQNUZ_5.3.x/svc-db2/known-issues-dbs.htm#known-issues-dbs__db2-instance-fails-sql0290n__title__1).

--- a/src/mas/devops/data/catalogs/v9-260313-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260313-amd64.yaml
@@ -83,7 +83,7 @@ mas_optimizer_version:
   9.2.x-feature: 9.2.0-pre.stable_12739 #  No Update
   9.1.x: 9.1.9         #  No Update
   9.0.x: 9.0.20        #  No Update
-  8.10.x: 8.4.26       #  Need to update
+  8.10.x: 8.4.26       #  No Update
   8.11.x: 8.5.26       #  No Update
 mas_predict_version:
   9.1.x: 9.1.5     # No Update
@@ -140,7 +140,7 @@ ccs_extras_version: 11.0.0
 
 # Extra Images for Amlen
 # ------------------------------------------------------------------------------
-amlen_extras_version: 1.1.3
+amlen_extras_version: 1.1.4
 
 # Default Cloud Pak for Data version
 # ------------------------------------------------------------------------------

--- a/src/mas/devops/data/catalogs/v9-260313-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260313-amd64.yaml
@@ -157,6 +157,7 @@ editorial:
     - IBM Maximo Manage 9.1.12
     - IBM Truststore Manager v1.7
     - IBM Suite License Service v3.12
+    - Amlen 1.1.4
   known_issues:
     - title: Customers using **Maximo Assist v8.7 or v8.8** should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
     - title: A known issue exists in the January 29, 2026 release affecting HSE and Oil & Gas (9.0.23 / 9.1.64). Customers with HSE installed should avoid upgrading to the January release. Installation of HSE or Oil & Gas on Manage 9.0.x / 9.1.x should be deferred until the February 2026 patch.

--- a/src/mas/devops/data/catalogs/v9-260313-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260313-amd64.yaml
@@ -1,0 +1,160 @@
+---
+# Case bundle configuration for IBM Maximo Operator Catalog 260313 (AMD64)
+# -----------------------------------------------------------------------------
+# In the future this won't be necessary as we'll be able to mirror from the
+# catalog itself, but not everything in the catalog supports this yet (including MAS)
+# so we need to use the CASE bundle mirror process still.
+
+catalog_digest: sha256:192fdb38b135b828916fba8d77c6bee10e6c4f33b4cfd252576ca120e442784b
+
+ocp_compatibility:
+- "4.16"
+- "4.17"
+- "4.18"
+- "4.19"
+- "4.20"
+
+# Dependencies
+# -----------------------------------------------------------------------------
+ibm_licensing_version: 4.2.17                # Operator version 4.2.14 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-licensing)
+common_svcs_version: 4.13.0                  # Operator version 4.13.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+common_svcs_version_1: 4.11.0                  # Additional version 4.11.0
+
+cp4d_platform_version: 5.2.0+20250709.170324               # Operator version 5.2.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-datacore/)
+ibm_zen_version: 6.2.0+20250530.152516.232                     # For CPD5 ibm-zen has to be explicitily mirrored
+
+db2u_version: 7.3.1+20250821.161005.16793    # Operator version 110509.0.6 to find the version 7.3.1+20250821.161005.16793, search db2u-operator digest on repo (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+db2_channel_default: v110509.0               # Default Channel version for db2u-operator
+events_version: 5.0.1                        # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
+uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
+sls_version: 3.12.5     # No Update          # Operator version 3.12.5 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
+tsm_version: 1.7.4      # Updated            # Operator version 1.7.4 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
+dd_version: 1.1.22                           # Operator version 1.1.22 (https://github.ibm.com/maximoappsuite/ibm-data-dictionary/releases)
+appconnect_version: 6.2.0                    # Operator version 6.2.0 # sticking to 6.2.0 version # Please do Not Change
+wsl_version: 11.0.0+20250521.202913.73                     # used for wsl and wsl_runtimes unless wsl_runtimes_version also specified
+wsl_runtimes_version: 11.0.0+20250515.090949.21               # cpd 5.1.3 uses version 10.3.0 of wsl runtimes but only 10.2.0 for wsl itself
+wml_version: 11.0.0+20250530.193146.282                             # Operator version 5.2.0
+postgress_version: 5.16.0+20250827.110911.2626                # ibm-cpd-cloud-native-postgresql-operator 5.2.0 cp4d 
+
+ccs_build: 11.0.0+20250605.130237.468       # cpd 5.2.0 using ccs build
+# datarefinery_build: +20240517.202103.146
+
+spark_version: 11.0.0+20250604.163055.2097                      # Operator version 5.2.0
+cognos_version: 28.0.0+20250515.175459.10054                     # Operator version 25.0.0
+couchdb_version: 1.0.13                     # Operator version 2.2.1 (1.0.13) sticking with 1.0.13 # (This is required for Assist 9.0, https://github.com/IBM/cloud-pak/blob/master/repo/case/ibm-couchdb/index.yaml)
+elasticsearch_version: 1.1.2667           # Operator version 1.1.2667 # used in cpd 5.1.3 only
+opensearch_version: 1.1.2494                # Operator version 1.1.2494
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  9.2.x-feature: 9.2.0-pre.stable_12926 # No Update
+  9.1.x: 9.1.10        #  No Update
+  9.0.x: 9.0.22        #  Updated
+  8.10.x: 8.10.35      #  No Update
+  8.11.x: 8.11.32      #  No Update
+mas_assist_version:
+  9.1.x: 9.1.8     #  No Update
+  9.0.x: 9.0.14    #  No Update
+  8.10.x: 8.7.8   # No Update
+  8.11.x: 8.8.7   # No Update
+mas_hputilities_version:
+  9.1.x: ""       # Not Supported
+  9.0.x: ""       # Not Supported
+  8.10.x: 8.6.7   # No Update
+  8.11.x: ""      # Not Supported
+mas_iot_version:
+  9.1.x: 9.1.8     #  No Update
+  9.0.x: 9.0.17    #  No Update
+  8.10.x: 8.7.31   #  No Update
+  8.11.x: 8.8.28   #  No Update
+mas_manage_version:
+  9.2.x-feature: 9.2.0-pre.stable_13730 #  No Update
+  9.1.x: 9.1.11        #  No Update
+  9.0.x: 9.0.23        #  No Update
+  8.10.x: 8.6.36       #  No Update
+  8.11.x: 8.7.30       #  No Update
+mas_monitor_version:
+  9.1.x: 9.1.8    #  No Update
+  9.0.x: 9.0.18   #  No Update
+  8.10.x: 8.10.28 #  No Update
+  8.11.x: 8.11.26 #  No Update
+mas_optimizer_version:
+  9.2.x-feature: 9.2.0-pre.stable_12739 #  No Update
+  9.1.x: 9.1.9         #  No Update
+  9.0.x: 9.0.20        #  No Update
+  8.10.x: 8.4.26       #  Need to update
+  8.11.x: 8.5.26       #  No Update
+mas_predict_version:
+  9.1.x: 9.1.5     # No Update
+  9.0.x: 9.0.12    # No Update
+  8.10.x: 8.8.13   # No Update
+  8.11.x: 8.9.15   # No Update
+mas_visualinspection_version:
+  9.2.x-feature: 9.2.0-pre.stable_12598 # No Update
+  9.1.x: 9.1.10        #  No Update
+  9.0.x: 9.0.17        #  No Update
+  8.10.x: 8.8.4        #  No Update
+  8.11.x: 8.9.20       #  No Update
+mas_facilities_version:
+  9.1.x: 9.1.8    #  No Update
+  9.0.x: ""       # Not Supported
+  8.10.x: ""      # Not Supported
+  8.11.x: ""      # Not Supported
+
+
+# Maximo AI Service
+# ------------------------------------------------------------------------------
+aiservice_version:
+  9.2.x-feature: 9.2.0-pre.stable_12908 #  No Update
+  9.1.x: 9.1.12  #  No Update
+ 
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.5.0
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version_default: 8.0.17
+
+# Variables used to mirror additional mongo image versions
+mongo_extras_version_4: 4.4.21
+mongo_extras_version_5: 5.0.23
+mongo_extras_version_6: 6.0.12
+mongo_extras_version_7: 7.0.23
+mongo_extras_version_8: 8.0.17
+
+# Extra Images for Db2u
+# ------------------------------------------------------------------------------
+db2u_extras_version: 1.0.6 # No Update
+db2u_filter: db2
+
+# Extra Images for CCS used for PCD 5.2.0 Hotfix
+# ------------------------------------------------------------------------------
+ccs_extras_version: 11.0.0
+
+# Extra Images for IBM Watson Discovery
+# ------------------------------------------------------------------------------
+#wd_extras_version: 1.0.4
+
+# Extra Images for Amlen
+# ------------------------------------------------------------------------------
+amlen_extras_version: 1.1.3
+
+# Default Cloud Pak for Data version
+# ------------------------------------------------------------------------------
+cpd_product_version_default: 5.2.0
+
+manage_extras_913: 9.1.3
+minio_version: RELEASE.2025-06-13T11-33-47Z
+
+editorial:
+  whats_new:
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v9.0.22
+    - IBM Truststore Manager v1.7 
+  known_issues:
+    - title: Customers using **Maximo Assist v8.7 or v8.8** should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
+    - title: A known issue exists in the January 29, 2026 release affecting HSE and Oil & Gas (9.0.23 / 9.1.64). Customers with HSE installed should avoid upgrading to the January release. Installation of HSE or Oil & Gas on Manage 9.0.x / 9.1.x should be deferred until the February 2026 patch.

--- a/src/mas/devops/data/catalogs/v9-260313-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260313-amd64.yaml
@@ -153,8 +153,10 @@ editorial:
   whats_new:
   - title: '**Security updates and bug fixes**'
     details:
-    - IBM Maximo Application Suite Core Platform v9.0.22
-    - IBM Truststore Manager v1.7 
+    - IBM Maximo Application Suite Core Platform v9.1.11
+    - IBM Maximo Manage 9.1.12
+    - IBM Truststore Manager v1.7
+    - IBM Suite License Service v3.12
   known_issues:
     - title: Customers using **Maximo Assist v8.7 or v8.8** should not update and must instead contact IBM Support for guidance regarding the removal of IBM Watson Discovery and upgrading to Maximo Assist v9.0
     - title: A known issue exists in the January 29, 2026 release affecting HSE and Oil & Gas (9.0.23 / 9.1.64). Customers with HSE installed should avoid upgrading to the January release. Installation of HSE or Oil & Gas on Manage 9.0.x / 9.1.x should be deferred until the February 2026 patch.

--- a/src/mas/devops/data/catalogs/v9-260313-ppc64le.yaml
+++ b/src/mas/devops/data/catalogs/v9-260313-ppc64le.yaml
@@ -5,7 +5,7 @@
 # catalog itself, but not everything in the catalog supports this yet (including MAS)
 # so we need to use the CASE bundle mirror process still.
 
-catalog_digest: sha256:5defbc1701537d0f5dcb60de1cf43fe687dde1d0d10074b21e82fbc222aa81de
+catalog_digest: sha256:e15e7288ac2e79cc5fef02ae0fdb2a528b5447b03cf1d7bdc50b4893ba7474f5
 
 ocp_compatibility:
 - "4.16"
@@ -15,21 +15,21 @@ ocp_compatibility:
 - "4.20"
 
 uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
-sls_version: 3.12.5     # No Update          # Operator version 3.12.5 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
-tsm_version: 1.7.4      # No Update            # Operator version 1.7.4 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
+sls_version: 3.12.6     # Updated         # Operator version 3.12.5 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
+tsm_version: 1.7.5      # Updated            # Operator version 1.7.4 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
 db2u_version: 7.3.1+20250821.161005.16793    # Operator version 110509.0.6 to find the version 7.3.1+20250821.161005.16793, search db2u-operator digest on repo (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
 
 # Maximo Application Suite
 # -----------------------------------------------------------------------------
 mas_core_version:
   9.2.x-feature: 9.2.0-pre.stable_12926 # No Update
-  9.1.x: 9.1.10                         # No Update
+  9.1.x: 9.1.11                         # Updated
   9.0.x: 9.0.22                         # No Update
   8.10.x: ""                            # Not Supported
   8.11.x: ""                            # Not Supported
 mas_manage_version:
   9.2.x-feature: 9.2.0-pre.stable_13730 # No Update
-  9.1.x: 9.1.11                         # No Update
+  9.1.x: 9.1.12                         # Updated
   9.0.x: 9.0.23                         # No Update
   8.10.x: ""                            # Not Supported
   8.11.x: ""                            # Not Supported

--- a/src/mas/devops/data/catalogs/v9-260313-ppc64le.yaml
+++ b/src/mas/devops/data/catalogs/v9-260313-ppc64le.yaml
@@ -1,0 +1,59 @@
+---
+# Case bundle configuration for IBM Maximo Operator Catalog 260313 (PPC)
+# -----------------------------------------------------------------------------
+# In the future this won't be necessary as we'll be able to mirror from the
+# catalog itself, but not everything in the catalog supports this yet (including MAS)
+# so we need to use the CASE bundle mirror process still.
+
+catalog_digest: sha256:5defbc1701537d0f5dcb60de1cf43fe687dde1d0d10074b21e82fbc222aa81de
+
+ocp_compatibility:
+- "4.16"
+- "4.17"
+- "4.18"
+- "4.19"
+- "4.20"
+
+uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
+sls_version: 3.12.5     # No Update          # Operator version 3.12.5 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
+tsm_version: 1.7.4      # No Update            # Operator version 1.7.4 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
+db2u_version: 7.3.1+20250821.161005.16793    # Operator version 110509.0.6 to find the version 7.3.1+20250821.161005.16793, search db2u-operator digest on repo (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  9.2.x-feature: 9.2.0-pre.stable_12926 # No Update
+  9.1.x: 9.1.10                         # No Update
+  9.0.x: 9.0.22                         # No Update
+  8.10.x: ""                            # Not Supported
+  8.11.x: ""                            # Not Supported
+mas_manage_version:
+  9.2.x-feature: 9.2.0-pre.stable_13730 # No Update
+  9.1.x: 9.1.11                         # No Update
+  9.0.x: 9.0.23                         # No Update
+  8.10.x: ""                            # Not Supported
+  8.11.x: ""                            # Not Supported
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.5.0
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version_default: 8.0.17
+
+# Variables used to mirror additional mongo image versions
+mongo_extras_version_4: 4.4.21
+mongo_extras_version_5: 5.0.23
+mongo_extras_version_6: 6.0.12
+mongo_extras_version_7: 7.0.12
+mongo_extras_version_8: 8.0.17
+
+editorial:
+  whats_new:
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v9.0.22
+    - IBM Truststore Manager v1.7
+  known_issues:
+    - title: A known issue exists in the January 29, 2026 release affecting HSE and Oil & Gas (9.0.23 / 9.1.64). Customers with HSE installed should avoid upgrading to the January release. Installation of HSE or Oil & Gas on Manage 9.0.x / 9.1.x should be deferred until the February 2026 patch.

--- a/src/mas/devops/data/catalogs/v9-260313-ppc64le.yaml
+++ b/src/mas/devops/data/catalogs/v9-260313-ppc64le.yaml
@@ -53,7 +53,9 @@ editorial:
   whats_new:
   - title: '**Security updates and bug fixes**'
     details:
-    - IBM Maximo Application Suite Core Platform v9.0.22
+    - IBM Maximo Application Suite Core Platform v9.1.11
+    - IBM Maximo Manage 9.1.12
     - IBM Truststore Manager v1.7
+    - IBM Suite License Service v3.12
   known_issues:
     - title: A known issue exists in the January 29, 2026 release affecting HSE and Oil & Gas (9.0.23 / 9.1.64). Customers with HSE installed should avoid upgrading to the January release. Installation of HSE or Oil & Gas on Manage 9.0.x / 9.1.x should be deferred until the February 2026 patch.

--- a/src/mas/devops/data/catalogs/v9-260313-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-260313-s390x.yaml
@@ -1,0 +1,59 @@
+---
+# Case bundle configuration for IBM Maximo Operator Catalog 260313 (Z)
+# -----------------------------------------------------------------------------
+# In the future this won't be necessary as we'll be able to mirror from the
+# catalog itself, but not everything in the catalog supports this yet (including MAS)
+# so we need to use the CASE bundle mirror process still.
+
+catalog_digest: sha256:9d26c342e18eabc90b2c0a4e6cd0fde33b2570ba0a562b9d2e172dda5e4daa37
+
+ocp_compatibility:
+- "4.16"
+- "4.17"
+- "4.18"
+- "4.19"
+- "4.20"
+
+uds_version: 2.0.12                           # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
+sls_version: 3.12.5  # No Update              # Operator version 3.12.5 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
+tsm_version: 1.7.4   # No Update                # Operator version 1.7.4 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
+db2u_version: 7.3.1+20250821.161005.16793     # Operator version 110509.0.6 to find the version 7.3.1+20250821.161005.16793, search db2u-operator digest on repo (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  9.2.x-feature: 9.2.0-pre.stable_12926 # No Update 
+  9.1.x: 9.1.10                         # No Update
+  9.0.x: 9.0.22                         # No Update
+  8.10.x: ""                            # Not Supported
+  8.11.x: ""                            # Not Supported
+mas_manage_version:
+  9.2.x-feature: 9.2.0-pre.stable_13730 # No Update
+  9.1.x: 9.1.11                         # No Update
+  9.0.x: 9.0.23                         # No Update
+  8.10.x: ""                            # Not Supported
+  8.11.x: ""                            # Not Supported
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.5.0
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version_default: 8.0.17
+
+# Variables used to mirror additional mongo image versions
+mongo_extras_version_4: 4.4.21
+mongo_extras_version_5: 5.0.23
+mongo_extras_version_6: 6.0.12
+mongo_extras_version_7: 7.0.12
+mongo_extras_version_8: 8.0.17
+
+editorial:
+  whats_new:
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform v9.0.22
+    - IBM Truststore Manager v1.7
+  known_issues:
+    - title: A known issue exists in the January 29, 2026 release affecting HSE and Oil & Gas (9.0.23 / 9.1.64). Customers with HSE installed should avoid upgrading to the January release. Installation of HSE or Oil & Gas on Manage 9.0.x / 9.1.x should be deferred until the February 2026 patch.

--- a/src/mas/devops/data/catalogs/v9-260313-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-260313-s390x.yaml
@@ -5,7 +5,7 @@
 # catalog itself, but not everything in the catalog supports this yet (including MAS)
 # so we need to use the CASE bundle mirror process still.
 
-catalog_digest: sha256:9d26c342e18eabc90b2c0a4e6cd0fde33b2570ba0a562b9d2e172dda5e4daa37
+catalog_digest: sha256:6fbd933bf20acb2b93e7dcbf97a470cd61ece22a0560ba197e014255223f8c7d
 
 ocp_compatibility:
 - "4.16"
@@ -15,21 +15,21 @@ ocp_compatibility:
 - "4.20"
 
 uds_version: 2.0.12                           # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
-sls_version: 3.12.5  # No Update              # Operator version 3.12.5 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
-tsm_version: 1.7.4   # No Update                # Operator version 1.7.4 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
+sls_version: 3.12.6     # Updated         # Operator version 3.12.5 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
+tsm_version: 1.7.5      # Updated            # Operator version 1.7.4 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
 db2u_version: 7.3.1+20250821.161005.16793     # Operator version 110509.0.6 to find the version 7.3.1+20250821.161005.16793, search db2u-operator digest on repo (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
 
 # Maximo Application Suite
 # -----------------------------------------------------------------------------
 mas_core_version:
   9.2.x-feature: 9.2.0-pre.stable_12926 # No Update 
-  9.1.x: 9.1.10                         # No Update
+  9.1.x: 9.1.11                         # Updated
   9.0.x: 9.0.22                         # No Update
   8.10.x: ""                            # Not Supported
   8.11.x: ""                            # Not Supported
 mas_manage_version:
   9.2.x-feature: 9.2.0-pre.stable_13730 # No Update
-  9.1.x: 9.1.11                         # No Update
+  9.1.x: 9.1.12                         # Updated
   9.0.x: 9.0.23                         # No Update
   8.10.x: ""                            # Not Supported
   8.11.x: ""                            # Not Supported

--- a/src/mas/devops/data/catalogs/v9-260313-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-260313-s390x.yaml
@@ -53,7 +53,9 @@ editorial:
   whats_new:
   - title: '**Security updates and bug fixes**'
     details:
-    - IBM Maximo Application Suite Core Platform v9.0.22
+    - IBM Maximo Application Suite Core Platform v9.1.11
+    - IBM Maximo Manage 9.1.12
     - IBM Truststore Manager v1.7
+    - IBM Suite License Service v3.12
   known_issues:
     - title: A known issue exists in the January 29, 2026 release affecting HSE and Oil & Gas (9.0.23 / 9.1.64). Customers with HSE installed should avoid upgrading to the January release. Installation of HSE or Oil & Gas on Manage 9.0.x / 9.1.x should be deferred until the February 2026 patch.


### PR DESCRIPTION
Catalog PR: https://github.ibm.com/maximoappsuite/ibm-maximo-operator-catalog/pull/925
FVT validation Jira: https://jsw.ibm.com/browse/MASCORE-12685

Addres kubernetes no_proxy issue MASISMIG-73418

Downgrade the Python kubernetes client to 33.1.0 as a temporary workaround for a proxy-related regression introduced in newer releases. Upstream issues report that versions 34.1.0+ can mishandle no_proxy, causing åKubernetes API requests that should bypass a configured proxy to be routed through it instead. In our OpenShift Ansible operator environment, this affects in-cluster API access when cluster-wide proxy variables are present. This change restores the previously working client version while we investigate if a longer-term fix: explicitly configuring kubernetes.core with K8S_AUTH_PROXY and K8S_AUTH_NO_PROXY is required rather than relying on inherited standard proxy environment variables.

Amlen
Amlen 1.1.3 has an issue in it because the operator pod has a kube-rbac-proxy container running and the image it references no longer exists so need to move to 1.1.4

verified in run 5056 here:
https://dashboard.ibmmas.com/tests/ib-dev2
uses catalog v9-ib-dev3-amd64

Jira issue:
https://jsw.ibm.com/browse/MASCORE-12655