### PR TITLE
[patch] fix for clean_backup flag in backup and restore pipelinerun

### DIFF
--- a/src/mas/devops/templates/pipelinerun-backup.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-backup.yml.j2
@@ -31,6 +31,10 @@ spec:
     # Backup Configuration
     - name: backup_version
       value: "{{ backup_version }}"
+    {% if clean_backup is defined and clean_backup != "" %}
+    - name: clean_backup
+      value: "{{ clean_backup }}"
+    {% endif %}
 
     # Component Flags
     {% if include_sls is defined and include_sls != "" %}

--- a/src/mas/devops/templates/pipelinerun-restore.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-restore.yml.j2
@@ -34,6 +34,10 @@ spec:
     # Restore Configuration
     - name: restore_version
       value: "{{ restore_version }}"
+    {% if clean_backup is defined and clean_backup != "" %}
+    - name: clean_backup
+      value: "{{ clean_backup }}"
+    {% endif %}
 
     # Component Flags
     {% if include_mongo is defined and include_mongo != "" %}


### PR DESCRIPTION
clean_backup param was missing and the default was always been used.