### PR TITLE
[patch] Revert "remove ibm_entitlement_key from Tekton param flow and…

### DIFF
--- a/src/mas/devops/tekton.py
+++ b/src/mas/devops/tekton.py
@@ -727,22 +727,17 @@ def prepareAiServicePipelinesNamespace(
         logger.info(f"Storage class {storageClass} uses volumeBindingMode={volumeBindingMode}, skipping PVC bind wait")
 
 
-def prepareRestoreSecrets(
-    dynClient: DynamicClient, namespace: str, restoreConfigs: dict = None, additionalConfigs: dict = None, ibm_entitlement_key: str = None
-):
+def prepareRestoreSecrets(dynClient: DynamicClient, namespace: str, restoreConfigs: dict = None):
     """
-    Create or update secrets required for MAS Restore pipeline.
+    Create or update secret required for MAS Restore pipeline.
 
-    Creates secrets in the specified namespace:
+    Creates secret in the specified namespace:
         - pipeline-restore-configs
-        - pipeline-additional-configs
 
     Parameters:
         dynClient (DynamicClient): OpenShift Dynamic Client
         namespace (str): The namespace to create secrets in
         restoreConfigs (dict, optional): configuration data for restore. Defaults to None (empty secret).
-        additionalConfigs (dict, optional): Additional configuration data. Defaults to None (empty secret).
-        ibm_entitlement_key (str, optional): IBM entitlement key for authentication. Defaults to None.
 
     Returns:
         None
@@ -769,31 +764,6 @@ def prepareRestoreSecrets(
         }
     secretsAPI.create(body=restoreConfigs, namespace=namespace)
 
-    # 2. Secret/pipeline-additional-configs
-    # -------------------------------------------------------------------------
-    # Must exist, but can be empty
-    try:
-        secretsAPI.delete(name="pipeline-additional-configs", namespace=namespace)
-    except NotFoundError:
-        pass
-
-    if additionalConfigs is None:
-        additionalConfigs = {"apiVersion": "v1", "kind": "Secret", "type": "Opaque", "metadata": {"name": "pipeline-additional-configs"}}
-
-    additionalConfigs.setdefault("apiVersion", "v1")
-    additionalConfigs.setdefault("kind", "Secret")
-    additionalConfigs.setdefault("type", "Opaque")
-    additionalConfigs.setdefault("metadata", {})
-    additionalConfigs["metadata"]["name"] = "pipeline-additional-configs"
-
-    # Add IBM_ENTITLEMENT_KEY to the secret if provided
-    if ibm_entitlement_key:
-        if "data" not in additionalConfigs:
-            additionalConfigs["data"] = {}
-        additionalConfigs["data"]["IBM_ENTITLEMENT_KEY"] = base64.b64encode(ibm_entitlement_key.encode()).decode()
-
-    secretsAPI.create(body=additionalConfigs, namespace=namespace)
-
 
 def prepareInstallSecrets(
     dynClient: DynamicClient,
@@ -807,7 +777,6 @@ def prepareInstallSecrets(
     aiserviceConfig: str = None,
     db2LicenseFile: dict | None = None,
     facilitiesProperties: dict | None = None,
-    ibm_entitlement_key: str = None,
 ) -> None:
     """
     Create or update secrets required for MAS installation pipelines.
@@ -828,7 +797,6 @@ def prepareInstallSecrets(
         slack_channel (str, optional): Slack channel ID for notifications. Defaults to None.
         aiserviceConfig (str, optional): AI Service tenant config data. Defaults to None (empty secret).
         facilitiesProperties (dict, optional): Facilities properties file content. Defaults to None (empty secret).
-        ibm_entitlement_key (str, optional): IBM entitlement key for authentication. Defaults to None.
 
     Returns:
         None
@@ -890,19 +858,6 @@ def prepareInstallSecrets(
             "type": "Opaque",
             "metadata": {"name": "pipeline-additional-configs"},
         }
-
-    additionalConfigs.setdefault("apiVersion", "v1")
-    additionalConfigs.setdefault("kind", "Secret")
-    additionalConfigs.setdefault("type", "Opaque")
-    additionalConfigs.setdefault("metadata", {})
-    additionalConfigs["metadata"]["name"] = "pipeline-additional-configs"
-
-    # Add IBM_ENTITLEMENT_KEY to the secret if provided
-    if ibm_entitlement_key:
-        if "data" not in additionalConfigs:
-            additionalConfigs["data"] = {}
-        additionalConfigs["data"]["IBM_ENTITLEMENT_KEY"] = base64.b64encode(ibm_entitlement_key.encode()).decode()
-
     secretsAPI.create(body=additionalConfigs, namespace=namespace)
 
     # 2. Secret/pipeline-sls-entitlement

--- a/src/mas/devops/templates/pipelinerun-aiservice-upgrade.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-aiservice-upgrade.yml.j2
@@ -22,6 +22,11 @@ spec:
     - name: aiservice_channel
       value: "{{ aiservice_channel }}"
 
+    # IBM Entitlement Key
+    # -------------------------------------------------------------------------
+    - name: ibm_entitlement_key
+      value: "{{ ibm_entitlement_key }}"
+
 {%- if skip_pre_check is defined and skip_pre_check != "" %}
     # Skip pre-check
     # -------------------------------------------------------------------------
@@ -50,9 +55,3 @@ spec:
     - name: shared-pod-templates
       secret:
         secretName: pipeline-pod-templates
-
-    # IBM entitlement key configurations
-    # -------------------------------------------------------------------------
-    - name: shared-additional-configs
-      secret:
-        secretName: pipeline-additional-configs

--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -19,6 +19,10 @@ spec:
     pipeline: "0"
 
   params:
+    # IBM Entitlement Key
+    # -------------------------------------------------------------------------
+    - name: ibm_entitlement_key
+      value: "{{ ibm_entitlement_key }}"
 {%- if skip_pre_check is defined and skip_pre_check != "" %}
 
     # Pipeline config
@@ -1056,5 +1060,3 @@ spec:
       secret:
         secretName: pipeline-facilities-properties
     {% endif %}
-
-

--- a/src/mas/devops/templates/pipelinerun-restore.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-restore.yml.j2
@@ -19,9 +19,6 @@ spec:
     - name: restore-configurations
       secret:
         secretName: pipeline-restore-configs
-    - name: shared-additional-configs
-      secret:
-        secretName: pipeline-additional-configs
   params:
     # Common Parameters
     - name: image_pull_policy
@@ -101,6 +98,10 @@ spec:
     {% if dro_contact_lastname is defined and dro_contact_lastname != "" %}
     - name: dro_contact_lastname
       value: "{{ dro_contact_lastname }}"
+    {% endif %}
+    {% if ibm_entitlement_key is defined and ibm_entitlement_key != "" %}
+    - name: ibm_entitlement_key
+      value: "{{ ibm_entitlement_key }}"
     {% endif %}
     {% if dro_namespace is defined and dro_namespace != "" %}
     - name: dro_namespace

--- a/src/mas/devops/templates/pipelinerun-update.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-update.yml.j2
@@ -28,6 +28,11 @@ spec:
     - name: mas_catalog_version
       value: "{{ mas_catalog_version }}"
 
+{%- if ibm_entitlement_key is defined and ibm_entitlement_key != "" %}
+    # TODO: What even uses this, nothing in the update pipeline should be using this
+    - name: ibm_entitlement_key
+      value: "{{ ibm_entitlement_key }}"
+{%- endif %}
 {%- if artifactory_username is defined and artifactory_username != "" %}
     # Enable development catalogs
     # -------------------------------------------------------------------------

--- a/src/mas/devops/templates/pipelinerun-upgrade.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-upgrade.yml.j2
@@ -30,6 +30,11 @@ spec:
     - name: mas_channel
       value: "{{ mas_channel }}"
 
+    # IBM Entitlement Key
+    # -------------------------------------------------------------------------
+    - name: ibm_entitlement_key
+      value: "{{ ibm_entitlement_key }}"
+
 {%- if skip_pre_check is defined and skip_pre_check != "" %}
     # Skip pre-check
     # -------------------------------------------------------------------------


### PR DESCRIPTION
… source from secrets (#397)"

This reverts commit 6b7ae3ec43b438e28aeaf4f46f8929a7ea0e7d56 due to the error in the update pipeline:
```
mas-update-260702-1633-update-db2-pod
CreateContainerConfigError
Error: secret "pipeline-additional-configs" not found
```