### PR TITLE
[patch] Fix postsync job 'postsync-setup-db2' is failing on the ENCRLIB validation check for the facilities DB2 instance.

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-19T12:37:02Z",
+  "generated_at": "2026-07-03T11:02:31Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -178,7 +178,7 @@
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 241,
+        "line_number": 247,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/src/mas/devops/db2.py
+++ b/src/mas/devops/db2.py
@@ -191,7 +191,7 @@ def cr_pod_v_matches(cr_k: str, cr_v: str, pod_v: str) -> bool:
 
     # special case for ENCRLIB — DB2 resolves the symlink and stores the full absolute path, so just check if the library name is present
     if cr_k == "ENCRLIB":
-        return "libdb2compr_encr.so" in pod_v
+        return cr_v in pod_v
 
     # Look for e.g. 8192 AUTOMATIC -> AUTOMATIC(8192)
     matches = re.search(r"(\d+)\s*AUTOMATIC", cr_v, re.IGNORECASE)

--- a/src/mas/devops/db2.py
+++ b/src/mas/devops/db2.py
@@ -189,6 +189,10 @@ def cr_pod_v_matches(cr_k: str, cr_v: str, pod_v: str) -> bool:
         # db2 appends something like "/NODE0000/LOGSTREAM0000/" to the cr_v in these cases
         return pod_v.startswith(cr_v)
 
+    # special case for ENCRLIB — DB2 resolves the symlink and stores the full absolute path, so just check if the library name is present
+    if cr_k == "ENCRLIB":
+        return "libdb2compr_encr.so" in pod_v
+
     # Look for e.g. 8192 AUTOMATIC -> AUTOMATIC(8192)
     matches = re.search(r"(\d+)\s*AUTOMATIC", cr_v, re.IGNORECASE)
     if matches is not None:

--- a/test/src/test_db2.py
+++ b/test/src/test_db2.py
@@ -49,6 +49,12 @@ from mas.devops import db2
         ("X", "otherSTRING", "OTHERstring", False),
         ("X", "other string", "other string", True),
         ("X", "22", "22", True),
+        # ENCRLIB — short filename in CR, full absolute path in pod → should pass
+        ("ENCRLIB", "libdb2compr_encr.so", "/opt/ibm/db2/V11.5.0.0/lib64/libdb2compr_encr.so.1", True),
+        # ENCRLIB — future DB2 version path → should still pass
+        ("ENCRLIB", "libdb2compr_encr.so", "/opt/ibm/db2/V11.5.10.0/lib64/libdb2compr_encr.so.1", True),
+        # ENCRLIB — completely wrong library → should fail
+        ("ENCRLIB", "libdb2compr_encr.so", "/opt/ibm/db2/V11.5.0.0/lib64/somewronglibrary.so", False),
     ],
 )
 def test_cr_pod_v_matches(cr_k, cr_v, pod_v, expected):


### PR DESCRIPTION
Issue
[MASCORE-13992](https://jsw.ibm.com/browse/MASCORE-13992)

Description
The cr_pod_v_matches() validator in db2.py performs an exact string match when validating DB2 configuration parameters. For ENCRLIB, the CR yaml may contain the short filename libdb2compr_encr.so, but DB2 internally resolves the symlink and stores the full absolute path (e.g. /opt/ibm/db2/V11.5.0.0/lib64/libdb2compr_encr.so.1). This caused the postsync validation job to fail with a mismatch error.

Additionally, DB2 rejects the short filename with SQL5099N when attempting to set it directly, meaning no valid value gets stored for comparison.

This fix adds a special case for ENCRLIB in cr_pod_v_matches() to check whether the DB2 pod value contains libdb2compr_encr.so rather than doing an exact match. This makes the validation version-agnostic and resilient to future DB2 upgrades where the absolute path version number will change.

Test Results
Manually reproduced the bug on dev cluster (inst-14124, facilities/BLUDB):
Setting ENCRLIB to short filename libdb2compr_encr.so → rejected by DB2 with SQL5099N
Setting ENCRLIB to absolute path /opt/ibm/db2/V11.5.0.0/lib64/libdb2compr_encr.so.1 → accepted by DB2 with DB20000I
<img width="2670" height="326" alt="image" src="https://github.com/user-attachments/assets/96c0fe01-904b-4e08-8b03-65df7072cc59" />

Unit tests added to test_cr_pod_v_matches covering:
<img width="1024" height="52" alt="image" src="https://github.com/user-attachments/assets/ee5b70a5-355b-4fc0-bbfc-63da6a7438aa" />
Short filename in CR, current version absolute path in pod → passes ✅
Short filename in CR, future version absolute path in pod → passes ✅
Short filename in CR, completely wrong library in pod → fails correctly ✅
Logs in open shift pod: 
<img width="903" height="766" alt="image" src="https://github.com/user-attachments/assets/dad1969a-fdcb-44a5-a798-a31d46180a65" />
All db cfg checks for BLUDB passed.




