### PR TITLE
[patch] Fix Maximo Manage link domain in catalogs

### DIFF
--- a/src/mas/devops/data/catalogs/v9-260625-ppc64le.yaml
+++ b/src/mas/devops/data/catalogs/v9-260625-ppc64le.yaml
@@ -74,7 +74,7 @@ editorial:
   - title: New feature release
     details:
     - IBM Maximo Application Suite Core Platform [v9.2.0](https://www.ibm.com/support/pages/node/7277376)
-    - IBM Maximo Manage [v9.2.0](https://supportcontent.ibm.com/support/pages/node/7276377)
+    - IBM Maximo Manage [v9.2.0](https://www.ibm.com/support/pages/node/7276377)
   - title: '**Security updates and bug fixes**'
     details:
     - IBM Maximo Application Suite Core Platform [v9.0.27](https://www.ibm.com/support/pages/node/7277381) and [v9.1.19](https://www.ibm.com/support/pages/node/7277382)

--- a/src/mas/devops/data/catalogs/v9-260625-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-260625-s390x.yaml
@@ -74,7 +74,7 @@ editorial:
   - title: New feature release
     details:
     - IBM Maximo Application Suite Core Platform [v9.2.0](https://www.ibm.com/support/pages/node/7277376)
-    - IBM Maximo Manage [v9.2.0](https://supportcontent.ibm.com/support/pages/node/7276377)
+    - IBM Maximo Manage [v9.2.0](https://www.ibm.com/support/pages/node/7276377)
   - title: '**Security updates and bug fixes**'
     details:
     - IBM Maximo Application Suite Core Platform [v9.0.27](https://www.ibm.com/support/pages/node/7277381) and [v9.1.19](https://www.ibm.com/support/pages/node/7277382)


### PR DESCRIPTION
Update IBM Maximo Manage link from supportcontent.ibm.com to www.ibm.com in v9-260625-ppc64le.yaml and v9-260625-s390x.yaml so the entries point to the official IBM support pages.