### PR TITLE
[patch] Gitops Workaround: initial user creation Job needs to ignore health app

### DIFF
--- a/src/mas/devops/users.py
+++ b/src/mas/devops/users.py
@@ -188,7 +188,9 @@ class MASUserUtils():
     @property
     def mas_workspace_application_ids(self):
         if self._mas_workspace_application_ids is None:
-            self._mas_workspace_application_ids = list(map(lambda ma: ma["id"], self.get_mas_applications_in_workspace()))
+            # Filter out "health"
+            all_apps = self.get_mas_applications_in_workspace()
+            self._mas_workspace_application_ids = [app["id"] for app in all_apps if app["id"] != "health"]
         return self._mas_workspace_application_ids
 
     def get_user(self, user_id):

--- a/test/src/test_users.py
+++ b/test/src/test_users.py
@@ -369,6 +369,18 @@ def test_mas_workspace_application_ids(user_utils, requests_mock):
     assert get.call_count == 1
 
 
+def test_mas_workspace_application_ids_filters_health(user_utils, requests_mock):
+    get = requests_mock.get(
+        f"{MAS_API_URL}/workspaces/{MAS_WORKSPACE_ID}/applications",
+        request_headers={"x-access-token": TOKEN},
+        json=[{"id": "manage"}, {"id": "health"}, {"id": "iot"}],
+        status_code=200
+    )
+    # health should be filtered out
+    assert user_utils.mas_workspace_application_ids == ["manage", "iot"]
+    assert get.call_count == 1
+
+
 def test_get_user_exists(user_utils, requests_mock, mock_manage_api_key):
     user_id = "user1"
     get_core, get_manage, get_manage_personid = mock_get_user_200(requests_mock, user_id, mock_manage_api_key)


### PR DESCRIPTION
Issue: [MASCORE-14490](https://jsw.ibm.com/browse/MASCORE-14490)

## Description
Health is now a component of Manage, not a first class application. However, a bug in coreapi GET /workspaces/workspace/applications API means it is still returning an entry for Health that will never show ready or available.
Until that bug is fixed, we need to filter out health