### PR TITLE
[patch] removed events_version property from the catalog data files

### DIFF
--- a/src/mas/devops/data/catalogs/v9-260129-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260129-amd64.yaml
@@ -41,8 +41,6 @@ opensearch_version: 1.1.2494                     # Operator version 1.1.2494
 # See: https://ibm-mas.slack.com/archives/C02PUHKQB5L/p1770849370378689
 datarefinery_version: 11.0.0+20250513.203727.232
 
-# TODO: Why is this here, there is no evidence that it is being used in image mirroring?
-events_version: 5.0.1  # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
 
 # Dependencies - Db2u
 # -----------------------------------------------------------------------------

--- a/src/mas/devops/data/catalogs/v9-260216-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260216-amd64.yaml
@@ -38,8 +38,6 @@ opensearch_version: 1.1.2494                     # Operator version 1.1.2494
 # See: https://ibm-mas.slack.com/archives/C02PUHKQB5L/p1770849370378689
 datarefinery_version: 11.0.0+20250513.203727.232
 
-# TODO: Why is this here, there is no evidence that it is being used in image mirroring?
-events_version: 5.0.1  # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
 
 # Dependencies - Db2u
 # -----------------------------------------------------------------------------

--- a/src/mas/devops/data/catalogs/v9-260226-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260226-amd64.yaml
@@ -41,8 +41,6 @@ opensearch_version: 1.1.2494                     # Operator version 1.1.2494
 # See: https://ibm-mas.slack.com/archives/C02PUHKQB5L/p1770849370378689
 datarefinery_version: 11.0.0+20250513.203727.232
 
-# TODO: Why is this here, there is no evidence that it is being used in image mirroring?
-events_version: 5.0.1  # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
 
 
 # Dependencies - Db2u

--- a/src/mas/devops/data/catalogs/v9-260305-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260305-amd64.yaml
@@ -41,8 +41,6 @@ opensearch_version: 1.1.2494                     # Operator version 1.1.2494
 # See: https://ibm-mas.slack.com/archives/C02PUHKQB5L/p1770849370378689
 datarefinery_version: 11.0.0+20250513.203727.232
 
-# TODO: Why is this here, there is no evidence that it is being used in image mirroring?
-events_version: 5.0.1  # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
 
 
 # Dependencies - Db2u

--- a/src/mas/devops/data/catalogs/v9-260313-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260313-amd64.yaml
@@ -41,8 +41,6 @@ opensearch_version: 1.1.2494                     # Operator version 1.1.2494
 # See: https://ibm-mas.slack.com/archives/C02PUHKQB5L/p1770849370378689
 datarefinery_version: 11.0.0+20250513.203727.232
 
-# TODO: Why is this here, there is no evidence that it is being used in image mirroring?
-events_version: 5.0.1  # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
 
 
 # Dependencies - Db2u

--- a/src/mas/devops/data/catalogs/v9-260318-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260318-amd64.yaml
@@ -41,9 +41,6 @@ opensearch_version: 1.1.2494                     # Operator version 1.1.2494
 # See: https://ibm-mas.slack.com/archives/C02PUHKQB5L/p1770849370378689
 datarefinery_version: 11.0.0+20250513.203727.232
 
-# TODO: Why is this here, there is no evidence that it is being used in image mirroring?
-events_version: 5.0.1  # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
-
 
 # Dependencies - Db2u
 # -----------------------------------------------------------------------------

--- a/src/mas/devops/data/catalogs/v9-260326-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260326-amd64.yaml
@@ -42,8 +42,6 @@ opensearch_version: 1.1.2494                     # Operator version 1.1.2494
 # See: https://ibm-mas.slack.com/archives/C02PUHKQB5L/p1770849370378689
 datarefinery_version: 11.0.0+20250513.203727.232
 
-# TODO: Why is this here, there is no evidence that it is being used in image mirroring?
-events_version: 5.0.1  # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
 
 
 # Dependencies - Db2u

--- a/src/mas/devops/data/catalogs/v9-260430-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260430-amd64.yaml
@@ -26,7 +26,6 @@ ibm_zen_version: 6.2.0+20250530.152516.232      # For CPD5 ibm-zen has to be exp
 
 db2u_version: 7.3.1+20250821.161005.16793       # Operator version 110509.0.6 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
 db2_channel_default: v110509.0                  # Default Channel version for db2u-operator
-events_version: 5.0.1                           # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
 uds_version: 2.0.12                             # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
 sls_version: 3.12.8             # Updated       # Operator version 3.12.7 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
 tsm_version: 1.7.6              # Updated       # Operator version 1.7.6 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)

--- a/src/mas/devops/data/catalogs/v9-260527-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260527-amd64.yaml
@@ -26,7 +26,6 @@ ibm_zen_version: 6.2.0+20250530.152516.232      # For CPD5 ibm-zen has to be exp
 
 db2u_version: 7.3.1+20250821.161005.16793       # Operator version 110509.0.6 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
 db2_channel_default: v110509.0                  # Default Channel version for db2u-operator
-events_version: 5.0.1                           # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
 uds_version: 2.0.12                             # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
 sls_version: 3.12.8             # No Update       # Operator version 3.12.7 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
 tsm_version: 1.7.6              # No Update       # Operator version 1.7.6 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)


### PR DESCRIPTION
Remove unused events_version property from the catalog data files
events_version: 5.0.1  # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)