### PR TITLE
[minor] Support scheduling configuration for AI Service tenant

### DIFF
--- a/src/mas/devops/tekton.py
+++ b/src/mas/devops/tekton.py
@@ -563,12 +563,12 @@ def prepareRestoreSecrets(dynClient: DynamicClient, namespace: str, restoreConfi
     secretsAPI.create(body=restoreConfigs, namespace=namespace)
 
 
-def prepareInstallSecrets(dynClient: DynamicClient, namespace: str, slsLicenseFile: str = None, additionalConfigs: dict = None, certs: str = None, podTemplates: str = None, slack_token: str = None, slack_channel: str = None) -> None:
+def prepareInstallSecrets(dynClient: DynamicClient, namespace: str, slsLicenseFile: str = None, additionalConfigs: dict = None, certs: str = None, podTemplates: str = None, slack_token: str = None, slack_channel: str = None, aiserviceConfig: str = None) -> None:
     """
     Create or update secrets required for MAS installation pipelines.
 
     Creates five secrets in the specified namespace: mas-devops-slack, pipeline-additional-configs,
-    pipeline-sls-entitlement, pipeline-certificates, and pipeline-pod-templates.
+    pipeline-sls-entitlement, pipeline-certificates, pipeline-pod-templates and pipeline-aiservice-config.
 
     Parameters:
         dynClient (DynamicClient): OpenShift Dynamic Client
@@ -579,6 +579,7 @@ def prepareInstallSecrets(dynClient: DynamicClient, namespace: str, slsLicenseFi
         podTemplates (str, optional): Pod template data. Defaults to None (empty secret).
         slack_token (str, optional): Slack bot token for notifications. Defaults to None.
         slack_channel (str, optional): Slack channel ID for notifications. Defaults to None.
+        aiserviceConfig (str, optional): AI Service tenant config data. Defaults to None (empty secret).
 
     Returns:
         None
@@ -700,6 +701,24 @@ def prepareInstallSecrets(dynClient: DynamicClient, namespace: str, slsLicenseFi
             }
         }
     secretsAPI.create(body=podTemplates, namespace=namespace)
+
+    # 5. Secret/pipeline-aiservice-config
+    # -------------------------------------------------------------------------
+    try:
+        secretsAPI.delete(name="pipeline-aiservice-config", namespace=namespace)
+    except NotFoundError:
+        pass
+
+    if aiserviceConfig is None:
+        aiserviceConfig = {
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "type": "Opaque",
+            "metadata": {
+                "name": "pipeline-aiservice-config"
+            }
+        }
+    secretsAPI.create(body=aiserviceConfig, namespace=namespace)
 
 
 def prepareUpdateSlackSecrets(dynClient: DynamicClient, slack_token: str = None, slack_channel: str = None) -> None:

--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -827,6 +827,10 @@ spec:
       value: "{{ tenant_entitlement_start_date }}"
     - name: tenant_entitlement_end_date
       value: "{{ tenant_entitlement_end_date }}"
+{%- if tenant_scheduling_config_file is defined and tenant_scheduling_config_file != "" %}
+    - name: tenant_scheduling_cfg_file
+      value: "{{ tenant_scheduling_config_file }}"
+{%- endif %}
 
     # RSL
     # -------------------------------------------------------------------------
@@ -901,7 +905,7 @@ spec:
     - name: aiservice_watsonxai_on_prem
       value: "{{ aiservice_watsonxai_on_prem }}"
 
-    # AI Service - watsonX
+    # AI Service - Certificate Issuer
     # -------------------------------------------------------------------------
 {%- if aiservice_certificate_issuer is defined and aiservice_certificate_issuer != "" %}
     - name: aiservice_certificate_issuer
@@ -944,3 +948,9 @@ spec:
     - name: shared-certificates
       secret:
         secretName: pipeline-certificates
+
+    # AI Service configurations
+    # -------------------------------------------------------------------------
+    - name: shared-aiservice-config
+      secret:
+        secretName: pipeline-aiservice-config


### PR DESCRIPTION
## Description

- Create a secret to store affinity configuration file for AI Service tenant.
- Added a new parameter and workspace in install pipelinerun to pass configuration to aiservice_tenant role.

## Test Results

- Tested a tenant installation with scheduling configuration specified, ensured that tenant is installed successfully.
- Tested a tenant installation without specifying scheduling configuration, ensured that tenant is installed successfully.

## Related PR

- ibm-mas/ansible-devops#2223
- ibm-mas/cli#2240

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.