### PR TITLE
[patch] include_mongo flag to allow to include/exclude mongo backup and restore

### DIFF
--- a/src/mas/devops/templates/pipelinerun-backup.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-backup.yml.j2
@@ -38,6 +38,11 @@ spec:
       value: "{{ include_sls }}"
     {% endif %}
 
+    {% if include_mongo is defined and include_mongo != "" %}
+    - name: include_mongo
+      value: "{{ include_mongo }}"
+    {% endif %}
+
     # MongoDB Configuration
     {% if mongodb_namespace is defined and mongodb_namespace != "" %}
     - name: mongodb_namespace

--- a/src/mas/devops/templates/pipelinerun-restore.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-restore.yml.j2
@@ -36,6 +36,10 @@ spec:
       value: "{{ restore_version }}"
 
     # Component Flags
+    {% if include_mongo is defined and include_mongo != "" %}
+    - name: include_mongo
+      value: "{{ include_mongo }}"
+    {% endif %}
     {% if include_sls is defined and include_sls != "" %}
     - name: include_sls
       value: "{{ include_sls }}"


### PR DESCRIPTION
include_mongo flag will be used to include/exclude mongo step in backup/restore.