### PR TITLE
[patch] pipeline-db2-license secret not created when Slack is not configured Slack config

### DIFF
--- a/src/mas/devops/tekton.py
+++ b/src/mas/devops/tekton.py
@@ -983,15 +983,32 @@ def prepareUpdateSecrets(
         namespaceAPI = dynClient.resources.get(api_version="v1", kind="Namespace")
         namespaceAPI.get(name=namespace)
     except NotFoundError:
-        logger.warning(f"Namespace {namespace} does not exist, skipping slack secret creation")
-        return
-
-    # Only create secret if both slack_token and slack_channel are provided
-    if not slack_token or not slack_channel:
-        logger.debug("Slack token or channel not provided, skipping slack secret creation")
+        logger.warning(f"Namespace {namespace} does not exist, skipping secret creation")
         return
 
     secretsAPI = dynClient.resources.get(api_version="v1", kind="Secret")
+
+    # Always create pipeline-db2-license secret — required by the PipelineRun workspace
+    # binding regardless of whether a license file was provided or Slack is configured
+    try:
+        secretsAPI.delete(name="pipeline-db2-license", namespace=namespace)
+    except NotFoundError:
+        pass
+
+    if db2LicenseFile is None:
+        db2LicenseFile = {
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "type": "Opaque",
+            "metadata": {"name": "pipeline-db2-license"},
+        }
+    secretsAPI.create(body=db2LicenseFile, namespace=namespace)
+    logger.info(f"Created pipeline-db2-license secret in namespace {namespace}")
+
+    # Only create mas-devops-slack secret if both slack_token and slack_channel are provided
+    if not slack_token or not slack_channel:
+        logger.debug("Slack token or channel not provided, skipping slack secret creation")
+        return
 
     # Delete existing secret if it exists
     try:
@@ -1018,21 +1035,6 @@ def prepareUpdateSecrets(
 
     secretsAPI.create(body=mas_devops_secret, namespace=namespace)
     logger.info(f"Created mas-devops-slack secret in namespace {namespace}")
-
-    try:
-        secretsAPI.delete(name="pipeline-db2-license", namespace=namespace)
-    except NotFoundError:
-        pass
-
-    if db2LicenseFile is None:
-        db2LicenseFile = {
-            "apiVersion": "v1",
-            "kind": "Secret",
-            "type": "Opaque",
-            "metadata": {"name": "pipeline-db2-license"},
-        }
-    secretsAPI.create(body=db2LicenseFile, namespace=namespace)
-    logger.info(f"Created pipeline-db2-license secret in namespace {namespace}")
 
 
 def testCLI() -> None:


### PR DESCRIPTION
The prepareUpdateSecrets() function in tekton.py was introduced in PR #425 ("day2 fix for devops slack secret issue") which added an early return when slack_token or slack_channel are not provided. This inadvertently placed the pipeline-db2-license secret creation after the early return, meaning the secret was never created for users who do not have Slack configured.

The PipelineRun template (pipelinerun-update.yml.j2) unconditionally binds the shared-db2 workspace to secretName: pipeline-db2-license. When the secret does not exist, the update-db2 task pod is stuck in Init:0/2 with repeated FailedMount errors, blocking the entire mas-update pipeline run.

Fix: move pipeline-db2-license secret creation before the Slack guard so it is always created regardless of whether Slack credentials are provided.

Fixes: update-db2 pod stuck at Init:0/2 — FailedMount: secret "pipeline-db2-license" not found