### PR TITLE
[minor] Add external database support for AIService

### DIFF
--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -1002,6 +1002,29 @@ spec:
       value: "{{ aiservice_certificate_issuer }}"
 {%- endif %}
 
+    # AI Service - Database Configuration
+    # -------------------------------------------------------------------------
+{%- if install_db2 is defined and install_db2 != "" %}
+    - name: install_db2
+      value: "{{ install_db2 }}"
+{%- endif %}
+{%- if aiservice_db_jdbc_url is defined and aiservice_db_jdbc_url != "" %}
+    - name: aiservice_db_jdbc_url
+      value: "{{ aiservice_db_jdbc_url }}"
+{%- endif %}
+{%- if aiservice_db_username is defined and aiservice_db_username != "" %}
+    - name: aiservice_db_username
+      value: "{{ aiservice_db_username }}"
+{%- endif %}
+{%- if aiservice_db_password is defined and aiservice_db_password != "" %}
+    - name: aiservice_db_password
+      value: "{{ aiservice_db_password }}"
+{%- endif %}
+{%- if aiservice_db_ca_cert is defined and aiservice_db_ca_cert != "" %}
+    - name: aiservice_db_ca_cert
+      value: "{{ aiservice_db_ca_cert }}"
+{%- endif %}
+
 {%- endif %}
 
   workspaces:

--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -1004,7 +1004,7 @@ spec:
 
     # AI Service - Database Configuration
     # -------------------------------------------------------------------------
-{%- if install_db2 is defined and install_db2 != "" %}
+{%- if install_db2 is defined %}
     - name: install_db2
       value: "{{ install_db2 }}"
 {%- endif %}


### PR DESCRIPTION
## Summary
Updates Tekton pipeline templates to pass external database parameters, enabling AI Service installation with external databases (Oracle, SQL Server, external DB2).

### Related PRs
https://github.com/ibm-mas/ansible-devops/pull/2336
https://github.com/ibm-mas/cli/pull/2427

### Related Issues
https://jsw.ibm.com/browse/MASAIB-2388