### PR TITLE
[patch] Add configure_aiassistant parameter to install aiassistant

### DIFF
--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -823,6 +823,10 @@ spec:
       value: "{{ aiservice_instance_id }}"
     - name: aiservice_channel
       value: "{{ aiservice_channel }}"
+{%- if configure_aiassistant is defined and configure_aiassistant != "" %}
+    - name: configure_aiassistant
+      value: "{{ configure_aiassistant }}"
+{%- endif %}
 
     - name: environment_type
       value: "{{ environment_type }}"


### PR DESCRIPTION
- Added configure_aiassistant parameter to AI Service section
- Parameter is conditionally included when defined and not empty
- Enables automatic AiCfg creation when set to 'pipeline'
- Fixes issue where parameter was missing from generated PipelineRun YAML