### PR TITLE
[patch] Add redis_extras_version (2.1.40) to catalog

### DIFF
--- a/src/mas/devops/data/catalogs/v9-260625-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260625-amd64.yaml
@@ -110,6 +110,10 @@ dd_version: 1.1.23              # No Update
 # https://github.com/opendatahub-io/opendatahub-operator/releases
 odh_version: 2.32.0
 
+# Extra Images for Redis (Collaborate)
+# ------------------------------------------------------------------------------
+redis_extras_version: 2.1.40             # No Update
+
 
 # Maximo Application Suite
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Add redis_extras_version: 2.1.40 to src/mas/devops/data/catalogs/v9-260625-amd64.yaml to include extra Redis images for Collaborate. The entry follows existing version entries and includes the 'No Update' comment.