### PR TITLE
[patch] Default mongo version set to 8.0.20

### DIFF
--- a/src/mas/devops/data/catalogs/v9-260527-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260527-amd64.yaml
@@ -1,0 +1,185 @@
+---
+# Case bundle configuration for IBM Maximo Operator Catalog 260430 (AMD64)
+# -----------------------------------------------------------------------------
+# In the future this won't be necessary as we'll be able to mirror from the
+# catalog itself, but not everything in the catalog supports this yet (including MAS)
+# so we need to use the CASE bundle mirror process still.
+
+catalog_digest: sha256:b328d8ee64b4b159124400edaef59c6ca04f4725749b127b8b03b2fd48944bf0
+
+ocp_compatibility:
+- "4.16"
+- "4.17"
+- "4.18"
+- "4.19"
+- "4.20"
+- "4.21"
+
+# Dependencies
+# -----------------------------------------------------------------------------
+ibm_licensing_version: 4.2.17                   # Operator version 4.2.14 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-licensing)
+common_svcs_version: 4.13.0                     # Operator version 4.13.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+common_svcs_version_1: 4.11.0                   # Additional version 4.11.0
+
+cp4d_platform_version: 5.2.0+20250709.170324    # Operator version 5.2.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-datacore/)
+ibm_zen_version: 6.2.0+20250530.152516.232      # For CPD5 ibm-zen has to be explicitily mirrored
+
+db2u_version: 7.3.1+20250821.161005.16793       # Operator version 110509.0.6 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+db2_channel_default: v110509.0                  # Default Channel version for db2u-operator
+events_version: 5.0.1                           # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
+uds_version: 2.0.12                             # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
+sls_version: 3.12.8             # Updated       # Operator version 3.12.7 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
+tsm_version: 1.7.6              # Updated       # Operator version 1.7.6 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
+dd_version: 1.1.23              # No Update     # Operator version 1.1.23 (https://github.ibm.com/maximoappsuite/ibm-data-dictionary/releases)
+appconnect_version: 6.2.0                       # Operator version 6.2.0 # sticking to 6.2.0 version # Please do Not Change
+wsl_version: 11.0.0+20250521.202913.73          # used for wsl and wsl_runtimes unless wsl_runtimes_version also specified
+wsl_runtimes_version: 11.0.0+20250515.090949.21 # cpd 5.1.3 uses version 10.3.0 of wsl runtimes but only 10.2.0 for wsl itself
+wml_version: 11.0.0+20250530.193146.282         # Operator version 5.2.0
+postgress_version: 5.16.0+20250827.110911.2626  # ibm-cpd-cloud-native-postgresql-operator 5.2.0 cp4d
+
+ccs_build: 11.0.0+20250605.130237.468           # cpd 5.2.0 using ccs build
+
+# I have added this as a guess as to the actual version used, we are currently using the wsl_version, but that does not exist for datarefinery
+# See: https://ibm-mas.slack.com/archives/C02PUHKQB5L/p1770849370378689
+datarefinery_version: 11.0.0+20250513.203727.232
+
+spark_version: 11.0.0+20250604.163055.2097      # Operator version 5.2.0
+cognos_version: 28.0.0+20250515.175459.10054    # Operator version 25.0.0
+couchdb_version: 1.0.13                         # Operator version 2.2.1 (1.0.13) sticking with 1.0.13 # (This is required for Assist 9.0, https://github.com/IBM/cloud-pak/blob/master/repo/case/ibm-couchdb/index.yaml)
+elasticsearch_version: 1.1.2667                 # Operator version 1.1.2667 # used in cpd 5.1.3 only
+opensearch_version: 1.1.2494                    # Operator version 1.1.2494
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  9.2.x-feature: 9.2.0-pre.stable_21734 # Updated
+  9.1.x: 9.1.16                         # Updated
+  9.0.x: 9.0.24                         # Updated
+  8.10.x: 8.10.37                       # Updated
+  8.11.x: 8.11.34                       # Updated
+mas_assist_version:
+  9.1.x: 9.1.10                         # Updated
+  9.0.x: 9.0.16                         # Updated
+  8.10.x: 8.7.8                         # No Update
+  8.11.x: 8.8.7                         # No Update
+mas_hputilities_version:
+  9.1.x: ""                             # Not Supported
+  9.0.x: ""                             # Not Supported
+  8.10.x: 8.6.7                         # No Update
+  8.11.x: ""                            # Not Supported
+mas_iot_version:
+  9.2.x-feature: 9.2.0-pre.stable_21024 # Updated
+  9.1.x: 9.1.10                         # Updated
+  9.0.x: 9.0.19                         # Updated
+  8.10.x: 8.7.33                        # Updated
+  8.11.x: 8.8.30                        # Updated
+mas_manage_version:
+  9.2.x-feature: 9.2.0-pre.stable_21956 # Updated
+  9.1.x: 9.1.17                         # Updated
+  9.0.x: 9.0.25                         # Updated
+  8.10.x: 8.6.38                        # Updated
+  8.11.x: 8.7.32                        # Updated
+mas_monitor_version:
+  9.2.x-feature: 9.2.0-pre.stable_21784 # Updated
+  9.1.x: 9.1.10                         # Updated
+  9.0.x: 9.0.20                         # Updated
+  8.10.x: 8.10.30                       # Updated
+  8.11.x: 8.11.28                       # Updated
+mas_optimizer_version:
+  9.2.x-feature: 9.2.0-pre.stable_21493 # Updated
+  9.1.x: 9.1.11                         # Updated
+  9.0.x: 9.0.22                         # Updated
+  8.10.x: 8.4.28                        # Updated
+  8.11.x: 8.5.28                        # Updated
+mas_predict_version:
+  9.2.x-feature: 9.2.0-pre.stable_22454 # Updated
+  9.1.x: 9.1.7                          # Updated
+  9.0.x: 9.0.14                         # Updated
+  8.10.x: 8.8.15                        # Updated
+  8.11.x: 8.9.17                        # Updated
+mas_visualinspection_version:
+  9.2.x-feature: 9.2.0-pre.stable_12598 # No Update
+  9.1.x: 9.1.12                         # Updated
+  9.0.x: 9.0.19                         # Updated
+  8.10.x: 8.8.4                         # No Update
+  8.11.x: 8.9.21                        # Updated
+mas_facilities_version:
+  9.2.x-feature: 9.2.0-pre.stable_16853 # No Update
+  9.1.x: 9.1.10                         # Updated
+  9.0.x: ""                             # Not Supported
+  8.10.x: ""                            # Not Supported
+  8.11.x: ""                            # Not Supported
+
+
+# Maximo AI Service
+# ------------------------------------------------------------------------------
+aiservice_version:
+  9.2.x-feature: 9.2.0-pre.stable_21747 # Updated
+  9.1.x: 9.1.14                         # Updated
+
+aiservice_tenant_version:
+  9.2.x-feature: 9.2.0-pre.stable_21714 # Updated
+
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.5.0
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version_default: 8.0.20
+
+# Variables used to mirror additional mongo image versions
+mongo_extras_version_4: 4.4.21
+mongo_extras_version_5: 5.0.23
+mongo_extras_version_6: 6.0.12
+mongo_extras_version_7: 7.0.23
+mongo_extras_version_8: 8.0.20
+
+# Extra Images for Db2u
+# ------------------------------------------------------------------------------
+db2u_extras_version: 1.0.6               # No Update
+db2u_filter: db2
+
+# Extra Images for CCS used for PCD 5.2.0 Hotfix
+# ------------------------------------------------------------------------------
+ccs_extras_version: 11.0.0               # No Update
+
+# Extra Images for IBM Watson Discovery
+# ------------------------------------------------------------------------------
+#wd_extras_version: 1.0.4
+
+# Extra Images for Amlen
+# ------------------------------------------------------------------------------
+amlen_extras_version: 1.1.4              # No Update
+
+# Extra Images for Redis (Collaborate)
+# ------------------------------------------------------------------------------
+redis_extras_version: 2.1.40             # No Update
+
+# Default Cloud Pak for Data version
+# ------------------------------------------------------------------------------
+cpd_product_version_default: 5.2.0       # No Update
+
+manage_extras_913: 9.1.3
+minio_version: RELEASE.2025-06-13T11-33-47Z
+
+editorial:
+  whats_new:
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform [v8.10.37](https://www.ibm.com/support/pages/node/7270974), [v8.11.34](https://www.ibm.com/support/pages/node/7270975), [v9.0.24](https://www.ibm.com/support/pages/node/7270976) and [v9.1.16](https://www.ibm.com/support/pages/node/7270977)
+    - IBM Maximo Manage [v8.6.38](https://www.ibm.com/support/pages/node/7270968), [v8.7.32](https://www.ibm.com/support/pages/node/7270969), [v9.0.25](https://www.ibm.com/support/pages/node/7270970) and [v9.1.17](https://www.ibm.com/support/pages/node/7270971)
+    - IBM Maximo IoT [v8.7.33](https://www.ibm.com/support/pages/node/7270683), [v8.8.30](https://www.ibm.com/support/pages/node/7270684), [v9.0.19](https://www.ibm.com/support/pages/node/7270685) and [v9.1.10](https://www.ibm.com/support/pages/node/7270686)
+    - IBM Maximo Monitor [v8.10.30](https://www.ibm.com/support/pages/node/7271126), [v8.11.28](https://www.ibm.com/support/pages/node/7271125), [v9.0.20](https://www.ibm.com/support/pages/node/7271124) and [v9.1.10](https://www.ibm.com/support/pages/node/7270981)
+    - IBM Maximo Optimizer [v8.4.28](https://www.ibm.com/support/pages/node/7266732),[v8.5.28](https://www.ibm.com/support/pages/node/7270110), [v9.0.22](https://www.ibm.com/support/pages/node/7270109) and [v9.1.11](https://www.ibm.com/support/pages/node/7270108)
+    - IBM Maximo Assist/Collaborate [v9.0.16](https://www.ibm.com/support/pages/node/7270678), [v9.1.10](https://www.ibm.com/support/pages/node/7270662)
+    - IBM Maximo Predict [v8.8.15](https://www.ibm.com/support/pages/node/7270810), [v8.9.17](https://www.ibm.com/support/pages/node/7270809), [v9.0.14](https://www.ibm.com/support/pages/node/7270807) and [v9.1.7](https://www.ibm.com/support/pages/node/7270808)
+    - IBM Maximo Visual Inspection [v8.9.21](https://www.ibm.com/support/pages/node/7270958), [v9.0.19](https://www.ibm.com/support/pages/node/7270959), [v9.1.12](https://www.ibm.com/support/pages/node/7270961)
+    - IBM Maximo Real Estate and Facilities [v9.1.10](https://www.ibm.com/support/pages/node/7270843)
+    - IBM Maximo AI Service [v9.1.14](https://www.ibm.com/support/pages/node/7270125)
+    - IBM Truststore Manager v1.7
+    - IBM Suite License Service v3.12
+
+  known_issues:
+    - title: A know issue in IBM Maximo Real Estate and Facilities, users may encounter failures during upgrade scenarios (9.1.9 → 9.2 FC).

--- a/src/mas/devops/data/catalogs/v9-260527-ppc64le.yaml
+++ b/src/mas/devops/data/catalogs/v9-260527-ppc64le.yaml
@@ -1,0 +1,62 @@
+---
+# Case bundle configuration for IBM Maximo Operator Catalog 260430 (PPC)
+# -----------------------------------------------------------------------------
+# In the future this won't be necessary as we'll be able to mirror from the
+# catalog itself, but not everything in the catalog supports this yet (including MAS)
+# so we need to use the CASE bundle mirror process still.
+
+catalog_digest: sha256:7f709aa2f1d94fa433c2e6f2d4e96b0662e649aa73b4b9c98dead21db62058c4
+
+ocp_compatibility:
+- "4.16"
+- "4.17"
+- "4.18"
+- "4.19"
+- "4.20"
+- "4.21"
+
+uds_version: 2.0.12                       # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
+sls_version: 3.12.8       # Updated       # Operator version 3.12.5 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
+tsm_version: 1.7.6        # Updated       # Operator version 1.7.4 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
+db2u_version: 7.3.1+20250821.161005.16793 # Operator version 110509.0.6 to find the version 7.3.1+20250821.161005.16793, search db2u-operator digest on repo (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  9.2.x-feature: 9.2.0-pre.stable_21734   # Updated
+  9.1.x: 9.1.16                           # Updated
+  9.0.x: 9.0.24                           # Updated
+  8.10.x: ""                              # Not Supported
+  8.11.x: ""                              # Not Supported
+mas_manage_version:
+  9.2.x-feature: 9.2.0-pre.stable_21956   # Updated
+  9.1.x: 9.1.17                           # Updated
+  9.0.x: 9.0.25                           # Updated
+  8.10.x: ""                              # Not Supported
+  8.11.x: ""                              # Not Supported
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.5.0                 # No Update
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version_default: 8.0.20      # No Update
+
+# Variables used to mirror additional mongo image versions
+mongo_extras_version_4: 4.4.21
+mongo_extras_version_5: 5.0.23
+mongo_extras_version_6: 6.0.12
+mongo_extras_version_7: 7.0.12
+mongo_extras_version_8: 8.0.20
+
+editorial:
+  whats_new:
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform [v9.0.24](https://www.ibm.com/support/pages/node/7270976) and [v9.1.16](https://www.ibm.com/support/pages/node/7270977)
+    - IBM Maximo Manage [v9.0.25](https://www.ibm.com/support/pages/node/7270970) and [v9.1.17](https://www.ibm.com/support/pages/node/7270971)
+    - IBM Truststore Manager v1.7
+    - IBM Suite License Service v3.12
+  known_issues:
+    - title: A know issue in IBM Maximo Real Estate and Facilities, users may encounter failures during upgrade scenarios (9.1.9 → 9.2 FC).

--- a/src/mas/devops/data/catalogs/v9-260527-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-260527-s390x.yaml
@@ -1,0 +1,62 @@
+---
+# Case bundle configuration for IBM Maximo Operator Catalog 260430 (Z)
+# -----------------------------------------------------------------------------
+# In the future this won't be necessary as we'll be able to mirror from the
+# catalog itself, but not everything in the catalog supports this yet (including MAS)
+# so we need to use the CASE bundle mirror process still.
+
+catalog_digest: sha256:28a6ba509cb960381dd67312173d13daadf0c7aa06d05775cf81e84789043443
+
+ocp_compatibility:
+- "4.16"
+- "4.17"
+- "4.18"
+- "4.19"
+- "4.20"
+- "4.21"
+
+uds_version: 2.0.12                       # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
+sls_version: 3.12.8         # Updated     # Operator version 3.12.5 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
+tsm_version: 1.7.6          # Updated     # Operator version 1.7.4 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
+db2u_version: 7.3.1+20250821.161005.16793 # Operator version 110509.0.6 to find the version 7.3.1+20250821.161005.16793, search db2u-operator digest on repo (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  9.2.x-feature: 9.2.0-pre.stable_21734 # Updated
+  9.1.x: 9.1.16                         # Updated
+  9.0.x: 9.0.24                         # Updated
+  8.10.x: ""                            # Not Supported
+  8.11.x: ""                            # Not Supported
+mas_manage_version:
+  9.2.x-feature: 9.2.0-pre.stable_21956 # Updated
+  9.1.x: 9.1.17                         # Updated
+  9.0.x: 9.0.25                         # Updated
+  8.10.x: ""                            # Not Supported
+  8.11.x: ""                            # Not Supported
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.5.0               # No Update
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version_default: 8.0.20    # No Update
+
+# Variables used to mirror additional mongo image versions
+mongo_extras_version_4: 4.4.21
+mongo_extras_version_5: 5.0.23
+mongo_extras_version_6: 6.0.12
+mongo_extras_version_7: 7.0.12
+mongo_extras_version_8: 8.0.20
+
+editorial:
+  whats_new:
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform [v9.0.24](https://www.ibm.com/support/pages/node/7270976) and [v9.1.16](https://www.ibm.com/support/pages/node/7270977)
+    - IBM Maximo Manage [v9.0.25](https://www.ibm.com/support/pages/node/7270970) and [v9.1.17](https://www.ibm.com/support/pages/node/7270971)
+    - IBM Truststore Manager v1.7
+    - IBM Suite License Service v3.12
+  known_issues:
+    - title: A know issue in IBM Maximo Real Estate and Facilities, users may encounter failures during upgrade scenarios (9.1.9 → 9.2 FC).

--- a/test/src/test_data.py
+++ b/test/src/test_data.py
@@ -32,7 +32,7 @@ def test_list_catalogs():
 def test_get_newest_catalog_tag():
     catalogTag = getNewestCatalogTag("amd64")
     # Reminder: update this test when adding a new catalog each month!
-    assert catalogTag == "v9-260430-amd64"
+    assert catalogTag == "v9-260527-amd64"
 
 
 def test_get_newest_catalog_tag_fail():


### PR DESCRIPTION
## Description

Default mongo version is set to 8.0.20 in latest catalog

## Test results

Tested the new mongo version installation, Upgrades from 8.0.x and 7.0.x versions
Reference [Jira Story MASR-8141](https://jsw.ibm.com/browse/MASR-8141)
Also curate test completed by Release team.