### PR TITLE
[patch] include mas_use_service_mesh install parameter to the install pipeline

### DIFF
--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -541,6 +541,10 @@ spec:
     - name: mas_ingress_controller_name
       value: "{{ mas_ingress_controller_name }}"
 {%- endif %}
+{%- if mas_use_service_mesh is defined and mas_use_service_mesh != "" %}
+    - name: mas_use_service_mesh
+      value: "{{ mas_use_service_mesh }}"
+{%- endif %}
 {%- if mas_deployment_progression is defined and mas_deployment_progression != "" %}
     - name: mas_deployment_progression
       value: "{{ mas_deployment_progression }}"


### PR DESCRIPTION
## Description
the mas_use_service_mesh parameter is required by the suite_install role to set istio annotation on the mas core namespace, causing mas core pods to start with the Service Mesh sidecar containers.

## Related Issues
https://jsw.ibm.com/browse/MASCORE-12032

## Test Results
Developed and tested on the servicemesh-489 cluster. Pre-release testing in personal FVT cluster pds.
FVT test results are here: https://dashboard.ibmmas.com/tests/pds build 6066. 

FVT tests show some failures, but similar to normal fvt stable runs, it looks like nothing fundamental is broken by using service mesh:
```
Build 6066 - Core
Failures: 13
Total Tests: 2574
Skipped: 1350
Failures: 13
Errors: 0
```
