### PR TITLE
[patch] Mark and temp disable tests that need OCP

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -46,7 +46,7 @@ jobs:
           cat ${GITHUB_WORKSPACE}/src/mas/devops/__init__.py
           python -m pip install --upgrade pip
           pip install .[dev]
-          python -m pytest
+          python -m pytest -m "not openshift"
 
       - name: Lint with flake8
         run: |

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-21T00:44:44Z",
+  "generated_at": "2026-05-21T00:57:00Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -178,7 +178,7 @@
         "hashed_secret": "94f5ed592906089c107208b29e178ddf1f9f5143",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 38,
+        "line_number": 42,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -186,7 +186,7 @@
         "hashed_secret": "a9410d9785f49750b9f8672794fc288558c1611c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 51,
+        "line_number": 55,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-21T00:23:08Z",
+  "generated_at": "2026-05-21T00:44:44Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -178,7 +178,7 @@
         "hashed_secret": "94f5ed592906089c107208b29e178ddf1f9f5143",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 35,
+        "line_number": 38,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -186,7 +186,7 @@
         "hashed_secret": "a9410d9785f49750b9f8672794fc288558c1611c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 48,
+        "line_number": 51,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,8 @@ requires = [
   "setuptools"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+markers = [
+    "openshift: marks tests as requiring an OpenShift cluster (deselect with '-m \"not openshift\"')",
+]

--- a/test/src/test_mas.py
+++ b/test/src/test_mas.py
@@ -8,12 +8,15 @@
 #
 # *****************************************************************************
 
+import pytest
 from openshift import dynamic
 from kubernetes import config
 from kubernetes.client import api_client
 from kubernetes.dynamic.resource import ResourceInstance
 
 from mas.devops import mas
+
+pytestmark = pytest.mark.openshift
 
 dynClient = dynamic.DynamicClient(
     api_client.ApiClient(configuration=config.load_kube_config())

--- a/test/src/test_mas.py
+++ b/test/src/test_mas.py
@@ -18,12 +18,16 @@ from mas.devops import mas
 
 pytestmark = pytest.mark.openshift
 
-dynClient = dynamic.DynamicClient(
-    api_client.ApiClient(configuration=config.load_kube_config())
-)
+
+@pytest.fixture(scope="module")
+def dynClient():
+    """Create DynamicClient for OpenShift cluster access."""
+    return dynamic.DynamicClient(
+        api_client.ApiClient(configuration=config.load_kube_config())
+    )
 
 
-def test_entitlement():
+def test_entitlement(dynClient):
     icrUsername = "testing-i"
     icrPassword = "not-a-real-password-i"
 
@@ -33,7 +37,7 @@ def test_entitlement():
     assert secret.metadata.name == "ibm-entitlement"
 
 
-def test_entitlement_with_artifactory():
+def test_entitlement_with_artifactory(dynClient):
     artifactoryUsername = "testing-a"
     artifactoryPassword = "not-a-real-password-a"
 
@@ -46,7 +50,7 @@ def test_entitlement_with_artifactory():
     assert secret.metadata.name == "ibm-entitlement"
 
 
-def test_entitlement_alt_name():
+def test_entitlement_alt_name(dynClient):
     icrUsername = "testing-i"
     icrPassword = "not-a-real-password-i"
 
@@ -56,23 +60,23 @@ def test_entitlement_alt_name():
     assert secret.metadata.name == "ibm-entitlement-key"
 
 
-def test_get_channel():
+def test_get_channel(dynClient):
     channel = mas.getMasChannel(dynClient, "doesnotexist")
     assert channel is None
 
 
-def test_is_airgap_install():
+def test_is_airgap_install(dynClient):
     # The cluster we are using to test with does not have the MAS ICSP or IDMS installed
     assert mas.isAirgapInstall(dynClient) is False
     assert mas.isAirgapInstall(dynClient, checkICSP=False) is False
 
 
-def test_get_mas_public_cluster_issuer():
+def test_get_mas_public_cluster_issuer(dynClient):
     # Test with non-existent instance - should return None
     issuer = mas.getMasPublicClusterIssuer(dynClient, "doesnotexist")
     assert issuer is None
 
 
-# def test_is_app_ready():
+# def test_is_app_ready(dynClient):
 #     mas.waitForAppReady(dynClient, "fvtcpd", "iot")
 #     mas.waitForAppReady(dynClient, "fvtcpd", "iot", "masdev")

--- a/test/src/test_olm.py
+++ b/test/src/test_olm.py
@@ -17,12 +17,16 @@ from mas.devops import olm, ocp
 
 pytestmark = pytest.mark.openshift
 
-dynClient = dynamic.DynamicClient(
-    api_client.ApiClient(configuration=config.load_kube_config())
-)
+
+@pytest.fixture(scope="module")
+def dynClient():
+    """Create DynamicClient for OpenShift cluster access."""
+    return dynamic.DynamicClient(
+        api_client.ApiClient(configuration=config.load_kube_config())
+    )
 
 
-def test_get_manifest():
+def test_get_manifest(dynClient):
     manifest = olm.getPackageManifest(dynClient, "ibm-sls")
     assert manifest is not None
     assert manifest.metadata.name == "ibm-sls"
@@ -33,12 +37,12 @@ def test_get_manifest():
     assert manifest.status.packageName == "ibm-sls"
 
 
-def test_get_manifest_none():
+def test_get_manifest_none(dynClient):
     manifest = olm.getPackageManifest(dynClient, "ibm-sls2")
     assert manifest is None
 
 
-def test_crud():
+def test_crud(dynClient):
     namespace = "cli-fvt-1"
     subscription = olm.applySubscription(dynClient, namespace, "ibm-sls", packageChannel="3.x")
     assert subscription.metadata.name == "ibm-sls"
@@ -65,7 +69,7 @@ def test_crud():
     assert failedSubscriptionLookup2 is None
 
 
-def test_crud_with_config():
+def test_crud_with_config(dynClient):
     namespace = "cli-fvt-2"
     # We don't need this, just want to test that it works
     testConfig = {
@@ -84,7 +88,7 @@ def test_crud_with_config():
     ocp.deleteNamespace(dynClient, namespace)
 
 
-def test_crud_with_manual_approval():
+def test_crud_with_manual_approval(dynClient):
     """
     Test that when installPlanApproval is Manual without a startingCSV,
     an OLMException is raised.
@@ -108,7 +112,7 @@ def test_crud_with_manual_approval():
         # Test passed - exception was raised as expected
 
 
-def test_crud_with_starting_csv():
+def test_crud_with_starting_csv(dynClient):
     namespace = "cli-fvt-4"
     # Note: This test assumes a specific CSV version exists in the catalog
     # You may need to adjust the version based on what's available
@@ -130,7 +134,7 @@ def test_crud_with_starting_csv():
     ocp.deleteNamespace(dynClient, namespace)
 
 
-def test_crud_with_manual_approval_and_starting_csv():
+def test_crud_with_manual_approval_and_starting_csv(dynClient):
     """
     Test that when installPlanApproval is Manual and startingCSV is specified,
     the first InstallPlan is automatically approved to reach the startingCSV.

--- a/test/src/test_olm.py
+++ b/test/src/test_olm.py
@@ -8,11 +8,14 @@
 #
 # *****************************************************************************
 
+import pytest
 from openshift import dynamic
 from kubernetes import config
 from kubernetes.client import api_client
 
 from mas.devops import olm, ocp
+
+pytestmark = pytest.mark.openshift
 
 dynClient = dynamic.DynamicClient(
     api_client.ApiClient(configuration=config.load_kube_config())


### PR DESCRIPTION
Our test OCP cluster is in poor health, and it's blocking builds.  The new pytest marker allows us to easily disable these tests.