### PR TITLE
[major] Upgrade to tekton.dev/v1 API

### DIFF
--- a/src/mas/devops/tekton.py
+++ b/src/mas/devops/tekton.py
@@ -1094,7 +1094,7 @@ def launchUpgradePipeline(
     pipelineRun = yaml.safe_load(renderedTemplate)
     applyResource(
         dynClient=dynClient,
-        apiVersion="tekton.dev/v1beta1",
+        apiVersion="tekton.dev/v1",
         kind="PipelineRun",
         body=pipelineRun,
         namespace=namespace,
@@ -1148,7 +1148,7 @@ def launchUninstallPipeline(
     pipelineRun = yaml.safe_load(renderedTemplate)
     applyResource(
         dynClient=dynClient,
-        apiVersion="tekton.dev/v1beta1",
+        apiVersion="tekton.dev/v1",
         kind="PipelineRun",
         body=pipelineRun,
         namespace=namespace,
@@ -1188,7 +1188,7 @@ def launchPipelineRun(dynClient: DynamicClient, namespace: str, templateName: st
     pipelineRun = yaml.safe_load(renderedTemplate)
     applyResource(
         dynClient=dynClient,
-        apiVersion="tekton.dev/v1beta1",
+        apiVersion="tekton.dev/v1",
         kind="PipelineRun",
         body=pipelineRun,
         namespace=namespace,
@@ -1319,7 +1319,7 @@ def launchAiServiceUpgradePipeline(
     pipelineRun = yaml.safe_load(renderedTemplate)
     applyResource(
         dynClient=dynClient,
-        apiVersion="tekton.dev/v1beta1",
+        apiVersion="tekton.dev/v1",
         kind="PipelineRun",
         body=pipelineRun,
         namespace=namespace,

--- a/src/mas/devops/templates/pipelinerun-aiservice-upgrade.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-aiservice-upgrade.yml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: "{{ aiservice_instance_id }}-upgrade-{{ timestamp }}"
@@ -9,7 +9,8 @@ spec:
   pipelineRef:
     name: aiservice-upgrade
 
-  serviceAccountName: "{{ service_account_name | default('pipeline', True) }}"
+  taskRunTemplate:
+    serviceAccountName: "{{ service_account_name | default('pipeline', True) }}"
   timeouts:
     pipeline: "0"
 

--- a/src/mas/devops/templates/pipelinerun-backup.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-backup.yml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: "{{ mas_instance_id }}-backup-{{ backup_version }}-{{ timestamp }}"
@@ -8,7 +8,8 @@ metadata:
 spec:
   pipelineRef:
     name: mas-backup
-  serviceAccountName: "{{ service_account_name | default('pipeline', True) }}"
+  taskRunTemplate:
+    serviceAccountName: "{{ service_account_name | default('pipeline', True) }}"
   timeouts:
     pipeline: "0"
   workspaces:

--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
 {%- if mas_instance_id is defined and mas_instance_id != "" %}
@@ -13,7 +13,8 @@ spec:
   pipelineRef:
     name: mas-install
 
-  serviceAccountName: "{{ service_account_name | default('pipeline', True) }}"
+  taskRunTemplate:
+    serviceAccountName: "{{ service_account_name | default('pipeline', True) }}"
   timeouts:
     pipeline: "0"
 
@@ -116,7 +117,7 @@ spec:
       value: "{{ db2_type }}"
     - name: db2_timezone
       value: "{{ db2_timezone }}"
-  {%- if db2_action_facilities == "install" %}      
+  {%- if db2_action_facilities == "install" %}
     - name: db2_facilities_timezone
       value: "{{ db2_facilities_timezone }}"
   {%- endif %}

--- a/src/mas/devops/templates/pipelinerun-restore.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-restore.yml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: "{{ mas_instance_id }}-restore-{{ restore_version }}-{{ timestamp }}"
@@ -8,7 +8,8 @@ metadata:
 spec:
   pipelineRef:
     name: mas-restore
-  serviceAccountName: "{{ service_account_name | default('pipeline', True) }}"
+  taskRunTemplate:
+    serviceAccountName: "{{ service_account_name | default('pipeline', True) }}"
   timeouts:
     pipeline: "0"
   workspaces:

--- a/src/mas/devops/templates/pipelinerun-uninstall.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-uninstall.yml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: "{{mas_instance_id}}-uninstall-{{ timestamp }}"
@@ -9,7 +9,8 @@ spec:
   pipelineRef:
     name: mas-uninstall
 
-  serviceAccountName: "{{ service_account_name | default('pipeline', True) }}"
+  taskRunTemplate:
+    serviceAccountName: "{{ service_account_name | default('pipeline', True) }}"
   timeouts:
     pipeline: "0"
 

--- a/src/mas/devops/templates/pipelinerun-update.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-update.yml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: "mas-update-{{ timestamp }}"
@@ -9,7 +9,8 @@ spec:
   pipelineRef:
     name: mas-update
 
-  serviceAccountName: "{{ service_account_name | default('pipeline', True) }}"
+  taskRunTemplate:
+    serviceAccountName: "{{ service_account_name | default('pipeline', True) }}"
   timeouts:
     pipeline: "0"
 

--- a/src/mas/devops/templates/pipelinerun-upgrade.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-upgrade.yml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: "{{ mas_instance_id }}-upgrade-{{ timestamp }}"
@@ -9,7 +9,8 @@ spec:
   pipelineRef:
     name: mas-upgrade
 
-  serviceAccountName: "{{ service_account_name | default('pipeline', True) }}"
+  taskRunTemplate:
+    serviceAccountName: "{{ service_account_name | default('pipeline', True) }}"
   timeouts:
     pipeline: "0"
 

--- a/test/src/test_tekton_update.py
+++ b/test/src/test_tekton_update.py
@@ -29,13 +29,13 @@ class TestUpdateTektonDefinitions:
         mock_isfile.return_value = True
         mock_yaml_load.return_value = [
             {
-                "apiVersion": "tekton.dev/v1beta1",
+                "apiVersion": "tekton.dev/v1",
                 "kind": "Task",
                 "metadata": {"name": "test-task"},
                 "spec": {},
             },
             {
-                "apiVersion": "tekton.dev/v1beta1",
+                "apiVersion": "tekton.dev/v1",
                 "kind": "Pipeline",
                 "metadata": {"name": "test-pipeline"},
                 "spec": {},
@@ -101,19 +101,19 @@ class TestUpdateTektonDefinitions:
         mock_isfile.return_value = True
         mock_yaml_load.return_value = [
             {
-                "apiVersion": "tekton.dev/v1beta1",
+                "apiVersion": "tekton.dev/v1",
                 "kind": "Task",
                 "metadata": {"name": "task-1"},
                 "spec": {},
             },
             {
-                "apiVersion": "tekton.dev/v1beta1",
+                "apiVersion": "tekton.dev/v1",
                 "kind": "Task",
                 "metadata": {"name": "task-2"},
                 "spec": {},
             },
             {
-                "apiVersion": "tekton.dev/v1beta1",
+                "apiVersion": "tekton.dev/v1",
                 "kind": "Pipeline",
                 "metadata": {"name": "pipeline-1"},
                 "spec": {},
@@ -145,7 +145,7 @@ class TestUpdateTektonDefinitions:
         mock_isfile.return_value = True
         mock_yaml_load.return_value = [
             {
-                "apiVersion": "tekton.dev/v1beta1",
+                "apiVersion": "tekton.dev/v1",
                 "kind": "Task",
                 "metadata": {"name": "test-task"},
                 "spec": {},
@@ -183,7 +183,7 @@ class TestUpdateTektonDefinitions:
         mock_isfile.return_value = True
         mock_yaml_load.return_value = [
             {
-                "apiVersion": "tekton.dev/v1beta1",
+                "apiVersion": "tekton.dev/v1",
                 "kind": "Task",
                 "metadata": {"name": "test-task"},
                 "spec": {},


### PR DESCRIPTION
Update `PipelineRun` templates from `tekton.dev/v1beta1` to `tekton.dev/v1`

This requires one significant change to the templates:

`spec.serviceAccountName` has been moved to `spec.taskRunTemplate.serviceAccountName`

- See: https://github.com/ibm-mas/cli/issues/2414