### PR TITLE
[patch] Fix connect()

### DIFF
--- a/src/mas/devops/ocp.py
+++ b/src/mas/devops/ocp.py
@@ -10,7 +10,7 @@
 
 import logging
 import os
-import tempfile
+from pathlib import Path
 from time import sleep
 
 from kubernetes import client, config
@@ -31,6 +31,7 @@ def connect(server: str, token: str, skipVerify: bool = False) -> bool:
     Connect to a target OpenShift Container Platform (OCP) cluster.
 
     Configures Kubernetes client with the provided server URL and authentication token.
+    Updates the default kubeconfig file with the new cluster context.
 
     Parameters:
         server (str): The OpenShift cluster API server URL (e.g., "https://api.cluster.example.com:6443")
@@ -46,51 +47,77 @@ def connect(server: str, token: str, skipVerify: bool = False) -> bool:
     logger.info(f"Connect(server={server}, token=***)")
 
     try:
-        # Create kubeconfig structure
-        kubeconfigDict = {
-            "apiVersion": "v1",
-            "kind": "Config",
-            "clusters": [
-                {
-                    "name": "my-cluster",
-                    "cluster": {
-                        "server": server,
-                        "insecure-skip-tls-verify": skipVerify,
-                    },
-                }
-            ],
-            "users": [
-                {
-                    "name": "my-credentials",
-                    "user": {"token": token},
-                }
-            ],
-            "contexts": [
-                {
-                    "name": "my-context",
-                    "context": {
-                        "cluster": "my-cluster",
-                        "user": "my-credentials",
-                    },
-                }
-            ],
-            "current-context": "my-context",
+        # Determine kubeconfig path
+        kubeconfig_path = os.environ.get("KUBECONFIG")
+        if not kubeconfig_path:
+            kubeconfig_path = os.path.join(Path.home(), ".kube", "config")
+
+        logger.debug(f"Using kubeconfig at {kubeconfig_path}")
+
+        # Load existing kubeconfig or create new one
+        if os.path.exists(kubeconfig_path):
+            with open(kubeconfig_path, "r") as f:
+                kubeconfigDict = yaml.safe_load(f) or {}
+        else:
+            kubeconfigDict = {"apiVersion": "v1", "kind": "Config", "clusters": [], "users": [], "contexts": [], "current-context": ""}
+            # Ensure directory exists
+            os.makedirs(os.path.dirname(kubeconfig_path), exist_ok=True)
+
+        # Ensure required keys exist
+        if "clusters" not in kubeconfigDict:
+            kubeconfigDict["clusters"] = []
+        if "users" not in kubeconfigDict:
+            kubeconfigDict["users"] = []
+        if "contexts" not in kubeconfigDict:
+            kubeconfigDict["contexts"] = []
+
+        # Define cluster, user, and context names
+        cluster_name = "mas-cluster"
+        user_name = "mas-user"
+        context_name = "mas-context"
+
+        # Update or add cluster
+        cluster_entry = {
+            "name": cluster_name,
+            "cluster": {
+                "server": server,
+                "insecure-skip-tls-verify": skipVerify,
+            },
         }
+        # Remove existing cluster with same name
+        kubeconfigDict["clusters"] = [c for c in kubeconfigDict["clusters"] if c.get("name") != cluster_name]
+        kubeconfigDict["clusters"].append(cluster_entry)
 
-        # Write to temporary file
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".kubeconfig", delete=False) as tmpFile:
-            tmpKubeconfigPath = tmpFile.name
-            yaml.dump(kubeconfigDict, tmpFile)
+        # Update or add user
+        user_entry = {"name": user_name, "user": {"token": token}}
+        # Remove existing user with same name
+        kubeconfigDict["users"] = [u for u in kubeconfigDict["users"] if u.get("name") != user_name]
+        kubeconfigDict["users"].append(user_entry)
 
-        logger.debug(f"Created temporary kubeconfig at {tmpKubeconfigPath}")
+        # Update or add context
+        context_entry = {
+            "name": context_name,
+            "context": {
+                "cluster": cluster_name,
+                "user": user_name,
+            },
+        }
+        # Remove existing context with same name
+        kubeconfigDict["contexts"] = [c for c in kubeconfigDict["contexts"] if c.get("name") != context_name]
+        kubeconfigDict["contexts"].append(context_entry)
 
-        # Load the configuration
-        config.load_kube_config(config_file=tmpKubeconfigPath)
-        logger.info("KubeConfig context changed to my-context")
+        # Set current context
+        kubeconfigDict["current-context"] = context_name
 
-        # Clean up temporary file
-        os.unlink(tmpKubeconfigPath)
-        logger.debug(f"Removed temporary kubeconfig {tmpKubeconfigPath}")
+        # Write updated kubeconfig
+        with open(kubeconfig_path, "w") as f:
+            yaml.dump(kubeconfigDict, f, default_flow_style=False)
+
+        logger.debug(f"Updated kubeconfig at {kubeconfig_path}")
+
+        # Load the configuration from the updated kubeconfig
+        config.load_kube_config(config_file=kubeconfig_path)
+        logger.info(f"KubeConfig context changed to {context_name}")
 
         return True
 

--- a/test/src/test_ocp_connect.py
+++ b/test/src/test_ocp_connect.py
@@ -8,7 +8,7 @@
 #
 # *****************************************************************************
 
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, mock_open
 from kubernetes.config.config_exception import ConfigException
 
 from mas.devops.ocp import connect
@@ -18,15 +18,16 @@ class TestOcpConnect:
     """Test suite for ocp.connect() function."""
 
     @patch("mas.devops.ocp.config.load_kube_config")
-    @patch("mas.devops.ocp.os.unlink")
-    @patch("mas.devops.ocp.tempfile.NamedTemporaryFile")
+    @patch("mas.devops.ocp.os.makedirs")
+    @patch("mas.devops.ocp.os.path.exists")
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("mas.devops.ocp.yaml.safe_load")
     @patch("mas.devops.ocp.yaml.dump")
-    def test_connect_success(self, mock_yaml_dump, mock_tempfile, mock_unlink, mock_load_config):
+    def test_connect_success(self, mock_yaml_dump, mock_yaml_load, mock_file, mock_exists, mock_makedirs, mock_load_config):
         """Test successful connection to OCP cluster."""
-        # Setup mock temporary file
-        mock_file = MagicMock()
-        mock_file.name = "/tmp/test.kubeconfig"
-        mock_tempfile.return_value.__enter__.return_value = mock_file
+        # Setup - kubeconfig exists with existing content
+        mock_exists.return_value = True
+        mock_yaml_load.return_value = {"apiVersion": "v1", "kind": "Config", "clusters": [], "users": [], "contexts": [], "current-context": ""}
 
         # Execute
         result = connect(
@@ -38,19 +39,21 @@ class TestOcpConnect:
         # Verify
         assert result is True
         mock_yaml_dump.assert_called_once()
-        mock_load_config.assert_called_once_with(config_file="/tmp/test.kubeconfig")
-        mock_unlink.assert_called_once_with("/tmp/test.kubeconfig")
+        mock_load_config.assert_called_once()
+        # Verify the kubeconfig was written
+        assert mock_file.call_count >= 2  # Once for read, once for write
 
     @patch("mas.devops.ocp.config.load_kube_config")
-    @patch("mas.devops.ocp.os.unlink")
-    @patch("mas.devops.ocp.tempfile.NamedTemporaryFile")
+    @patch("mas.devops.ocp.os.makedirs")
+    @patch("mas.devops.ocp.os.path.exists")
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("mas.devops.ocp.yaml.safe_load")
     @patch("mas.devops.ocp.yaml.dump")
-    def test_connect_with_tls_skip(self, mock_yaml_dump, mock_tempfile, mock_unlink, mock_load_config):
+    def test_connect_with_tls_skip(self, mock_yaml_dump, mock_yaml_load, mock_file, mock_exists, mock_makedirs, mock_load_config):
         """Test connection with TLS verification skipped."""
-        # Setup mock temporary file
-        mock_file = MagicMock()
-        mock_file.name = "/tmp/test.kubeconfig"
-        mock_tempfile.return_value.__enter__.return_value = mock_file
+        # Setup - kubeconfig exists
+        mock_exists.return_value = True
+        mock_yaml_load.return_value = {"apiVersion": "v1", "kind": "Config", "clusters": [], "users": [], "contexts": [], "current-context": ""}
 
         # Execute
         result = connect(
@@ -66,15 +69,16 @@ class TestOcpConnect:
         assert call_args["clusters"][0]["cluster"]["insecure-skip-tls-verify"] is True
 
     @patch("mas.devops.ocp.config.load_kube_config")
-    @patch("mas.devops.ocp.os.unlink")
-    @patch("mas.devops.ocp.tempfile.NamedTemporaryFile")
+    @patch("mas.devops.ocp.os.makedirs")
+    @patch("mas.devops.ocp.os.path.exists")
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("mas.devops.ocp.yaml.safe_load")
     @patch("mas.devops.ocp.yaml.dump")
-    def test_connect_config_exception(self, mock_yaml_dump, mock_tempfile, mock_unlink, mock_load_config):
+    def test_connect_config_exception(self, mock_yaml_dump, mock_yaml_load, mock_file, mock_exists, mock_makedirs, mock_load_config):
         """Test connection failure with ConfigException."""
-        # Setup mock temporary file
-        mock_file = MagicMock()
-        mock_file.name = "/tmp/test.kubeconfig"
-        mock_tempfile.return_value.__enter__.return_value = mock_file
+        # Setup - kubeconfig exists
+        mock_exists.return_value = True
+        mock_yaml_load.return_value = {"apiVersion": "v1", "kind": "Config", "clusters": [], "users": [], "contexts": [], "current-context": ""}
 
         # Setup mock to raise ConfigException
         mock_load_config.side_effect = ConfigException("Invalid configuration")
@@ -87,18 +91,18 @@ class TestOcpConnect:
 
         # Verify
         assert result is False
-        mock_unlink.assert_not_called()  # Should not clean up on error
 
     @patch("mas.devops.ocp.config.load_kube_config")
-    @patch("mas.devops.ocp.os.unlink")
-    @patch("mas.devops.ocp.tempfile.NamedTemporaryFile")
+    @patch("mas.devops.ocp.os.makedirs")
+    @patch("mas.devops.ocp.os.path.exists")
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("mas.devops.ocp.yaml.safe_load")
     @patch("mas.devops.ocp.yaml.dump")
-    def test_connect_unexpected_exception(self, mock_yaml_dump, mock_tempfile, mock_unlink, mock_load_config):
+    def test_connect_unexpected_exception(self, mock_yaml_dump, mock_yaml_load, mock_file, mock_exists, mock_makedirs, mock_load_config):
         """Test connection failure with unexpected exception."""
-        # Setup mock temporary file
-        mock_file = MagicMock()
-        mock_file.name = "/tmp/test.kubeconfig"
-        mock_tempfile.return_value.__enter__.return_value = mock_file
+        # Setup - kubeconfig exists
+        mock_exists.return_value = True
+        mock_yaml_load.return_value = {"apiVersion": "v1", "kind": "Config", "clusters": [], "users": [], "contexts": [], "current-context": ""}
 
         # Setup mock to raise unexpected exception
         mock_load_config.side_effect = RuntimeError("Unexpected error")
@@ -111,4 +115,26 @@ class TestOcpConnect:
 
         # Verify
         assert result is False
-        mock_unlink.assert_not_called()  # Should not clean up on error
+
+    @patch("mas.devops.ocp.config.load_kube_config")
+    @patch("mas.devops.ocp.os.makedirs")
+    @patch("mas.devops.ocp.os.path.exists")
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("mas.devops.ocp.yaml.dump")
+    def test_connect_creates_new_kubeconfig(self, mock_yaml_dump, mock_file, mock_exists, mock_makedirs, mock_load_config):
+        """Test connection creates new kubeconfig when it doesn't exist."""
+        # Setup - kubeconfig doesn't exist
+        mock_exists.return_value = False
+
+        # Execute
+        result = connect(
+            server="https://api.test.example.com:6443",
+            token="test-token-123",
+            skipVerify=False,
+        )
+
+        # Verify
+        assert result is True
+        mock_makedirs.assert_called_once()  # Should create directory
+        mock_yaml_dump.assert_called_once()
+        mock_load_config.assert_called_once()


### PR DESCRIPTION
Working with a temporary kubeconfig doesn't have the desired effect, we need to work with the actual kubeconfig file, just like we did when using the old library (that was basically a shim directly running `kubectl` commands)