### PR TITLE
[patch] Fix aiservice namespace in pre-install

### DIFF
--- a/src/mas/devops/pre_install.py
+++ b/src/mas/devops/pre_install.py
@@ -180,7 +180,7 @@ def _get_preinstall_mas_rbac_namespaces(masInstanceId: str, permissionMode: str,
     namespaces = {f"mas-{masInstanceId}-core"}
 
     appNamespaces = {
-        "aiservice": f"mas-{masInstanceId}-aiservice",
+        "aiservice": f"aiservice-{masInstanceId}",
         "arcgis": f"mas-{masInstanceId}-arcgis",
         "facilities": f"mas-{masInstanceId}-facilities",
         "iot": f"mas-{masInstanceId}-iot",


### PR DESCRIPTION
The aiservice namespace is different to mas ones.