### PR TITLE
[patch] Update DevOps catalog versions for June 25, 2026

### DIFF
--- a/src/mas/devops/data/catalogs/v9-260625-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260625-amd64.yaml
@@ -1,0 +1,185 @@
+---
+# Case bundle configuration for IBM Maximo Operator Catalog 260625 (AMD64)
+# -----------------------------------------------------------------------------
+# In the future this won't be necessary as we'll be able to mirror from the
+# catalog itself, but not everything in the catalog supports this yet (including MAS)
+# so we need to use the CASE bundle mirror process still.
+
+catalog_digest: sha256:29f96e5e36bfb8594c8747043d72a662206a2836959ed3c76ed6fc62462d8241
+
+ocp_compatibility:
+- "4.16"
+- "4.17"
+- "4.18"
+- "4.19"
+- "4.20"
+- "4.21"
+
+# Dependencies
+# -----------------------------------------------------------------------------
+ibm_licensing_version: 4.2.17                   # Operator version 4.2.14 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-licensing)
+common_svcs_version: 4.13.0                     # Operator version 4.13.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+#common_svcs_version_1: 4.11.0                   # Additional version 4.11.0
+
+cp4d_platform_version: 5.2.0+20250709.170324    # Operator version 5.2.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-datacore/)
+ibm_zen_version: 6.2.0+20250530.152516.232      # For CPD5 ibm-zen has to be explicitily mirrored
+
+db2u_version: 7.3.1+20250821.161005.16793       # Operator version 110509.0.6 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+db2_channel_default: v110509.0                  # Default Channel version for db2u-operator
+uds_version: 2.0.12                             # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
+sls_version: 3.12.8             # No Update       # Operator version 3.12.7 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
+tsm_version: 1.7.6              # No Update       # Operator version 1.7.6 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
+dd_version: 1.1.23              # No Update     # Operator version 1.1.23 (https://github.ibm.com/maximoappsuite/ibm-data-dictionary/releases)
+appconnect_version: 6.2.0                       # Operator version 6.2.0 # sticking to 6.2.0 version # Please do Not Change
+wsl_version: 11.0.0+20250521.202913.73          # used for wsl and wsl_runtimes unless wsl_runtimes_version also specified
+wsl_runtimes_version: 11.0.0+20250515.090949.21 # cpd 5.1.3 uses version 10.3.0 of wsl runtimes but only 10.2.0 for wsl itself
+wml_version: 11.0.0+20250530.193146.282         # Operator version 5.2.0
+postgress_version: 5.16.0+20250827.110911.2626  # ibm-cpd-cloud-native-postgresql-operator 5.2.0 cp4d
+
+ccs_build: 11.0.0+20250605.130237.468           # cpd 5.2.0 using ccs build
+
+# I have added this as a guess as to the actual version used, we are currently using the wsl_version, but that does not exist for datarefinery
+# See: https://ibm-mas.slack.com/archives/C02PUHKQB5L/p1770849370378689
+datarefinery_version: 11.0.0+20250513.203727.232
+
+spark_version: 11.0.0+20250604.163055.2097      # Operator version 5.2.0
+cognos_version: 28.0.0+20250515.175459.10054    # Operator version 25.0.0
+couchdb_version: 1.0.13                         # Operator version 2.2.1 (1.0.13) sticking with 1.0.13 # (This is required for Assist 9.0, https://github.com/IBM/cloud-pak/blob/master/repo/case/ibm-couchdb/index.yaml)
+elasticsearch_version: 1.1.2667                 # Operator version 1.1.2667 # used in cpd 5.1.3 only
+opensearch_version: 1.1.2494                    # Operator version 1.1.2494
+
+# Dependencies - Opendata hub
+# -----------------------------------------------------------------------------
+# https://github.com/opendatahub-io/opendatahub-operator/releases
+odh_version: 2.32.0
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  9.2.x-feature: 9.2.0-pre.stable_21734 # No Update
+  9.1.x: 9.1.18                         # Updated
+  9.0.x: 9.0.26                         # Updated
+  8.10.x: 8.10.37                       # No Update
+  8.11.x: 8.11.34                       # No Update
+mas_assist_version:
+  9.1.x: 9.1.11                         # Updated
+  9.0.x: 9.0.17                         # Updated
+  8.10.x: 8.7.8                         # No Update
+  8.11.x: 8.8.7                         # No Update
+mas_hputilities_version:
+  9.1.x: ""                             # Not Supported
+  9.0.x: ""                             # Not Supported
+  8.10.x: 8.6.7                         # No Update
+  8.11.x: ""                            # Not Supported
+mas_iot_version:
+  9.2.x-feature: 9.2.0-pre.stable_21024 # No Update
+  9.1.x: 9.1.11                         # Updated
+  9.0.x: 9.0.20                         # Updated
+  8.10.x: 8.7.33                        # No Update
+  8.11.x: 8.8.30                        # No Update
+mas_manage_version:
+  9.2.x-feature: 9.2.0-pre.stable_21956 # No Update
+  9.1.x: 9.1.18                         # Updated
+  9.0.x: 9.0.26                         # Updated
+  8.10.x: 8.6.38                        # No Update
+  8.11.x: 8.7.32                        # No Update
+mas_monitor_version:
+  9.2.x-feature: 9.2.0-pre.stable_21784 # No Update
+  9.1.x: 9.1.11                         # Updated
+  9.0.x: 9.0.20                         # No Update
+  8.10.x: 8.10.30                       # No Update
+  8.11.x: 8.11.28                       # No Update
+mas_optimizer_version:
+  9.2.x-feature: 9.2.0-pre.stable_21493 # No Update
+  9.1.x: 9.1.12                         # Updated
+  9.0.x: 9.0.23                         # Updated
+  8.10.x: 8.4.28                        # No Update
+  8.11.x: 8.5.28                        # No Update
+mas_predict_version:
+  9.2.x-feature: 9.2.0-pre.stable_22454 # No Update
+  9.1.x: 9.1.8                          # Updated
+  9.0.x: 9.0.15                         # Updated
+  8.10.x: 8.8.15                        # No Update
+  8.11.x: 8.9.17                        # No Update
+mas_visualinspection_version:
+  9.2.x-feature: 9.2.0-pre.stable_12598 # No Update
+  9.1.x: 9.1.17                         # Updated
+  9.0.x: 9.0.20                         # Updated
+  8.10.x: 8.8.4                         # No Update
+  8.11.x: 8.9.21                        # No Update
+mas_facilities_version:
+  9.2.x-feature: 9.2.0-pre.stable_16853 # No Update
+  9.1.x: 9.1.11                         # Updated
+  9.0.x: ""                             # Not Supported
+  8.10.x: ""                            # Not Supported
+  8.11.x: ""                            # Not Supported
+
+
+# Maximo AI Service
+# ------------------------------------------------------------------------------
+aiservice_version:
+  9.2.x-feature: 9.2.0-pre.stable_21747 # No Update
+  9.1.x: 9.1.15                         # Updated
+
+aiservice_tenant_version:
+  9.2.x-feature: 9.2.0-pre.stable_21714 # No Update
+
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.5.0
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version_default: 8.0.20
+
+# Variables used to mirror additional mongo image versions
+mongo_extras_version_4: 4.4.21
+mongo_extras_version_5: 5.0.23
+mongo_extras_version_6: 6.0.12
+mongo_extras_version_7: 7.0.23
+mongo_extras_version_8: 8.0.20
+
+# Extra Images for Db2u
+# ------------------------------------------------------------------------------
+db2u_extras_version: 1.0.6               # No Update
+db2u_filter: db2
+
+# Extra Images for CCS used for PCD 5.2.0 Hotfix
+# ------------------------------------------------------------------------------
+ccs_extras_version: 11.0.0               # No Update
+
+# Extra Images for IBM Watson Discovery
+# ------------------------------------------------------------------------------
+#wd_extras_version: 1.0.4
+
+# Extra Images for Amlen
+# ------------------------------------------------------------------------------
+amlen_extras_version: 1.1.4              # No Update
+
+# Extra Images for Redis (Collaborate)
+# ------------------------------------------------------------------------------
+redis_extras_version: 2.1.40             # No Update
+
+# Default Cloud Pak for Data version
+# ------------------------------------------------------------------------------
+cpd_product_version_default: 5.2.0       # No Update
+
+minio_version: RELEASE.2025-06-13T11-33-47Z
+
+editorial:
+  whats_new:
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform [v9.0.26](https://www.ibm.com/support/pages/node/7273948) and [v9.1.18](https://supportcontent.ibm.com/support/pages/node/7273949)
+    - IBM Maximo Manage [v9.0.26](https://www.ibm.com/support/pages/node/7274051) and [v9.1.18](https://www.ibm.com/support/pages/node/7274052)
+    - IBM Maximo IoT [v9.0.20](https://www.ibm.com/support/pages/node/7273937) and [v9.1.11](https://www.ibm.com/support/pages/node/7273938)
+    - IBM Maximo Monitor [v9.1.11](https://www.ibm.com/support/pages/node/7274017)
+    - IBM Maximo Optimizer [v9.0.23]( https://www.ibm.com/support/pages/node/7273440) and [v9.1.12](https://www.ibm.com/support/pages/node/7273443)
+    - IBM Maximo Assist/Collaborate [v9.0.17](https://www.ibm.com/support/pages/node/7273929), [v9.1.11](https://www.ibm.com/support/pages/node/7273930)
+    - IBM Maximo Predict [v9.0.15](https://www.ibm.com/support/pages/node/7273940) and [v9.1.8](https://www.ibm.com/support/pages/node/7273939)
+    - IBM Maximo Visual Inspection [v9.0.20](https://www.ibm.com/support/pages/node/7274038), [v9.1.17](https://www.ibm.com/support/pages/node/7274039)
+    - IBM Maximo Real Estate and Facilities [v9.1.11](https://www.ibm.com/support/pages/node/7273955)
+    - IBM Maximo AI Service [v9.1.15](https://www.ibm.com/support/pages/node/7273795)
+  known_issues:
+    - title: NA

--- a/src/mas/devops/data/catalogs/v9-260625-ppc64le.yaml
+++ b/src/mas/devops/data/catalogs/v9-260625-ppc64le.yaml
@@ -1,0 +1,61 @@
+---
+# Case bundle configuration for IBM Maximo Operator Catalog 260625 (PPC)
+# -----------------------------------------------------------------------------
+# In the future this won't be necessary as we'll be able to mirror from the
+# catalog itself, but not everything in the catalog supports this yet (including MAS)
+# so we need to use the CASE bundle mirror process still.
+
+catalog_digest: sha256:44b82c3e8c618fe8d34849c5c080401c33753939ccdcc0ee51708bb026610b2d
+
+ocp_compatibility:
+- "4.16"
+- "4.17"
+- "4.18"
+- "4.19"
+- "4.20"
+- "4.21"
+
+uds_version: 2.0.12                       # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
+sls_version: 3.12.8       # No Update       # Operator version 3.12.5 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
+tsm_version: 1.7.6        # No Update       # Operator version 1.7.4 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
+db2u_version: 7.3.1+20250821.161005.16793       # Operator version 110509.0.6 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+db2_channel_default: v110509.0                  # Default Channel version for db2u-operator
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  9.2.x-feature: 9.2.0-pre.stable_21734   # No Update
+  9.1.x: 9.1.18                           # Updated
+  9.0.x: 9.0.26                           # Updated
+  8.10.x: ""                              # Not Supported
+  8.11.x: ""                              # Not Supported
+mas_manage_version:
+  9.2.x-feature: 9.2.0-pre.stable_21956   # No Update
+  9.1.x: 9.1.18                           # Updated
+  9.0.x: 9.0.26                           # Updated
+  8.10.x: ""                              # Not Supported
+  8.11.x: ""                              # Not Supported
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.5.0                 # No Update
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version_default: 8.0.20      # No Update
+
+# Variables used to mirror additional mongo image versions
+mongo_extras_version_4: 4.4.21
+mongo_extras_version_5: 5.0.23
+mongo_extras_version_6: 6.0.12
+mongo_extras_version_7: 7.0.12
+mongo_extras_version_8: 8.0.20
+
+editorial:
+  whats_new:
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform [v9.0.26](https://www.ibm.com/support/pages/node/7273948) and [v9.1.18](https://supportcontent.ibm.com/support/pages/node/7273949)
+    - IBM Maximo Manage [v9.0.26](https://www.ibm.com/support/pages/node/7274051) and [v9.1.18](https://www.ibm.com/support/pages/node/7274052)
+  known_issues:
+    - title: NA

--- a/src/mas/devops/data/catalogs/v9-260625-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-260625-s390x.yaml
@@ -1,0 +1,61 @@
+---
+# Case bundle configuration for IBM Maximo Operator Catalog 260625 (Z)
+# -----------------------------------------------------------------------------
+# In the future this won't be necessary as we'll be able to mirror from the
+# catalog itself, but not everything in the catalog supports this yet (including MAS)
+# so we need to use the CASE bundle mirror process still.
+
+catalog_digest: sha256:6850fe15ea49526c61616f389181608a173587d63407d321fdbd3d6c13634648
+
+ocp_compatibility:
+- "4.16"
+- "4.17"
+- "4.18"
+- "4.19"
+- "4.20"
+- "4.21"
+
+uds_version: 2.0.12                       # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
+sls_version: 3.12.8         # No Update     # Operator version 3.12.5 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
+tsm_version: 1.7.6          # No Update     # Operator version 1.7.4 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
+db2u_version: 7.3.1+20250821.161005.16793       # Operator version 110509.0.6 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+db2_channel_default: v110509.0                  # Default Channel version for db2u-operator
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  9.2.x-feature: 9.2.0-pre.stable_21734 # No Update
+  9.1.x: 9.1.18                         # Updated
+  9.0.x: 9.0.26                         # Updated
+  8.10.x: ""                            # Not Supported
+  8.11.x: ""                            # Not Supported
+mas_manage_version:
+  9.2.x-feature: 9.2.0-pre.stable_21956 # No Update
+  9.1.x: 9.1.18                         # Updated
+  9.0.x: 9.0.26                         # Updated
+  8.10.x: ""                            # Not Supported
+  8.11.x: ""                            # Not Supported
+
+# Extra Images for UDS
+# ------------------------------------------------------------------------------
+uds_extras_version: 1.5.0               # No Update
+
+# Extra Images for Mongo
+# ------------------------------------------------------------------------------
+mongo_extras_version_default: 8.0.20    # No Update
+
+# Variables used to mirror additional mongo image versions
+mongo_extras_version_4: 4.4.21
+mongo_extras_version_5: 5.0.23
+mongo_extras_version_6: 6.0.12
+mongo_extras_version_7: 7.0.12
+mongo_extras_version_8: 8.0.20
+
+editorial:
+  whats_new:
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform [v9.0.26](https://www.ibm.com/support/pages/node/7273948) and [v9.1.18](https://supportcontent.ibm.com/support/pages/node/7273949)
+    - IBM Maximo Manage [v9.0.26](https://www.ibm.com/support/pages/node/7274051) and [v9.1.18](https://www.ibm.com/support/pages/node/7274052)
+  known_issues:
+    - title: NA


### PR DESCRIPTION
This PR updates the catalog files with new digests for the June 25, 2026 release (v9-260625).

## Changes
- Created v9-260625-amd64.yaml with updated digest
- Created v9-260625-ppc64le.yaml with updated digest
- Created v9-260625-s390x.yaml with updated digest

## Digests
- amd64: sha256:29f96e5e36bfb8594c8747043d72a662206a2836959ed3c76ed6fc62462d8241
- ppc64le: sha256:44b82c3e8c618fe8d34849c5c080401c33753939ccdcc0ee51708bb026610b2d
- s390x: sha256:6850fe15ea49526c61616f389181608a173587d63407d321fdbd3d6c13634648