### PR TITLE
[patch] Add setuptools to dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         'openshift',               # Apache Software License
         'kubernetes',              # Apache Software License
         'kubeconfig',              # BSD License
+        'setuptools',              # MIT License (required to install kubeconfig)
         'jinja2',                  # BSD License
         'jinja2-base64-filters',   # MIT License
         'semver',                  # BSD License
@@ -69,7 +70,6 @@ setup(
             'pytest',         # MIT License
             'pytest-mock',    # MIT License
             'requests-mock',  # Apache Software License
-            'setuptools',     # MIT License
         ],
         'docs': [
             'mkdocs',                      # BSD License


### PR DESCRIPTION
`kubeconfig` can not be installed without `distutils` due to poorly configured packaging (of this unmaintained package) so we need to declare `setuptools` as a dependency in this package.

We will look to migrate away from use of `kubeconfig`, but in the meantime this will address installation issues for the `mas-devops` package.