### PR TITLE
[patch] Remove use of pandoc to convert to RST

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,6 @@ __pycache__/
 # Distribution / packaging
 dist
 *.egg-info
-pandoc-*-amd64.deb
-pandoc-*-windows-x86_64.msi
-pandoc-*-x86_64-macOS.pkg
-README.rst
 
 # Environments
 .venv/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [build-system]
 requires = [
-  "setuptools",
-  "pypandoc"
+  "setuptools"
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -14,13 +14,8 @@ import os
 sys.path.insert(0, 'src')
 
 
-if not os.path.exists('README.rst'):
-    import pypandoc
-    pypandoc.download_pandoc(targetfolder='~/bin/')
-    pypandoc.convert_file('README.md', 'rst', outputfile='README.rst')
-
 here = os.path.abspath(os.path.dirname(__file__))
-with open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
+with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 # Maintain a single source of versioning
@@ -54,6 +49,7 @@ setup(
     license='Eclipse Public License - v1.0',
     description='Python for Maximo Application Suite Dev/Ops',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     install_requires=[
         'pyyaml',                  # MIT License
         'openshift',               # Apache Software License


### PR DESCRIPTION
PyPi has long supported markdown format, we just need to add 

```
    long_description_content_type='text/markdown',
```