### PR TITLE
[patch] remove ibm_entitlement_key from Tekton param flow and source from secrets

### DIFF
--- a/src/mas/devops/tekton.py
+++ b/src/mas/devops/tekton.py
@@ -598,7 +598,7 @@ def prepareRestoreSecrets(dynClient: DynamicClient, namespace: str, restoreConfi
     secretsAPI.create(body=restoreConfigs, namespace=namespace)
 
 
-def prepareInstallSecrets(dynClient: DynamicClient, namespace: str, slsLicenseFile: str = None, additionalConfigs: dict = None, certs: str = None, podTemplates: str = None, slack_token: str = None, slack_channel: str = None, aiserviceConfig: str = None, db2LicenseFile: dict | None = None, facilitiesProperties: dict | None = None) -> None:
+def prepareInstallSecrets(dynClient: DynamicClient, namespace: str, slsLicenseFile: str = None, additionalConfigs: dict = None, certs: str = None, podTemplates: str = None, slack_token: str = None, slack_channel: str = None, aiserviceConfig: str = None, db2LicenseFile: dict | None = None, facilitiesProperties: dict | None = None, ibm_entitlement_key: str = None) -> None:
     """
     Create or update secrets required for MAS installation pipelines.
 
@@ -618,6 +618,7 @@ def prepareInstallSecrets(dynClient: DynamicClient, namespace: str, slsLicenseFi
         slack_channel (str, optional): Slack channel ID for notifications. Defaults to None.
         aiserviceConfig (str, optional): AI Service tenant config data. Defaults to None (empty secret).
         facilitiesProperties (dict, optional): Facilities properties file content. Defaults to None (empty secret).
+        ibm_entitlement_key (str, optional): IBM entitlement key for authentication. Defaults to None.
 
     Returns:
         None
@@ -685,6 +686,19 @@ def prepareInstallSecrets(dynClient: DynamicClient, namespace: str, slsLicenseFi
                 "name": "pipeline-additional-configs"
             }
         }
+
+    additionalConfigs.setdefault("apiVersion", "v1")
+    additionalConfigs.setdefault("kind", "Secret")
+    additionalConfigs.setdefault("type", "Opaque")
+    additionalConfigs.setdefault("metadata", {})
+    additionalConfigs["metadata"]["name"] = "pipeline-additional-configs"
+
+    # Add IBM_ENTITLEMENT_KEY to the secret if provided
+    if ibm_entitlement_key:
+        if "data" not in additionalConfigs:
+            additionalConfigs["data"] = {}
+        additionalConfigs["data"]["IBM_ENTITLEMENT_KEY"] = base64.b64encode(ibm_entitlement_key.encode()).decode()
+
     secretsAPI.create(body=additionalConfigs, namespace=namespace)
 
     # 2. Secret/pipeline-sls-entitlement

--- a/src/mas/devops/tekton.py
+++ b/src/mas/devops/tekton.py
@@ -679,17 +679,20 @@ def prepareAiServicePipelinesNamespace(
         logger.info(f"Storage class {storageClass} uses volumeBindingMode={volumeBindingMode}, skipping PVC bind wait")
 
 
-def prepareRestoreSecrets(dynClient: DynamicClient, namespace: str, restoreConfigs: dict = None):
+def prepareRestoreSecrets(dynClient: DynamicClient, namespace: str, restoreConfigs: dict = None, additionalConfigs: dict = None, ibm_entitlement_key: str = None):
     """
-    Create or update secret required for MAS Restore pipeline.
+    Create or update secrets required for MAS Restore pipeline.
 
-    Creates secret in the specified namespace:
+    Creates secrets in the specified namespace:
         - pipeline-restore-configs
+        - pipeline-additional-configs
 
     Parameters:
         dynClient (DynamicClient): OpenShift Dynamic Client
         namespace (str): The namespace to create secrets in
         restoreConfigs (dict, optional): configuration data for restore. Defaults to None (empty secret).
+        additionalConfigs (dict, optional): Additional configuration data. Defaults to None (empty secret).
+        ibm_entitlement_key (str, optional): IBM entitlement key for authentication. Defaults to None.
 
     Returns:
         None
@@ -715,6 +718,38 @@ def prepareRestoreSecrets(dynClient: DynamicClient, namespace: str, restoreConfi
             "metadata": {"name": "pipeline-restore-configs"},
         }
     secretsAPI.create(body=restoreConfigs, namespace=namespace)
+
+    # 2. Secret/pipeline-additional-configs
+    # -------------------------------------------------------------------------
+    # Must exist, but can be empty
+    try:
+        secretsAPI.delete(name="pipeline-additional-configs", namespace=namespace)
+    except NotFoundError:
+        pass
+
+    if additionalConfigs is None:
+        additionalConfigs = {
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "type": "Opaque",
+            "metadata": {
+                "name": "pipeline-additional-configs"
+            }
+        }
+
+    additionalConfigs.setdefault("apiVersion", "v1")
+    additionalConfigs.setdefault("kind", "Secret")
+    additionalConfigs.setdefault("type", "Opaque")
+    additionalConfigs.setdefault("metadata", {})
+    additionalConfigs["metadata"]["name"] = "pipeline-additional-configs"
+
+    # Add IBM_ENTITLEMENT_KEY to the secret if provided
+    if ibm_entitlement_key:
+        if "data" not in additionalConfigs:
+            additionalConfigs["data"] = {}
+        additionalConfigs["data"]["IBM_ENTITLEMENT_KEY"] = base64.b64encode(ibm_entitlement_key.encode()).decode()
+
+    secretsAPI.create(body=additionalConfigs, namespace=namespace)
 
 
 def prepareInstallSecrets(

--- a/src/mas/devops/tekton.py
+++ b/src/mas/devops/tekton.py
@@ -679,7 +679,9 @@ def prepareAiServicePipelinesNamespace(
         logger.info(f"Storage class {storageClass} uses volumeBindingMode={volumeBindingMode}, skipping PVC bind wait")
 
 
-def prepareRestoreSecrets(dynClient: DynamicClient, namespace: str, restoreConfigs: dict = None, additionalConfigs: dict = None, ibm_entitlement_key: str = None):
+def prepareRestoreSecrets(
+    dynClient: DynamicClient, namespace: str, restoreConfigs: dict = None, additionalConfigs: dict = None, ibm_entitlement_key: str = None
+):
     """
     Create or update secrets required for MAS Restore pipeline.
 
@@ -728,14 +730,7 @@ def prepareRestoreSecrets(dynClient: DynamicClient, namespace: str, restoreConfi
         pass
 
     if additionalConfigs is None:
-        additionalConfigs = {
-            "apiVersion": "v1",
-            "kind": "Secret",
-            "type": "Opaque",
-            "metadata": {
-                "name": "pipeline-additional-configs"
-            }
-        }
+        additionalConfigs = {"apiVersion": "v1", "kind": "Secret", "type": "Opaque", "metadata": {"name": "pipeline-additional-configs"}}
 
     additionalConfigs.setdefault("apiVersion", "v1")
     additionalConfigs.setdefault("kind", "Secret")

--- a/src/mas/devops/templates/pipelinerun-aiservice-upgrade.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-aiservice-upgrade.yml.j2
@@ -21,11 +21,6 @@ spec:
     - name: aiservice_channel
       value: "{{ aiservice_channel }}"
 
-    # IBM Entitlement Key
-    # -------------------------------------------------------------------------
-    - name: ibm_entitlement_key
-      value: "{{ ibm_entitlement_key }}"
-
 {%- if skip_pre_check is defined and skip_pre_check != "" %}
     # Skip pre-check
     # -------------------------------------------------------------------------

--- a/src/mas/devops/templates/pipelinerun-aiservice-upgrade.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-aiservice-upgrade.yml.j2
@@ -49,3 +49,9 @@ spec:
     - name: shared-pod-templates
       secret:
         secretName: pipeline-pod-templates
+
+    # IBM entitlement key configurations
+    # -------------------------------------------------------------------------
+    - name: shared-additional-configs
+      secret:
+        secretName: pipeline-additional-configs

--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -1001,3 +1001,4 @@ spec:
       secret:
         secretName: pipeline-facilities-properties
     {% endif %}
+    

--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -1001,4 +1001,5 @@ spec:
       secret:
         secretName: pipeline-facilities-properties
     {% endif %}
-    
+
+

--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -18,10 +18,6 @@ spec:
     pipeline: "0"
 
   params:
-    # IBM Entitlement Key
-    # -------------------------------------------------------------------------
-    - name: ibm_entitlement_key
-      value: "{{ ibm_entitlement_key }}"
 {%- if skip_pre_check is defined and skip_pre_check != "" %}
 
     # Pipeline config

--- a/src/mas/devops/templates/pipelinerun-restore.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-restore.yml.j2
@@ -98,10 +98,6 @@ spec:
     - name: dro_contact_lastname
       value: "{{ dro_contact_lastname }}"
     {% endif %}
-    {% if ibm_entitlement_key is defined and ibm_entitlement_key != "" %}
-    - name: ibm_entitlement_key
-      value: "{{ ibm_entitlement_key }}"
-    {% endif %}
     {% if dro_namespace is defined and dro_namespace != "" %}
     - name: dro_namespace
       value: "{{ dro_namespace }}"

--- a/src/mas/devops/templates/pipelinerun-restore.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-restore.yml.j2
@@ -18,6 +18,9 @@ spec:
     - name: restore-configurations
       secret:
         secretName: pipeline-restore-configs
+    - name: shared-additional-configs
+      secret:
+        secretName: pipeline-additional-configs
   params:
     # Common Parameters
     - name: image_pull_policy

--- a/src/mas/devops/templates/pipelinerun-update.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-update.yml.j2
@@ -27,11 +27,6 @@ spec:
     - name: mas_catalog_version
       value: "{{ mas_catalog_version }}"
 
-{%- if ibm_entitlement_key is defined and ibm_entitlement_key != "" %}
-    # TODO: What even uses this, nothing in the update pipeline should be using this
-    - name: ibm_entitlement_key
-      value: "{{ ibm_entitlement_key }}"
-{%- endif %}
 {%- if artifactory_username is defined and artifactory_username != "" %}
     # Enable development catalogs
     # -------------------------------------------------------------------------

--- a/src/mas/devops/templates/pipelinerun-upgrade.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-upgrade.yml.j2
@@ -29,11 +29,6 @@ spec:
     - name: mas_channel
       value: "{{ mas_channel }}"
 
-    # IBM Entitlement Key
-    # -------------------------------------------------------------------------
-    - name: ibm_entitlement_key
-      value: "{{ ibm_entitlement_key }}"
-
 {%- if skip_pre_check is defined and skip_pre_check != "" %}
     # Skip pre-check
     # -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
`ibm_entitlement_key` was appearing as plaintext in pod environment variables and being passed through MAS install/restore PipelineRuns into pod specs via tekton parameters.
This change removes `ibm_entitlement_key` from the Tekton parameter flow and updates all affected task pods under [/tekton/src/tasks](https://github.com/ibm-mas/cli/tree/fix-secrets/tekton/src/tasks) to read `IBM_ENTITLEMENT_KEY` directly from the Kubernetes secret `pipeline-additional-configs` via `secretKeyRef`. It also extends the mas-restore pipeline to carry the `shared-additional-configs` workspace so the restore flow has the same secret access as install.
It also applies the SLS speific-fix in [/cli/tekton/src/tasks/dependencies/sls.yml.j2](https://github.com/ibm-mas/cli/blob/fix-secrets/tekton/src/tasks/dependencies/sls.yml.j2#L106) so `IBM_ENTITLEMENT_KEY` is not injected into the SLS pod for newer SLS channel paths (sls_channel > 3.7.0).


## Changes
Removed `ibm_entitlement_key` param from PipelineRuns from templates under [src/mas/devops/templates/](https://github.com/ibm-mas/python-devops/tree/fix-secrets/src/mas/devops/templates).
[/src/mas/devops/tekton.py](https://github.com/ibm-mas/python-devops/blob/fix-secrets/src/mas/devops/tekton.py) updated to write secret:
   [prepareInstallSecrets()](https://github.com/ibm-mas/python-devops/blob/fix-secrets/src/mas/devops/tekton.py#L798) - updated to writeIBM_ENTITLEMENT_KEY into `pipeline-additional-configs` secret when provided
   [prepareRestoreSecrets()](https://github.com/ibm-mas/python-devops/blob/fix-secrets/src/mas/devops/tekton.py#L731) -  same behaviour as prepareInstallSecrets() for the restore pipeline flow; creates `pipeline-additional-configs` secret in the target namespace.
Added `shared-additional-configs` workspace binding (backed bypipeline-additional-configs secret) to [/src/mas/devops/templates/pipelinerun-aiservice-upgrade.yml.j2](https://github.com/ibm-mas/python-devops/blob/fix-secrets/src/mas/devops/templates/pipelinerun-aiservice-upgrade.yml.j2#L56).
Added `shared-additional-configs` workspace binding to [/src/mas/devops/templates/pipelinerun-restore.yml.j2](https://github.com/ibm-mas/python-devops/blob/fix-secrets/src/mas/devops/templates/pipelinerun-restore.yml.j2#L22).


## Validation
Validation details are attached in
[MAS-Core-Manage-PFVT-Cluster-Validations.docx](https://github.com/user-attachments/files/29540943/MAS-Core-Manage-PFVT-Cluster-Validations.docx) for  cluster and PFVT validations.
[AIService-PFVT-Cluster-Validations.docx](https://github.com/user-attachments/files/29540953/AIService-PFVT-Cluster-Validations.docx) for cluster and PFVT validations.
Both files contain OC CLI validations and OpenShift UI validations confirming:
- PipelineRuns do not contain `ibm_entitlement_key` as a parameter
- Secret `pipeline-additional-configs` contains `IBM_ENTITLEMENT_KEY`
- All affected pods use `valueFrom.secretKeyRef`  - no plaintext value
- No pod YAML contains the old lowercase `ibm_entitlement_key` param name

Validated on Fyre OCP cluster:
- Install pipeline for MASCore/Manage completed.
- `fvt-core` completed successfully.
- `fvt-manage` completed successfully.
-  Install pipeline for AIService completed.

FVT results:
MASCore: https://dashboard.ibmmas.com/tests/fixsecurity/3291
AIService: https://dashboard.ibmmas.com/tests/fixsecurity/3305