### PR TITLE
[patch] Only set mas_appws_bindings_health_wsl_flag if cpd is set

### DIFF
--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -618,9 +618,11 @@ spec:
     - name: manage_bind_aiservice_tenant_id
       value: "{{ manage_bind_aiservice_tenant_id }}"
   {%- endif %}
+  {%- if cpd_product_version is defined and cpd_product_version != "" %}
   {%- if mas_appws_bindings_health_wsl_flag is defined and mas_appws_bindings_health_wsl_flag != "" %}
     - name: mas_appws_bindings_health_wsl_flag
       value: "{{ mas_appws_bindings_health_wsl_flag }}"
+  {%- endif %}
   {%- endif %}
   {%- if mas_app_settings_aio_flag is defined and mas_app_settings_aio_flag != "" %}
     - name: mas_app_settings_aio_flag


### PR DESCRIPTION
When using the cli in advanced mode and install manage, you will be prompted for:
```
Enable integration with Watson Studio Local? [y/n] n
```

which sets the mas_appws_bindings_health_wsl_flag to false, and if nothing else (i.e. predict) would cause cpd to be set then the cpd_product_version is not set. However the pipeline attempts to install cpd as `mas_appws_bindings_health_wsl_flag` is set to something (even if false) https://github.com/ibm-mas/cli/blob/21.7.0/tekton/src/pipelines/taskdefs/cp4d/cp4d-platform.yml.j2#L21

The fix is like the cognos_install which only sets those variables if cpd_platform_version is set as the mas_appws_bindings_health_wsl_flag flag controls if we install watson studio or not.