### PR TITLE
[minor] param for operator customization file

### DIFF
--- a/src/mas/devops/templates/pipelinerun-install.yml.j2
+++ b/src/mas/devops/templates/pipelinerun-install.yml.j2
@@ -926,6 +926,10 @@ spec:
     - name: tenant_scheduling_cfg_file
       value: "{{ tenant_scheduling_config_file }}"
 {%- endif %}
+{%- if tenant_operator_config_file is defined and tenant_operator_config_file != "" %}
+    - name: tenant_operator_cfg_file
+      value: "{{ tenant_operator_config_file }}"
+{%- endif %}
 
 {%- if rsl_ca_crt is defined and rsl_ca_crt != "" %}
     # RSL - CA Certificate


### PR DESCRIPTION
## Issue
MASAIB-2648

## Description
Param for setting the params file for customizing the AI Service tenant operator.

## Test Results
Triggered a deployment with the CLI and confirmed that the new parameter is correctly passed to the PipelineRun when instantiated in the cluster:

<img width="494" height="571" alt="Screenshot 2026-08-05 at 13 38 46" src="https://github.com/user-attachments/assets/f9fe482e-56c5-4a78-8156-e41edb7bec88" />

