### PR TITLE
[patch] Backup and restore - apps pvc optional and better error handling

### DIFF
--- a/src/mas/devops/backup.py
+++ b/src/mas/devops/backup.py
@@ -11,7 +11,7 @@ import logging
 import os
 import yaml
 from openshift.dynamic import DynamicClient
-from openshift.dynamic.exceptions import NotFoundError
+from openshift.dynamic.exceptions import NotFoundError, ResourceNotFoundError
 import boto3
 from botocore.exceptions import ClientError, NoCredentialsError
 
@@ -226,7 +226,7 @@ def backupResources(dynClient: DynamicClient, kind: str, api_version: str, backu
 
         return (backed_up_count, not_found_count, failed_count, discovered_secrets)
 
-    except NotFoundError:
+    except (NotFoundError, ResourceNotFoundError):
         if name:
             logger.info(f"{kind} '{name}' not found in {scope_desc}")
             not_found_count = 1

--- a/src/mas/devops/restore.py
+++ b/src/mas/devops/restore.py
@@ -126,7 +126,7 @@ def restoreResource(dynClient: DynamicClient, resource_data: dict, namespace=Non
             return (False, resource_name, error_msg)
 
     except ResourceNotFoundError:
-        return (True, resource_data.get('kind'), "skipped")
+        return (True, resource_data.get("kind"), "skipped")
 
     except Exception as e:
         error_msg = f"Error restoring resource: {e}"

--- a/src/mas/devops/restore.py
+++ b/src/mas/devops/restore.py
@@ -10,7 +10,7 @@
 import logging
 import yaml
 from openshift.dynamic import DynamicClient
-from openshift.dynamic.exceptions import NotFoundError
+from openshift.dynamic.exceptions import NotFoundError, ResourceNotFoundError
 
 logger = logging.getLogger(name=__name__)
 
@@ -115,6 +115,9 @@ def restoreResource(dynClient: DynamicClient, resource_data: dict, namespace=Non
             error_msg = f"Failed to {action} {kind} '{resource_name}': {e}"
             logger.error(error_msg)
             return (False, resource_name, error_msg)
+
+    except ResourceNotFoundError:
+        return (True, resource_data.get('kind'), "skipped")
 
     except Exception as e:
         error_msg = f"Error restoring resource: {e}"

--- a/src/mas/devops/templates/pipelinerun-backup.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-backup.yml.j2
@@ -130,6 +130,10 @@ spec:
     - name: manage_workspace_id
       value: "{{ manage_workspace_id }}"
     {% endif %}
+    {% if backup_manage_include_pvc is defined and backup_manage_include_pvc != "" %}
+    - name: backup_manage_include_pvc
+      value: "{{ backup_manage_include_pvc }}"
+    {% endif %}
 
     # Manage Db2 Backup Configuration
     {% if manage_db2_namespace is defined and manage_db2_namespace != "" %}
@@ -177,6 +181,10 @@ spec:
     {% if facilities_workspace_id is defined and facilities_workspace_id != "" %}
     - name: facilities_workspace_id
       value: "{{ facilities_workspace_id }}"
+    {% endif %}
+    {% if backup_facilities_include_pvc is defined and backup_facilities_include_pvc != "" %}
+    - name: backup_facilities_include_pvc
+      value: "{{ backup_facilities_include_pvc }}"
     {% endif %}
 
     # Facilities Db2 Backup Configuration

--- a/src/mas/devops/templates/pipelinerun-restore.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-restore.yml.j2
@@ -204,6 +204,10 @@ spec:
     - name: restore_manage_db
       value: "{{ restore_manage_db }}"
     {% endif %}
+    {% if restore_manage_include_pvc is defined and restore_manage_include_pvc != "" %}
+    - name: restore_manage_include_pvc
+      value: "{{ restore_manage_include_pvc }}"
+    {% endif %}
     # Manage App Storage class
     {% if manage_app_override_storageclass is defined and manage_app_override_storageclass != "" %}
     - name: manage_app_override_storageclass
@@ -245,6 +249,10 @@ spec:
     {% if restore_facilities_db is defined and restore_facilities_db != "" %}
     - name: restore_facilities_db
       value: "{{ restore_facilities_db }}"
+    {% endif %}
+    {% if restore_facilities_include_pvc is defined and restore_facilities_include_pvc != "" %}
+    - name: restore_facilities_include_pvc
+      value: "{{ restore_facilities_include_pvc }}"
     {% endif %}
     # Facilities App Storage class
     {% if facilities_app_override_storageclass is defined and facilities_app_override_storageclass != "" %}


### PR DESCRIPTION
Changes:
- Option to include/exclude Apps' PVC backup and restore in pipelines
- Better error handling during backup and restore resource lookup.

The error handling improvements allows backup and restore to skip the resources when the Kind is not found.
this allows backup and restore to work across different MAS releases where some kinds are exclusive.
