### PR TITLE
[patch] integrate monthlyupdate changes and add mas_monitor_install_order support in pipelineruns

### DIFF
--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -707,6 +707,10 @@ spec:
     # -------------------------------------------------------------------------
     - name: mas_app_channel_monitor
       value: "{{ mas_app_channel_monitor }}"
+  {%- if mas_monitor_install_order is defined and mas_monitor_install_order != "" %}
+    - name: mas_monitor_install_order
+      value: "{{ mas_monitor_install_order }}"
+  {%- endif %}
 {%- endif %}
 {%- if mas_app_channel_optimizer is defined and mas_app_channel_optimizer != "" %}
 

--- a/src/mas/devops/templates/pipelinerun-upgrade.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-upgrade.yml.j2
@@ -119,6 +119,13 @@ spec:
       value: "{{ db2_data_storage_size }}"
   {%- endif %}
 {%- endif %}
+{%- if mas_monitor_install_order is defined and mas_monitor_install_order != "" %}
+
+    # Monitor Install Order
+    # -------------------------------------------------------------------------
+    - name: mas_monitor_install_order
+      value: "{{ mas_monitor_install_order }}"
+{%- endif %}
 {%- if mas_app_channel_manage is defined and mas_app_channel_manage != "" %}
 
     # Manage Application


### PR DESCRIPTION
Key Changes
1. Monitor Install Order Support for Version > 9.2+
Added mas_monitor_install_order parameter to:
pipelinerun-install.yml.j2
pipelinerun-upgrade.yml.j2
Enables pipeline-level control of Monitor installation sequencing based on version compatibility