### PR TITLE
[patch] Update SLS version to 3.13.0 in v9-260625 catalogs

### DIFF
--- a/src/mas/devops/data/catalogs/v9-260625-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260625-amd64.yaml
@@ -27,7 +27,7 @@ ibm_zen_version: 6.2.0+20250530.152516.232      # For CPD5 ibm-zen has to be exp
 db2u_version: 7.3.1+20250821.161005.16793       # Operator version 110509.0.6 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
 db2_channel_default: v110509.0                  # Default Channel version for db2u-operator
 uds_version: 2.0.12                             # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
-sls_version: 3.12.8             # No Update       # Operator version 3.12.7 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
+sls_version: 3.13.0             # Updated         # Operator version 3.13.0 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
 tsm_version: 1.7.7                              # https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases
 dd_version: 1.1.23              # No Update     # Operator version 1.1.23 (https://github.ibm.com/maximoappsuite/ibm-data-dictionary/releases)
 appconnect_version: 6.2.0                       # Operator version 6.2.0 # sticking to 6.2.0 version # Please do Not Change

--- a/src/mas/devops/data/catalogs/v9-260625-ppc64le.yaml
+++ b/src/mas/devops/data/catalogs/v9-260625-ppc64le.yaml
@@ -16,7 +16,7 @@ ocp_compatibility:
 - "4.21"
 
 uds_version: 2.0.12                       # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
-sls_version: 3.12.8       # No Update       # Operator version 3.12.5 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
+sls_version: 3.13.0       # Updated         # Operator version 3.13.0 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
 tsm_version: 1.7.7                          # https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases
 db2u_version: 7.3.1+20250821.161005.16793       # Operator version 110509.0.6 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
 db2_channel_default: v110509.0                  # Default Channel version for db2u-operator

--- a/src/mas/devops/data/catalogs/v9-260625-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-260625-s390x.yaml
@@ -16,7 +16,7 @@ ocp_compatibility:
 - "4.21"
 
 uds_version: 2.0.12                       # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
-sls_version: 3.12.8         # No Update     # Operator version 3.12.5 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
+sls_version: 3.13.0         # Updated       # Operator version 3.13.0 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
 tsm_version: 1.7.7                          # https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases
 db2u_version: 7.3.1+20250821.161005.16793       # Operator version 110509.0.6 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
 db2_channel_default: v110509.0                  # Default Channel version for db2u-operator


### PR DESCRIPTION
- Updated sls_version from 3.12.8 to 3.13.0 across all architectures
- Updated for amd64, ppc64le, and s390x catalogs
- Aligns with latest SLS release: https://github.ibm.com/maximoappsuite/ibm-sls/releases/tag/3.13.0
