### PR TITLE
[patch] removed manage_extras_913 from catalog data files

### DIFF
--- a/src/mas/devops/data/catalogs/v9-251231-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-251231-amd64.yaml
@@ -140,7 +140,6 @@ amlen_extras_version: 1.1.3
 # ------------------------------------------------------------------------------
 cpd_product_version_default: 5.2.0
 
-manage_extras_913: 9.1.3
 minio_version: RELEASE.2025-06-13T11-33-47Z
 
 

--- a/src/mas/devops/data/catalogs/v9-260129-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260129-amd64.yaml
@@ -155,8 +155,7 @@ mas_facilities_version:
   8.10.x: ""      # Not Supported
   8.11.x: ""      # Not Supported
 
-# TODO: What is this?  It almost certainly should not be here.
-manage_extras_913: 9.1.3
+
 
 
 # Maximo AI Service

--- a/src/mas/devops/data/catalogs/v9-260216-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260216-amd64.yaml
@@ -152,8 +152,6 @@ mas_facilities_version:
   8.10.x: ""      # Not Supported
   8.11.x: ""      # Not Supported
 
-# TODO: What is this?  It almost certainly should not be here.
-manage_extras_913: 9.1.3
 
 
 # Maximo AI Service

--- a/src/mas/devops/data/catalogs/v9-260226-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260226-amd64.yaml
@@ -174,8 +174,7 @@ aiservice_version:
   9.1.x: 9.1.12  #  Updated
 
 
-# TODO: What is this?  It almost certainly should not be here.
-manage_extras_913: 9.1.3
+
 
 
 # Editorial

--- a/src/mas/devops/data/catalogs/v9-260305-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260305-amd64.yaml
@@ -174,8 +174,6 @@ aiservice_version:
   9.1.x: 9.1.12  #  No Update
 
 
-# TODO: What is this?  It almost certainly should not be here.
-manage_extras_913: 9.1.3
 
 
 # Editorial

--- a/src/mas/devops/data/catalogs/v9-260313-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260313-amd64.yaml
@@ -174,8 +174,6 @@ aiservice_version:
   9.1.x: 9.1.12  #  No Update
 
 
-# TODO: What is this?  It almost certainly should not be here.
-manage_extras_913: 9.1.3
 
 
 # Editorial

--- a/src/mas/devops/data/catalogs/v9-260318-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260318-amd64.yaml
@@ -174,8 +174,6 @@ aiservice_version:
   9.1.x: 9.1.12  #  No Update
 
 
-# TODO: What is this?  It almost certainly should not be here.
-manage_extras_913: 9.1.3
 
 
 # Editorial

--- a/src/mas/devops/data/catalogs/v9-260326-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260326-amd64.yaml
@@ -176,8 +176,6 @@ aiservice_version:
   9.1.x: 9.1.13  # Updated
 
 
-# TODO: What is this?  It almost certainly should not be here.
-manage_extras_913: 9.1.3
 
 
 # Editorial

--- a/src/mas/devops/data/catalogs/v9-260430-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260430-amd64.yaml
@@ -161,7 +161,6 @@ redis_extras_version: 2.1.40             # No Update
 # ------------------------------------------------------------------------------
 cpd_product_version_default: 5.2.0       # No Update
 
-manage_extras_913: 9.1.3
 minio_version: RELEASE.2025-06-13T11-33-47Z
 
 editorial:

--- a/src/mas/devops/data/catalogs/v9-260527-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260527-amd64.yaml
@@ -161,7 +161,6 @@ redis_extras_version: 2.1.40             # No Update
 # ------------------------------------------------------------------------------
 cpd_product_version_default: 5.2.0       # No Update
 
-manage_extras_913: 9.1.3
 minio_version: RELEASE.2025-06-13T11-33-47Z
 
 editorial:


### PR DESCRIPTION
Remove manage_extras_913 from catalog data files this variable added for specifically for the validation of manage 9.1.3 release that is no longer needed now.