### PR TITLE
[minor] Support optional kafka binding for ManageWorkspace

### DIFF
--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -104,7 +104,7 @@ spec:
     - name: db2_action_facilities
       value: "{{ db2_action_facilities}}"
     - name: db2_action_aiservice
-      value: "{{ db2_action_aiservice }}"   
+      value: "{{ db2_action_aiservice }}"
 
     # Dependencies - Db2u Operator
     # -------------------------------------------------------------------------
@@ -626,6 +626,10 @@ spec:
     - name: mas_appws_bindings_jdbc_manage
       value: "{{ mas_appws_bindings_jdbc_manage }}"
   {%- endif %}
+  {%- if mas_appws_bindings_kafka_manage is defined and mas_appws_bindings_kafka_manage != "" %}
+    - name: mas_appws_bindings_kafka_manage
+      value: "{{ mas_appws_bindings_kafka_manage }}"
+  {%- endif %}
   {%- if mas_app_settings_persistent_volumes_flag is defined and mas_app_settings_persistent_volumes_flag != "" %}
     - name: mas_app_settings_persistent_volumes_flag
       value: "{{ mas_app_settings_persistent_volumes_flag }}"
@@ -960,7 +964,7 @@ spec:
     - name: shared-certificates
       secret:
         secretName: pipeline-certificates
-    
+
     # The Db2 license file
     - name: shared-db2
       secret:

--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -627,7 +627,7 @@ spec:
       value: "{{ mas_appws_bindings_jdbc_manage }}"
   {%- endif %}
   {%- if mas_appws_bindings_kafka_manage is defined and mas_appws_bindings_kafka_manage != "" %}
-    - name: mas_appws_bindings_kafka_manage
+    - name: mas_appws_bindings_kafka
       value: "{{ mas_appws_bindings_kafka_manage }}"
   {%- endif %}
   {%- if mas_app_settings_persistent_volumes_flag is defined and mas_app_settings_persistent_volumes_flag != "" %}

--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -627,7 +627,7 @@ spec:
       value: "{{ mas_appws_bindings_jdbc_manage }}"
   {%- endif %}
   {%- if mas_appws_bindings_kafka_manage is defined and mas_appws_bindings_kafka_manage != "" %}
-    - name: mas_appws_bindings_kafka
+    - name: mas_appws_bindings_kafka_manage
       value: "{{ mas_appws_bindings_kafka_manage }}"
   {%- endif %}
   {%- if mas_app_settings_persistent_volumes_flag is defined and mas_app_settings_persistent_volumes_flag != "" %}


### PR DESCRIPTION
To support optional install of Kafka Image Processor in Manage 9.2, we need to be able to pass through the desired `spec.bindings.kafka` value (usually `system`) in the install pipelinerun, in the same way we handle `spec.bindings.jdbc`.