### PR TITLE
[patch] Downgrade kubernetes client <36 

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -45,7 +45,7 @@ jobs:
           cat ${GITHUB_WORKSPACE}/src/mas/devops/__init__.py
           python -m pip install --upgrade pip
           pip install .[dev]
-          python -m pytest -m "not openshift"
+          python -m pytest
 
       # 3. Flake8 Linting
       # -------------------------------------------------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     install_requires=[
         'pyyaml',                  # MIT License
         'openshift',               # Apache Software License
-        'kubernetes',              # Apache Software License
+        'kubernetes<36',           # Apache Software License
         'kubeconfig',              # BSD License
         'setuptools',              # MIT License (required to install kubeconfig)
         'jinja2',                  # BSD License


### PR DESCRIPTION
**Issue:** 
The SPS builds were failing with the below error : 

```
22 May, 00:23:11 debug    [bash] fatal: [localhost]: FAILED! => {"changed": false, "msg": "Failed to get client due to 403
22 May, 00:23:11 Reason: Forbidden
22 May, 00:23:11 HTTP response headers: HTTPHeaderDict({'Audit-Id': '185cd6c5-5dd4-4074-8ace-111d132dc2e2', 'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 'Strict-Transport-Security': 'max-age=31536000', 'X-Content-Type-Options': 'nosniff', 'X-Kubernetes-Pf-Flowschema-Uid': 'd4e25838-8e23-4d2a-a0b9-a6a96e1b2976', 'X-Kubernetes-Pf-Prioritylevel-Uid': '2dbadecb-b7b7-4388-bd87-d98b28c628b9', 'Date': 'Thu, 21 May 2026 23:23:10 GMT', 'Content-Length': '189'})
22 May, 00:23:11 HTTP response body: {\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"forbidden: User \\"system:anonymous\\" cannot get path \\"/apis\\"\",\"reason\":\"Forbidden\",\"details\":{},\"code\":403}
22 May, 00:23:11
22 May, 00:23:11 Original traceback:
22 May, 00:23:11   File \"/usr/local/venvs/py311/lib64/python3.11/site-packages/kubernetes/dynamic/client.py\", line 55, in inner
22 May, 00:23:11     resp = func(self, *args, **kwargs)
22 May, 00:23:11            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
22 May, 00:23:11
22 May, 00:23:11   File \"/usr/local/venvs/py311/lib64/python3.11/site-packages/kubernetes/dynamic/client.py\", line 277, in request
22 May, 00:23:11     api_response = self.client.call_api(
22 May, 00:23:11                    ^^^^^^^^^^^^^^^^^^^^^
22 May, 00:23:11
22 May, 00:23:11   File \"/usr/local/venvs/py311/lib64/python3.11/site-packages/kubernetes/client/api_client.py\", line 374, in call_api
22 May, 00:23:11     return self.__call_api(resource_path, method,
22 May, 00:23:11            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
22 May, 00:23:11
22 May, 00:23:11   File \"/usr/local/venvs/py311/lib64/python3.11/site-packages/kubernetes/client/api_client.py\", line 191, in __call_api
22 May, 00:23:11     raise e
22 May, 00:23:11
22 May, 00:23:11   File \"/usr/local/venvs/py311/lib64/python3.11/site-packages/kubernetes/client/api_client.py\", line 184, in __call_api
22 May, 00:23:11     response_data = self.request(
22 May, 00:23:11                     ^^^^^^^^^^^^^
22 May, 00:23:11
22 May, 00:23:11   File \"/usr/local/venvs/py311/lib64/python3.11/site-packages/kubernetes/client/api_client.py\", line 400, in request
22 May, 00:23:11     return self.rest_client.GET(url,
22 May, 00:23:11            ^^^^^^^^^^^^^^^^^^^^^^^^^
22 May, 00:23:11
22 May, 00:23:11   File \"/usr/local/venvs/py311/lib64/python3.11/site-packages/kubernetes/client/rest.py\", line 246, in GET
22 May, 00:23:11     return self.request(\"GET\", url,
22 May, 00:23:11            ^^^^^^^^^^^^^^^^^^^^^^^^
22 May, 00:23:11
22 May, 00:23:11   File \"/usr/local/venvs/py311/lib64/python3.11/site-packages/kubernetes/client/rest.py\", line 232, in request
22 May, 00:23:11     raise ForbiddenException(http_resp=r)
22 May, 00:23:11 "}
```

**More detailed explaination:** 
https://github.com/kubernetes-client/python/issues/2582

**Workaround applied** : Downgraded the Kubernetes Client < 36 

**File: setup.py**
'kubernetes<36'

**Tested :** 

**Reverted commit** - 67c9a3ef18a257bb8b7fdda51db07d7da1beb51e 
File - python-release.yml ( removed  -m "not openshift" ) 

<img width="3456" height="1516" alt="image" src="https://github.com/user-attachments/assets/b2406618-623f-4657-b671-a9bde1766ba4" />
