### PR TITLE
[patch] added release note whats new in this release

### DIFF
--- a/src/mas/devops/data/catalogs/v9-260527-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260527-amd64.yaml
@@ -171,18 +171,18 @@ editorial:
   whats_new:
   - title: '**Security updates and bug fixes**'
     details:
-    - IBM Maximo Application Suite Core Platform [v8.10.37](https://www.ibm.com/support/pages/node/7270974), [v8.11.34](https://www.ibm.com/support/pages/node/7270975), [v9.0.24](https://www.ibm.com/support/pages/node/7270976) and [v9.1.16](https://www.ibm.com/support/pages/node/7270977)
-    - IBM Maximo Manage [v8.6.38](https://www.ibm.com/support/pages/node/7270968), [v8.7.32](https://www.ibm.com/support/pages/node/7270969), [v9.0.25](https://www.ibm.com/support/pages/node/7270970) and [v9.1.17](https://www.ibm.com/support/pages/node/7270971)
-    - IBM Maximo IoT [v8.7.33](https://www.ibm.com/support/pages/node/7270683), [v8.8.30](https://www.ibm.com/support/pages/node/7270684), [v9.0.19](https://www.ibm.com/support/pages/node/7270685) and [v9.1.10](https://www.ibm.com/support/pages/node/7270686)
-    - IBM Maximo Monitor [v8.10.30](https://www.ibm.com/support/pages/node/7271126), [v8.11.28](https://www.ibm.com/support/pages/node/7271125), [v9.0.20](https://www.ibm.com/support/pages/node/7271124) and [v9.1.10](https://www.ibm.com/support/pages/node/7270981)
-    - IBM Maximo Optimizer [v8.4.28](https://www.ibm.com/support/pages/node/7266732),[v8.5.28](https://www.ibm.com/support/pages/node/7270110), [v9.0.22](https://www.ibm.com/support/pages/node/7270109) and [v9.1.11](https://www.ibm.com/support/pages/node/7270108)
-    - IBM Maximo Assist/Collaborate [v9.0.16](https://www.ibm.com/support/pages/node/7270678), [v9.1.10](https://www.ibm.com/support/pages/node/7270662)
-    - IBM Maximo Predict [v8.8.15](https://www.ibm.com/support/pages/node/7270810), [v8.9.17](https://www.ibm.com/support/pages/node/7270809), [v9.0.14](https://www.ibm.com/support/pages/node/7270807) and [v9.1.7](https://www.ibm.com/support/pages/node/7270808)
-    - IBM Maximo Visual Inspection [v8.9.21](https://www.ibm.com/support/pages/node/7270958), [v9.0.19](https://www.ibm.com/support/pages/node/7270959), [v9.1.12](https://www.ibm.com/support/pages/node/7270961)
-    - IBM Maximo Real Estate and Facilities [v9.1.10](https://www.ibm.com/support/pages/node/7270843)
-    - IBM Maximo AI Service [v9.1.14](https://www.ibm.com/support/pages/node/7270125)
+    - IBM Maximo Application Suite Core Platform [v9.0.26](https://www.ibm.com/support/pages/node/7273948) and [v9.1.18](https://supportcontent.ibm.com/support/pages/node/7273949)
+    - IBM Maximo Manage [v9.0.26](https://www.ibm.com/support/pages/node/7274051) and [v9.1.18](https://www.ibm.com/support/pages/node/7274052)
+    - IBM Maximo IoT [v9.0.20](https://www.ibm.com/support/pages/node/7273937) and [v9.1.11](https://www.ibm.com/support/pages/node/7273938)
+    - IBM Maximo Monitor [v9.1.11](https://www.ibm.com/support/pages/node/7270981)
+    - IBM Maximo Optimizer [v9.0.23]( https://www.ibm.com/support/pages/node/7273440) and [v9.1.12](https://www.ibm.com/support/pages/node/7273443)
+    - IBM Maximo Assist/Collaborate [v9.0.17](https://www.ibm.com/support/pages/node/7273929), [v9.1.11](https://www.ibm.com/support/pages/node/7273930)
+    - IBM Maximo Predict [v9.0.15](https://www.ibm.com/support/pages/node/7273940) and [v9.1.8](https://www.ibm.com/support/pages/node/7273939)
+    - IBM Maximo Visual Inspection [v9.0.20](https://www.ibm.com/support/pages/node/7274038), [v9.1.17](https://www.ibm.com/support/pages/node/7274039)
+    - IBM Maximo Real Estate and Facilities [v9.1.11](https://www.ibm.com/support/pages/node/7273955)
+    - IBM Maximo AI Service [v9.1.15](https://www.ibm.com/support/pages/node/7273795)
     - IBM Truststore Manager v1.7
     - IBM Suite License Service v3.12
 
   known_issues:
-    - title: A know issue in IBM Maximo Real Estate and Facilities, users may encounter failures during upgrade scenarios (9.1.9 → 9.2 FC).
+    - title: NA

--- a/src/mas/devops/data/catalogs/v9-260527-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260527-amd64.yaml
@@ -174,7 +174,7 @@ editorial:
     - IBM Maximo Application Suite Core Platform [v9.0.26](https://www.ibm.com/support/pages/node/7273948) and [v9.1.18](https://supportcontent.ibm.com/support/pages/node/7273949)
     - IBM Maximo Manage [v9.0.26](https://www.ibm.com/support/pages/node/7274051) and [v9.1.18](https://www.ibm.com/support/pages/node/7274052)
     - IBM Maximo IoT [v9.0.20](https://www.ibm.com/support/pages/node/7273937) and [v9.1.11](https://www.ibm.com/support/pages/node/7273938)
-    - IBM Maximo Monitor [v9.1.11](https://www.ibm.com/support/pages/node/7270981)
+    - IBM Maximo Monitor [v9.1.11](https://www.ibm.com/support/pages/node/7274017)
     - IBM Maximo Optimizer [v9.0.23]( https://www.ibm.com/support/pages/node/7273440) and [v9.1.12](https://www.ibm.com/support/pages/node/7273443)
     - IBM Maximo Assist/Collaborate [v9.0.17](https://www.ibm.com/support/pages/node/7273929), [v9.1.11](https://www.ibm.com/support/pages/node/7273930)
     - IBM Maximo Predict [v9.0.15](https://www.ibm.com/support/pages/node/7273940) and [v9.1.8](https://www.ibm.com/support/pages/node/7273939)

--- a/src/mas/devops/data/catalogs/v9-260527-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260527-amd64.yaml
@@ -181,8 +181,5 @@ editorial:
     - IBM Maximo Visual Inspection [v9.0.20](https://www.ibm.com/support/pages/node/7274038), [v9.1.17](https://www.ibm.com/support/pages/node/7274039)
     - IBM Maximo Real Estate and Facilities [v9.1.11](https://www.ibm.com/support/pages/node/7273955)
     - IBM Maximo AI Service [v9.1.15](https://www.ibm.com/support/pages/node/7273795)
-    - IBM Truststore Manager v1.7
-    - IBM Suite License Service v3.12
-
   known_issues:
     - title: NA

--- a/src/mas/devops/data/catalogs/v9-260527-ppc64le.yaml
+++ b/src/mas/devops/data/catalogs/v9-260527-ppc64le.yaml
@@ -55,9 +55,7 @@ editorial:
   whats_new:
   - title: '**Security updates and bug fixes**'
     details:
-    - IBM Maximo Application Suite Core Platform [v9.0.24](https://www.ibm.com/support/pages/node/7270976) and [v9.1.16](https://www.ibm.com/support/pages/node/7270977)
-    - IBM Maximo Manage [v9.0.25](https://www.ibm.com/support/pages/node/7270970) and [v9.1.17](https://www.ibm.com/support/pages/node/7270971)
-    - IBM Truststore Manager v1.7
-    - IBM Suite License Service v3.12
+    - IBM Maximo Application Suite Core Platform [v9.0.26](https://www.ibm.com/support/pages/node/7273948) and [v9.1.18](https://supportcontent.ibm.com/support/pages/node/7273949)
+    - IBM Maximo Manage [v9.0.26](https://www.ibm.com/support/pages/node/7274051) and [v9.1.18](https://www.ibm.com/support/pages/node/7274052)
   known_issues:
-    - title: A know issue in IBM Maximo Real Estate and Facilities, users may encounter failures during upgrade scenarios (9.1.9 → 9.2 FC).
+    - title: NA

--- a/src/mas/devops/data/catalogs/v9-260527-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-260527-s390x.yaml
@@ -55,9 +55,7 @@ editorial:
   whats_new:
   - title: '**Security updates and bug fixes**'
     details:
-    - IBM Maximo Application Suite Core Platform [v9.0.24](https://www.ibm.com/support/pages/node/7270976) and [v9.1.16](https://www.ibm.com/support/pages/node/7270977)
-    - IBM Maximo Manage [v9.0.25](https://www.ibm.com/support/pages/node/7270970) and [v9.1.17](https://www.ibm.com/support/pages/node/7270971)
-    - IBM Truststore Manager v1.7
-    - IBM Suite License Service v3.12
+    - IBM Maximo Application Suite Core Platform [v9.0.26](https://www.ibm.com/support/pages/node/7273948) and [v9.1.18](https://supportcontent.ibm.com/support/pages/node/7273949)
+    - IBM Maximo Manage [v9.0.26](https://www.ibm.com/support/pages/node/7274051) and [v9.1.18](https://www.ibm.com/support/pages/node/7274052)
   known_issues:
-    - title: A know issue in IBM Maximo Real Estate and Facilities, users may encounter failures during upgrade scenarios (9.1.9 → 9.2 FC).
+    - title: NA


### PR DESCRIPTION
- title: '**Security updates and bug fixes**'
    details:
    - IBM Maximo Application Suite Core Platform [v9.0.26](https://www.ibm.com/support/pages/node/7273948) and [v9.1.18](https://supportcontent.ibm.com/support/pages/node/7273949)
    - IBM Maximo Manage [v9.0.26](https://www.ibm.com/support/pages/node/7274051) and [v9.1.18](https://www.ibm.com/support/pages/node/7274052)
    - IBM Maximo IoT [v9.0.20](https://www.ibm.com/support/pages/node/7273937) and [v9.1.11](https://www.ibm.com/support/pages/node/7273938)
    - IBM Maximo Monitor [v9.1.11](https://www.ibm.com/support/pages/node/7270981)
    - IBM Maximo Optimizer [v9.0.23]( https://www.ibm.com/support/pages/node/7273440) and [v9.1.12](https://www.ibm.com/support/pages/node/7273443)
    - IBM Maximo Assist/Collaborate [v9.0.17](https://www.ibm.com/support/pages/node/7273929), [v9.1.11](https://www.ibm.com/support/pages/node/7273930)
    - IBM Maximo Predict [v9.0.15](https://www.ibm.com/support/pages/node/7273940) and [v9.1.8](https://www.ibm.com/support/pages/node/7273939)
    - IBM Maximo Visual Inspection [v9.0.20](https://www.ibm.com/support/pages/node/7274038), [v9.1.17](https://www.ibm.com/support/pages/node/7274039)
    - IBM Maximo Real Estate and Facilities [v9.1.11](https://www.ibm.com/support/pages/node/7273955)
    - IBM Maximo AI Service [v9.1.15](https://www.ibm.com/support/pages/node/7273795)
    - IBM Truststore Manager v1.7
    - IBM Suite License Service v3.12