### PR TITLE
[patch] Extending mongo 8.0.23 support

### DIFF
--- a/src/mas/devops/data/catalogs/v9-260730-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260730-amd64.yaml
@@ -1,0 +1,233 @@
+---
+# Case bundle configuration for IBM Maximo Operator Catalog 260625 (AMD64)
+# -----------------------------------------------------------------------------
+# In the future this won't be necessary as we'll be able to mirror from the
+# catalog itself, but not everything in the catalog supports this yet (including MAS)
+# so we need to use the CASE bundle mirror process still.
+
+catalog_digest: sha256:028ecfe475c743c277917ef818698dea0ddfe7dcee79830ffaa5b3a61f89cdbd
+
+ocp_compatibility:
+- "4.16"
+- "4.17"
+- "4.18"
+- "4.19"
+- "4.20"
+- "4.21"
+
+# Dependencies - Cloud Pak for Data
+# -----------------------------------------------------------------------------
+cpd_product_version_default: 5.2.0       # No Update
+
+ibm_licensing_version: 4.2.17                    # Operator version 4.2.14 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-licensing)
+common_svcs_version: 4.13.0                      # Operator version 4.13.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+#common_svcs_version_1: 4.11.0                   # Additional version 4.11.0
+cp4d_platform_version: 5.2.0+20250709.170324     # Operator version 5.2.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-datacore/)
+ibm_zen_version: 6.2.0+20250530.152516.232       # For CPD5 ibm-zen has to be explicitily mirrored
+wsl_version: 11.0.0+20250521.202913.73           # used for wsl and wsl_runtimes unless wsl_runtimes_version also specified
+wsl_runtimes_version: 11.0.0+20250515.090949.21  # cpd 5.1.3 uses version 10.3.0 of wsl runtimes but only 10.2.0 for wsl itself
+wml_version: 11.0.0+20250530.193146.282          # Operator version 5.2.0
+spark_version: 11.0.0+20250604.163055.2097       # Operator version 5.2.0
+cognos_version: 28.0.0+20250515.175459.10054     # Operator version 25.0.0
+
+postgress_version: 5.16.0+20250827.110911.2626   # ibm-cpd-cloud-native-postgresql-operator 5.2.0 cp4d
+ccs_build: 11.0.0+20250605.130237.468            # cpd 5.2.0 using ccs build
+ccs_extras_version: 11.0.0                       # Extra Images for CCS used for PCD 5.2.0 Hotfix
+
+elasticsearch_version: 1.1.2667                  # Operator version 1.1.2667 # used in cpd 5.1.3 only
+opensearch_version: 1.1.2494                     # Operator version 1.1.2494
+
+# I have added this as a guess as to the actual version used, we are currently using the wsl_version, but that does not exist for datarefinery
+# See: https://ibm-mas.slack.com/archives/C02PUHKQB5L/p1770849370378689
+datarefinery_version: 11.0.0+20250513.203727.232
+
+
+# Dependencies - Db2u
+# -----------------------------------------------------------------------------
+db2u_version: 7.6.0+20260224.123157.19264        # Operator version 120104.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+db2u_extras_version: 1.0.6                       # No Update
+db2u_filter: db2
+
+db2_channel_default: v120104.0                   # Default Channel version for db2u-operator
+
+
+# Dependencies - CouchDb
+# -----------------------------------------------------------------------------
+# Note: This is required for Assist 9.0 (https://github.com/IBM/cloud-pak/blob/master/repo/case/ibm-couchdb/index.yaml)
+couchdb_version: 1.0.13  # Operator version 2.2.1 (1.0.13) sticking with 1.0.13
+
+
+# Dependencies - Minio
+# -----------------------------------------------------------------------------
+minio_version: RELEASE.2025-06-13T11-33-47Z
+minio_extras_version: 1.0.0
+
+# Dependencies - MongoDB
+# -----------------------------------------------------------------------------
+mongo_extras_version_default: 8.0.23
+mongo_extras_version_4: 4.4.21
+mongo_extras_version_5: 5.0.23
+mongo_extras_version_6: 6.0.12
+mongo_extras_version_7: 7.0.23
+mongo_extras_version_8: 8.0.23
+
+
+# Dependencies - Amlen
+# -----------------------------------------------------------------------------
+amlen_extras_version: 1.1.5              # Updated
+
+
+# Dependencies - UDS
+# -----------------------------------------------------------------------------
+uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
+uds_extras_version: 1.5.0
+
+
+# Dependencies - App Connect
+# -----------------------------------------------------------------------------
+appconnect_version: 6.2.0                    # Operator version 6.2.0 # sticking to 6.2.0 version # Please do Not Change
+
+
+# Dependencies - Suite License Service
+# -----------------------------------------------------------------------------
+# https://github.ibm.com/maximoappsuite/ibm-sls/releases
+sls_version: 3.13.0             # Updated
+
+
+# Dependencies - Truststore Manager
+# -----------------------------------------------------------------------------
+# https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases
+tsm_version: 1.7.7              # Updated
+
+
+# Dependencies - Data Dictionary
+# -----------------------------------------------------------------------------
+# https://github.ibm.com/maximoappsuite/ibm-data-dictionary/releases
+dd_version: 1.1.23              # No Update
+
+# Dependencies - Opendata hub
+# -----------------------------------------------------------------------------
+# https://github.com/opendatahub-io/opendatahub-operator/releases
+odh_version: 2.32.0
+
+# Extra Images for Redis (Collaborate)
+# ------------------------------------------------------------------------------
+redis_extras_version: 2.1.40             # No Update
+
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  9.2.x: 9.2.0                          # Updated
+  9.2.x-feature: 9.2.0                  # Updated
+  9.1.x: 9.1.19                         # Updated
+  9.0.x: 9.0.27                         # Updated
+  8.10.x: 8.10.37                       # No Update
+  8.11.x: 8.11.34                       # No Update
+mas_assist_version:
+  9.1.x: 9.1.12                         # Updated
+  9.0.x: 9.0.18                         # Updated
+  8.10.x: 8.7.8                         # No Update
+  8.11.x: 8.8.7                         # No Update
+mas_hputilities_version:
+  9.1.x: ""                             # Not Supported
+  9.0.x: ""                             # Not Supported
+  8.10.x: 8.6.7                         # No Update
+  8.11.x: ""                            # Not Supported
+mas_iot_version:
+  9.2.x: 9.2.0                          # Updated
+  9.2.x-feature: 9.2.0                  # Updated
+  9.1.x: 9.1.12                         # Updated
+  9.0.x: 9.0.21                         # Updated
+  8.10.x: 8.7.33                        # No Update
+  8.11.x: 8.8.30                        # No Update
+mas_manage_version:
+  9.2.x: 9.2.0                          # Updated
+  9.2.x-feature: 9.2.0                  # Updated
+  9.1.x: 9.1.19                         # Updated
+  9.0.x: 9.0.27                         # Updated
+  8.10.x: 8.6.38                        # No Update
+  8.11.x: 8.7.32                        # No Update
+mas_monitor_version:
+  9.2.x: 9.2.0                          # Updated
+  9.2.x-feature: 9.2.0                  # Updated
+  9.1.x: 9.1.12                         # Updated
+  9.0.x: 9.0.22                         # Updated
+  8.10.x: 8.10.30                       # No Update
+  8.11.x: 8.11.28                       # No Update
+mas_optimizer_version:
+  9.2.x: 9.2.0                          # Updated
+  9.2.x-feature: 9.2.0                  # Updated
+  9.1.x: 9.1.13                         # Updated
+  9.0.x: 9.0.24                         # Updated
+  8.10.x: 8.4.28                        # Updated
+  8.11.x: 8.5.28                        # Updated
+mas_predict_version:
+  9.2.x: 9.2.0                          # Updated
+  9.2.x-feature: 9.2.0                  # Updated
+  9.1.x: 9.1.9                          # Updated
+  9.0.x: 9.0.16                         # Updated
+  8.10.x: 8.8.15                        # No Update
+  8.11.x: 8.9.17                        # No Update
+mas_visualinspection_version:
+  9.2.x: 9.2.0                          # Updated
+  9.2.x-feature: 9.2.0                  # Updated
+  9.1.x: 9.1.18                         # Updated
+  9.0.x: 9.0.21                         # Updated
+  8.10.x: 8.8.4                         # No Update
+  8.11.x: 8.9.21                        # No Update
+mas_facilities_version:
+  9.2.x: 9.2.0                          # Updated
+  9.2.x-feature: 9.2.0                  # Updated
+  9.1.x: 9.1.12                         # Updated
+  9.0.x: ""                             # Not Supported
+  8.10.x: ""                            # Not Supported
+  8.11.x: ""                            # Not Supported
+
+
+# Maximo AI Service
+# ------------------------------------------------------------------------------
+aiservice_version:
+  9.2.x: 9.2.0                          # Updated
+  9.2.x-feature: 9.2.0                  # Updated
+  9.1.x: 9.1.16                         # Updated
+
+aiservice_tenant_version:
+  9.2.x: 9.2.0                          # Updated
+  9.2.x-feature: 9.2.0                  # Updated
+
+
+# Editorial
+# ------------------------------------------------------------------------------
+editorial:
+  whats_new:
+  - title: New feature release
+    details:
+    - IBM Maximo Application Suite Core Platform [v9.2.0](https://www.ibm.com/support/pages/node/7277376)
+    - IBM Maximo Manage [v9.2.0](https://www.ibm.com/support/pages/node/7276377)
+    - IBM Maximo Monitor/IoT [v9.2.0](https://www.ibm.com/support/pages/node/7277101)
+    - IBM Maximo Optimizer [v9.2.0](https://www.ibm.com/support/pages/node/7276586)
+    - IBM Maximo Predict [v9.2.0](https://www.ibm.com/support/pages/node/7275237)
+    - IBM Maximo Visual Inspection [v9.2.0](https://www.ibm.com/support/pages/node/7277289)
+    - IBM Maximo Real Estate and Facilities [v9.2.0](https://www.ibm.com/support/pages/node/7275247)
+    - IBM Maximo AI Service [v9.2.0](https://www.ibm.com/support/pages/node/7276603)
+    - IBM Maximo AI Service Tenant v9.2
+    - IBM Maximo Location Service for Esri v9.2
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform [v9.0.27](https://www.ibm.com/support/pages/node/7277381) and [v9.1.19](https://www.ibm.com/support/pages/node/7277382)
+    - IBM Maximo Manage [v9.0.27](https://www.ibm.com/support/pages/node/7276396) and [v9.1.19](https://www.ibm.com/support/pages/node/7276393)
+    - IBM Maximo IoT [v9.0.21](https://www.ibm.com/support/pages/node/7277130) and [v9.1.12](https://www.ibm.com/support/pages/node/7277131)
+    - IBM Maximo Monitor [v9.0.22](https://www.ibm.com/support/pages/node/7277099) and [v9.1.12](https://www.ibm.com/support/pages/node/7277100)
+    - IBM Maximo Optimizer [v9.0.24](https://www.ibm.com/support/pages/node/7276568) and [v9.1.13](https://www.ibm.com/support/pages/node/7276570)
+    - IBM Maximo Assist/Collaborate [v9.0.18](https://www.ibm.com/support/pages/node/7273929), [v9.1.12](https://www.ibm.com/support/pages/node/7273930)
+    - IBM Maximo Predict [v9.0.16](https://www.ibm.com/support/pages/node/7276914) and [v9.1.9](https://www.ibm.com/support/pages/node/7276913)
+    - IBM Maximo Visual Inspection [v9.0.21](https://www.ibm.com/support/pages/node/7277291) and [v9.1.18](https://www.ibm.com/support/pages/node/7277891)
+    - IBM Maximo Real Estate and Facilities [v9.1.12](https://www.ibm.com/support/pages/node/7276768)
+    - IBM Maximo AI Service [v9.1.16](https://www.ibm.com/support/pages/node/7276604)
+    - IBM Truststore Manager v1.7
+    - IBM Suite License Service v3.13
+    - Amlen v1.1
+  known_issues:
+    - title: A known issue exists in the June 25, 2026 release affecting IBM Maximo Visual Inspection. Customers with MVI installed and using custom cluster issuer should avoid upgrading to the June release. Installation of MVI 9.2.x should be deferred until the July 2026 patch.
+    - title: A know issue exists in the June 25 2026 release when a customer has environment setup with mas core+manage+Optimizer with out AIP as a addon. Then under manage work space two pods will appear aipoptimization-uninstall and it will be in error status. Even though these pods are in error status it does not have any functional impact on manage or optimizer. The fix has been identified and will be delivered in upcoming July 9.2 patch.

--- a/src/mas/devops/data/catalogs/v9-260730-ppc64le.yaml
+++ b/src/mas/devops/data/catalogs/v9-260730-ppc64le.yaml
@@ -1,0 +1,86 @@
+---
+# Case bundle configuration for IBM Maximo Operator Catalog 260625 (PPC)
+# -----------------------------------------------------------------------------
+# In the future this won't be necessary as we'll be able to mirror from the
+# catalog itself, but not everything in the catalog supports this yet (including MAS)
+# so we need to use the CASE bundle mirror process still.
+
+catalog_digest: sha256:3d6166394a6acbca30392c4675606fccea36613de3a305a8ca6094a65949ea26
+
+ocp_compatibility:
+- "4.16"
+- "4.17"
+- "4.18"
+- "4.19"
+- "4.20"
+- "4.21"
+
+# Dependencies - Db2u
+# -----------------------------------------------------------------------------
+db2u_version: 7.6.0+20260224.123157.19264        # Operator version 120104.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+
+db2_channel_default: v120104.0                   # Default Channel version for db2u-operator
+
+
+# Dependencies - UDS
+# -----------------------------------------------------------------------------
+uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
+uds_extras_version: 1.5.0                    # No Update
+
+
+# Dependencies - Suite License Service
+# -----------------------------------------------------------------------------
+# https://github.ibm.com/maximoappsuite/ibm-sls/releases
+sls_version: 3.13.0             # Updated
+
+
+# Dependencies - Truststore Manager
+# -----------------------------------------------------------------------------
+# https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases
+tsm_version: 1.7.7              # Updated
+
+
+# Dependencies - MongoDB
+# -----------------------------------------------------------------------------
+mongo_extras_version_default: 8.0.23
+mongo_extras_version_4: 4.4.21
+mongo_extras_version_5: 5.0.23
+mongo_extras_version_6: 6.0.12
+mongo_extras_version_7: 7.0.12
+mongo_extras_version_8: 8.0.23
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  9.2.x: 9.2.0                          # Updated
+  9.2.x-feature: 9.2.0                  # Updated
+  9.1.x: 9.1.19                         # Updated
+  9.0.x: 9.0.27                         # Updated
+  8.10.x: ""                            # Not Supported
+  8.11.x: ""                            # Not Supported
+mas_manage_version:
+  9.2.x: 9.2.0                          # Updated
+  9.2.x-feature: 9.2.0                  # Updated
+  9.1.x: 9.1.19                         # Updated
+  9.0.x: 9.0.27                         # Updated
+  8.10.x: ""                            # Not Supported
+  8.11.x: ""                            # Not Supported
+
+
+# Editorial
+# ------------------------------------------------------------------------------
+editorial:
+  whats_new:
+  - title: New feature release
+    details:
+    - IBM Maximo Application Suite Core Platform [v9.2.0](https://www.ibm.com/support/pages/node/7277376)
+    - IBM Maximo Manage [v9.2.0](https://www.ibm.com/support/pages/node/7276377)
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform [v9.0.27](https://www.ibm.com/support/pages/node/7277381) and [v9.1.19](https://www.ibm.com/support/pages/node/7277382)
+    - IBM Maximo Manage [v9.0.27](https://www.ibm.com/support/pages/node/7276396) and [v9.1.19](https://www.ibm.com/support/pages/node/7276393)
+    - IBM Truststore Manager v1.7
+    - IBM Suite License Service v3.13
+  known_issues:
+    - title: A known issue exists in the June 25, 2026 release affecting IBM Maximo Visual Inspection. Customers with MVI installed and using custom cluster issuer should avoid upgrading to the June release. Installation of MVI 9.2.x should be deferred until the July 2026 patch.
+    - title: A know issue exists in the June 25 2026 release when a customer has environment setup with mas core+manage+Optimizer with out AIP as a addon. Then under manage work space two pods will appear aipoptimization-uninstall and it will be in error status. Even though these pods are in error status it does not have any functional impact on manage or optimizer. The fix has been identified and will be delivered in upcoming July 9.2 patch.

--- a/src/mas/devops/data/catalogs/v9-260730-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-260730-s390x.yaml
@@ -1,0 +1,86 @@
+---
+# Case bundle configuration for IBM Maximo Operator Catalog 260625 (Z)
+# -----------------------------------------------------------------------------
+# In the future this won't be necessary as we'll be able to mirror from the
+# catalog itself, but not everything in the catalog supports this yet (including MAS)
+# so we need to use the CASE bundle mirror process still.
+
+catalog_digest: sha256:d044437a912032f3d436e498b8b629ed827ccfd80292efaaed62c7a7769e9c9d
+
+ocp_compatibility:
+- "4.16"
+- "4.17"
+- "4.18"
+- "4.19"
+- "4.20"
+- "4.21"
+
+# Dependencies - Db2u
+# -----------------------------------------------------------------------------
+db2u_version: 7.6.0+20260224.123157.19264        # Operator version 120104.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+
+db2_channel_default: v120104.0                   # Default Channel version for db2u-operator
+
+
+# Dependencies - UDS
+# -----------------------------------------------------------------------------
+uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
+uds_extras_version: 1.5.0                    # No Update
+
+
+# Dependencies - Suite License Service
+# -----------------------------------------------------------------------------
+# https://github.ibm.com/maximoappsuite/ibm-sls/releases
+sls_version: 3.13.0             # Updated
+
+
+# Dependencies - Truststore Manager
+# -----------------------------------------------------------------------------
+# https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases
+tsm_version: 1.7.7              # Updated
+
+
+# Dependencies - MongoDB
+# -----------------------------------------------------------------------------
+mongo_extras_version_default: 8.0.23
+mongo_extras_version_4: 4.4.21
+mongo_extras_version_5: 5.0.23
+mongo_extras_version_6: 6.0.12
+mongo_extras_version_7: 7.0.12
+mongo_extras_version_8: 8.0.23
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  9.2.x: 9.2.0                          # Updated
+  9.2.x-feature: 9.2.0                  # Updated
+  9.1.x: 9.1.19                         # Updated
+  9.0.x: 9.0.27                         # Updated
+  8.10.x: ""                            # Not Supported
+  8.11.x: ""                            # Not Supported
+mas_manage_version:
+  9.2.x: 9.2.0                          # Updated
+  9.2.x-feature: 9.2.0                  # Updated
+  9.1.x: 9.1.19                         # Updated
+  9.0.x: 9.0.27                         # Updated
+  8.10.x: ""                            # Not Supported
+  8.11.x: ""                            # Not Supported
+
+
+# Editorial
+# ------------------------------------------------------------------------------
+editorial:
+  whats_new:
+  - title: New feature release
+    details:
+    - IBM Maximo Application Suite Core Platform [v9.2.0](https://www.ibm.com/support/pages/node/7277376)
+    - IBM Maximo Manage [v9.2.0](https://www.ibm.com/support/pages/node/7276377)
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform [v9.0.27](https://www.ibm.com/support/pages/node/7277381) and [v9.1.19](https://www.ibm.com/support/pages/node/7277382)
+    - IBM Maximo Manage [v9.0.27](https://www.ibm.com/support/pages/node/7276396) and [v9.1.19](https://www.ibm.com/support/pages/node/7276393)
+    - IBM Truststore Manager v1.7
+    - IBM Suite License Service v3.13
+  known_issues:
+    - title: A known issue exists in the June 25, 2026 release affecting IBM Maximo Visual Inspection. Customers with MVI installed and using custom cluster issuer should avoid upgrading to the June release. Installation of MVI 9.2.x should be deferred until the July 2026 patch.
+    - title: A know issue exists in the June 25 2026 release when a customer has environment setup with mas core+manage+Optimizer with out AIP as a addon. Then under manage work space two pods will appear aipoptimization-uninstall and it will be in error status. Even though these pods are in error status it does not have any functional impact on manage or optimizer. The fix has been identified and will be delivered in upcoming July 9.2 patch.

--- a/test/src/test_data.py
+++ b/test/src/test_data.py
@@ -32,7 +32,7 @@ def test_list_catalogs():
 def test_get_newest_catalog_tag():
     catalogTag = getNewestCatalogTag("amd64")
     # Reminder: update this test when adding a new catalog each month!
-    assert catalogTag == "v9-260625-amd64"
+    assert catalogTag == "v9-260730-amd64"
 
 
 def test_get_newest_catalog_tag_fail():


### PR DESCRIPTION
## Description
Extending support to mongo patch version 8.0.23

## Test Results
Mongo installation, upgrade test successful. This chnage should be included in curate test
Refer Jira [MASCORE-14663](https://jsw.ibm.com/browse/MASCORE-14663)

Validated in July curated testing:
9.0.x-dev : [#3642](https://dashboard.ibmmas.com/tests/pfvtcurate/3642) 
9.1.x-dev : [#3658](https://dashboard.ibmmas.com/tests/pfvtcurate/3658) 
9.2.x-dev : [#3664](https://dashboard.ibmmas.com/tests/pfvtcurate/3664)
9.2.x-stable : [#3340](https://dashboard.ibmmas.com/tests/pfvtcurate/3340)  [#3657](https://dashboard.ibmmas.com/tests/pfvtcurate/3657)

NB: Depends on https://github.com/ibm-mas/ansible-devops/pull/2374