### PR TITLE
[minor] Support August Interim Catalog Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,4 +89,3 @@ Example of initial_users secret:
 ```json
 {"john.smith1@example.com":"primary,john1,smith1","john.smith2@example.com":"primary,john2,smith2","john.smith3@example.com":"secondary,john3,smith3"}
 ```
-

--- a/src/mas/devops/data/catalogs/v9-260805-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260805-amd64.yaml
@@ -118,15 +118,15 @@ redis_extras_version: 2.1.40             # No Update
 # Maximo Application Suite
 # -----------------------------------------------------------------------------
 mas_core_version:
-  9.2.x: 9.2.1                          # Updated
+  9.2.x: 9.2.2                          # Updated
   9.2.x-feature: 9.2.0                  # No Update
-  9.1.x: 9.1.20                         # Updated
-  9.0.x: 9.0.28                         # Updated
+  9.1.x: 9.1.20                         # No Update
+  9.0.x: 9.0.28                         # No Update
   8.10.x: 8.10.37                       # No Update
   8.11.x: 8.11.34                       # No Update
 mas_assist_version:
-  9.1.x: 9.1.13                         # Updated
-  9.0.x: 9.0.19                         # Updated
+  9.1.x: 9.1.13                         # No Update
+  9.0.x: 9.0.19                         # No Update
   8.10.x: 8.7.8                         # No Update
   8.11.x: 8.8.7                         # No Update
 mas_hputilities_version:
@@ -135,51 +135,51 @@ mas_hputilities_version:
   8.10.x: 8.6.7                         # No Update
   8.11.x: ""                            # Not Supported
 mas_iot_version:
-  9.2.x: 9.2.1                          # Updated
+  9.2.x: 9.2.1                          # No Update
   9.2.x-feature: 9.2.0                  # No Update
-  9.1.x: 9.1.13                         # Updated
-  9.0.x: 9.0.22                         # Updated
+  9.1.x: 9.1.13                         # No Update
+  9.0.x: 9.0.22                         # No Update
   8.10.x: 8.7.33                        # No Update
   8.11.x: 8.8.30                        # No Update
 mas_manage_version:
-  9.2.x: 9.2.1                          # Updated
+  9.2.x: 9.2.1                          # No Update
   9.2.x-feature: 9.2.0                  # No Update
-  9.1.x: 9.1.20                         # Updated
-  9.0.x: 9.0.28                         # Updated
+  9.1.x: 9.1.20                         # No Update
+  9.0.x: 9.0.28                         # No Update
   8.10.x: 8.6.38                        # No Update
   8.11.x: 8.7.32                        # No Update
 mas_monitor_version:
-  9.2.x: 9.2.1                          # Updated
+  9.2.x: 9.2.1                          # No Update
   9.2.x-feature: 9.2.0                  # No Update
-  9.1.x: 9.1.13                         # Updated
-  9.0.x: 9.0.23                         # Updated
+  9.1.x: 9.1.13                         # No Update
+  9.0.x: 9.0.23                         # No Update
   8.10.x: 8.10.30                       # No Update
   8.11.x: 8.11.28                       # No Update
 mas_optimizer_version:
-  9.2.x: 9.2.1                          # Updated
+  9.2.x: 9.2.1                          # No Update
   9.2.x-feature: 9.2.0                  # No Update
-  9.1.x: 9.1.14                         # Updated
-  9.0.x: 9.0.25                         # Updated
+  9.1.x: 9.1.14                         # No Update
+  9.0.x: 9.0.25                         # No Update
   8.10.x: 8.4.28                        # No Update
   8.11.x: 8.5.28                        # No Update
 mas_predict_version:
-  9.2.x: 9.2.1                          # Updated
+  9.2.x: 9.2.1                          # No Update
   9.2.x-feature: 9.2.0                  # No Update
-  9.1.x: 9.1.10                         # Updated
-  9.0.x: 9.0.17                         # Updated
+  9.1.x: 9.1.10                         # No Update
+  9.0.x: 9.0.17                         # No Update
   8.10.x: 8.8.15                        # No Update
   8.11.x: 8.9.17                        # No Update
 mas_visualinspection_version:
-  9.2.x: 9.2.1                          # Updated
+  9.2.x: 9.2.1                          # No Update
   9.2.x-feature: 9.2.0                  # No Update
-  9.1.x: 9.1.19                         # Updated
-  9.0.x: 9.0.22                         # Updated
+  9.1.x: 9.1.19                         # No Update
+  9.0.x: 9.0.22                         # No Update
   8.10.x: 8.8.4                         # No Update
   8.11.x: 8.9.21                        # No Update
 mas_facilities_version:
-  9.2.x: 9.2.1                          # Updated
+  9.2.x: 9.2.1                          # No Update
   9.2.x-feature: 9.2.0                  # No Update
-  9.1.x: 9.1.13                         # Updated
+  9.1.x: 9.1.13                         # No Update
   9.0.x: ""                             # Not Supported
   8.10.x: ""                            # Not Supported
   8.11.x: ""                            # Not Supported
@@ -188,12 +188,12 @@ mas_facilities_version:
 # Maximo AI Service
 # ------------------------------------------------------------------------------
 aiservice_version:
-  9.2.x: 9.2.1                          # Updated
+  9.2.x: 9.2.1                          # No Update
   9.2.x-feature: 9.2.0                  # No Update
-  9.1.x: 9.1.17                         # Updated
+  9.1.x: 9.1.17                         # No Update
 
 aiservice_tenant_version:
-  9.2.x: 9.2.1                          # Updated
+  9.2.x: 9.2.1                          # No Update
   9.2.x-feature: 9.2.0                  # No Update
 
 
@@ -203,15 +203,4 @@ editorial:
   whats_new:
   - title: '**Security updates and bug fixes**'
     details:
-    - IBM Maximo Application Suite Core Platform [v9.0.28](https://www.ibm.com/support/pages/node/7281592), [v9.1.20](https://www.ibm.com/support/pages/node/7281593) and [v9.2.1](https://www.ibm.com/support/pages/node/7281594)
-    - IBM Maximo Manage [v9.0.28](https://www.ibm.com/support/pages/node/7281106),[v9.1.20](https://www.ibm.com/support/pages/node/7281105) and [v9.2.1](https://www.ibm.com/support/pages/node/7276395)
-    - IBM Maximo IoT [v9.0.22](https://www.ibm.com/support/pages/node/7281365) ,[v9.1.13](https://www.ibm.com/support/pages/node/7281366)
-    - IBM Maximo Monitor [v9.0.23](https://www.ibm.com/support/pages/node/7280601),[v9.1.13](https://www.ibm.com/support/pages/node/7280594) and [v9.2.1](https://www.ibm.com/support/pages/node/7280603)
-    - IBM Maximo Optimizer [v9.0.25](https://www.ibm.com/support/pages/node/7276568),[v9.1.14](https://www.ibm.com/support/pages/node/7280908), [v9.2.1](https://www.ibm.com/support/pages/node/7280906)
-    - IBM Maximo Assist/Collaborate [v9.0.19](https://www.ibm.com/support/pages/node/7281391), [v9.1.13](https://www.ibm.com/support/pages/node/7281392)
-    - IBM Maximo Predict [v9.0.17](https://www.ibm.com/support/pages/node/7280608), [v9.1.10](https://www.ibm.com/support/pages/node/7280609) and [v9.2.1](https://www.ibm.com/support/pages/node/7280611)
-    - IBM Maximo Visual Inspection [v9.0.22](https://www.ibm.com/support/pages/node/7281598),[v9.1.19](https://www.ibm.com/support/pages/node/7281597) and [v9.2.1](https://www.ibm.com/support/pages/node/7281599)
-    - IBM Maximo Real Estate and Facilities [v9.1.13](https://www.ibm.com/support/pages/node/7281077) and [v9.2.1](https://www.ibm.com/support/pages/node/7281367)
-    - IBM Maximo AI Service [v9.1.17](https://www.ibm.com/support/pages/node/7280919) and [v9.2.1](https://www.ibm.com/support/pages/node/7280920)
-  known_issues:
-    - title: A known issue exists in the 9.0.x release affecting IBM Maximo Manage customers upgrading from 8.7.x to 9.0.x with the Civil component and Image Stitching deployed; the Image Stitching CR will not recover post-upgrade without manual intervention. To recover, patch the ManageWorkspace CR with kubectl -n mas-{instanceId}-manage patch manageworkspace {instanceId}-{workspaceId} --type merge -p '{"spec":{"components":{"civil":{"imagestitchingpvcname":"imagestitching-pvc-in"}}}}', replacing imagestitching-pvc-in with the value obtained by running kubectl -n mas-{instanceId}-manage get pvc -l app.kubernetes.io/component=imagestitching-api and stripping the {instanceId}-{workspaceId}- prefix from the returned PVC name.
+    - IBM Maximo Application Suite Core Platform v9.2.2

--- a/src/mas/devops/data/catalogs/v9-260805-amd64.yaml
+++ b/src/mas/devops/data/catalogs/v9-260805-amd64.yaml
@@ -1,0 +1,217 @@
+---
+# Case bundle configuration for IBM Maximo Operator Catalog 260805 (AMD64)
+# -----------------------------------------------------------------------------
+# In the future this won't be necessary as we'll be able to mirror from the
+# catalog itself, but not everything in the catalog supports this yet (including MAS)
+# so we need to use the CASE bundle mirror process still.
+
+catalog_digest: sha256:b26345aa36372f7cb283ab67fcdb0a432bd6b1c0fa1c06469547f81c33ad7a7c
+
+ocp_compatibility:
+- "4.16"
+- "4.17"
+- "4.18"
+- "4.19"
+- "4.20"
+- "4.21"
+
+# Dependencies - Cloud Pak for Data
+# -----------------------------------------------------------------------------
+cpd_product_version_default: 5.2.0       # No Update
+
+ibm_licensing_version: 4.2.17                    # Operator version 4.2.14 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-licensing)
+common_svcs_version: 4.13.0                      # Operator version 4.13.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+#common_svcs_version_1: 4.11.0                   # Additional version 4.11.0
+cp4d_platform_version: 5.2.0+20250709.170324     # Operator version 5.2.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-datacore/)
+ibm_zen_version: 6.2.0+20250530.152516.232       # For CPD5 ibm-zen has to be explicitily mirrored
+wsl_version: 11.0.0+20250521.202913.73           # used for wsl and wsl_runtimes unless wsl_runtimes_version also specified
+wsl_runtimes_version: 11.0.0+20250515.090949.21  # cpd 5.1.3 uses version 10.3.0 of wsl runtimes but only 10.2.0 for wsl itself
+wml_version: 11.0.0+20250530.193146.282          # Operator version 5.2.0
+spark_version: 11.0.0+20250604.163055.2097       # Operator version 5.2.0
+cognos_version: 28.0.0+20250515.175459.10054     # Operator version 25.0.0
+
+postgress_version: 5.16.0+20250827.110911.2626   # ibm-cpd-cloud-native-postgresql-operator 5.2.0 cp4d
+ccs_build: 11.0.0+20250605.130237.468            # cpd 5.2.0 using ccs build
+ccs_extras_version: 11.0.0                       # Extra Images for CCS used for PCD 5.2.0 Hotfix
+
+elasticsearch_version: 1.1.2667                  # Operator version 1.1.2667 # used in cpd 5.1.3 only
+opensearch_version: 1.1.2494                     # Operator version 1.1.2494
+
+# I have added this as a guess as to the actual version used, we are currently using the wsl_version, but that does not exist for datarefinery
+# See: https://ibm-mas.slack.com/archives/C02PUHKQB5L/p1770849370378689
+datarefinery_version: 11.0.0+20250513.203727.232
+
+
+# Dependencies - Db2u
+# -----------------------------------------------------------------------------
+db2u_version: 7.6.0+20260224.123157.19264        # Operator version 120104.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+db2u_extras_version: 1.0.6                       # No Update
+db2u_filter: db2
+
+db2_channel_default: v120104.0                   # Default Channel version for db2u-operator
+
+
+# Dependencies - CouchDb
+# -----------------------------------------------------------------------------
+# Note: This is required for Assist 9.0 (https://github.com/IBM/cloud-pak/blob/master/repo/case/ibm-couchdb/index.yaml)
+couchdb_version: 1.0.13  # Operator version 2.2.1 (1.0.13) sticking with 1.0.13
+
+
+# Dependencies - Minio
+# -----------------------------------------------------------------------------
+minio_version: RELEASE.2025-06-13T11-33-47Z
+minio_extras_version: 1.0.0
+
+# Dependencies - MongoDB
+# -----------------------------------------------------------------------------
+mongo_extras_version_default: 8.0.23
+mongo_extras_version_4: 4.4.21
+mongo_extras_version_5: 5.0.23
+mongo_extras_version_6: 6.0.12
+mongo_extras_version_7: 7.0.23
+mongo_extras_version_8: 8.0.23
+
+
+# Dependencies - Amlen
+# -----------------------------------------------------------------------------
+amlen_extras_version: 1.1.5              # No Update
+
+
+# Dependencies - UDS
+# -----------------------------------------------------------------------------
+uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
+uds_extras_version: 1.5.0
+
+
+# Dependencies - App Connect
+# -----------------------------------------------------------------------------
+appconnect_version: 6.2.0                    # Operator version 6.2.0 # sticking to 6.2.0 version # Please do Not Change
+
+
+# Dependencies - Suite License Service
+# -----------------------------------------------------------------------------
+# https://github.ibm.com/maximoappsuite/ibm-sls/releases
+sls_version: 3.13.0             # No Update
+
+
+# Dependencies - Truststore Manager
+# -----------------------------------------------------------------------------
+# https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases
+tsm_version: 1.7.7              # No Update
+
+
+# Dependencies - Data Dictionary
+# -----------------------------------------------------------------------------
+# https://github.ibm.com/maximoappsuite/ibm-data-dictionary/releases
+dd_version: 1.1.23              # No Update
+
+# Dependencies - Opendata hub
+# -----------------------------------------------------------------------------
+# https://github.com/opendatahub-io/opendatahub-operator/releases
+odh_version: 2.32.0
+
+# Extra Images for Redis (Collaborate)
+# ------------------------------------------------------------------------------
+redis_extras_version: 2.1.40             # No Update
+
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  9.2.x: 9.2.1                          # Updated
+  9.2.x-feature: 9.2.0                  # No Update
+  9.1.x: 9.1.20                         # Updated
+  9.0.x: 9.0.28                         # Updated
+  8.10.x: 8.10.37                       # No Update
+  8.11.x: 8.11.34                       # No Update
+mas_assist_version:
+  9.1.x: 9.1.13                         # Updated
+  9.0.x: 9.0.19                         # Updated
+  8.10.x: 8.7.8                         # No Update
+  8.11.x: 8.8.7                         # No Update
+mas_hputilities_version:
+  9.1.x: ""                             # Not Supported
+  9.0.x: ""                             # Not Supported
+  8.10.x: 8.6.7                         # No Update
+  8.11.x: ""                            # Not Supported
+mas_iot_version:
+  9.2.x: 9.2.1                          # Updated
+  9.2.x-feature: 9.2.0                  # No Update
+  9.1.x: 9.1.13                         # Updated
+  9.0.x: 9.0.22                         # Updated
+  8.10.x: 8.7.33                        # No Update
+  8.11.x: 8.8.30                        # No Update
+mas_manage_version:
+  9.2.x: 9.2.1                          # Updated
+  9.2.x-feature: 9.2.0                  # No Update
+  9.1.x: 9.1.20                         # Updated
+  9.0.x: 9.0.28                         # Updated
+  8.10.x: 8.6.38                        # No Update
+  8.11.x: 8.7.32                        # No Update
+mas_monitor_version:
+  9.2.x: 9.2.1                          # Updated
+  9.2.x-feature: 9.2.0                  # No Update
+  9.1.x: 9.1.13                         # Updated
+  9.0.x: 9.0.23                         # Updated
+  8.10.x: 8.10.30                       # No Update
+  8.11.x: 8.11.28                       # No Update
+mas_optimizer_version:
+  9.2.x: 9.2.1                          # Updated
+  9.2.x-feature: 9.2.0                  # No Update
+  9.1.x: 9.1.14                         # Updated
+  9.0.x: 9.0.25                         # Updated
+  8.10.x: 8.4.28                        # No Update
+  8.11.x: 8.5.28                        # No Update
+mas_predict_version:
+  9.2.x: 9.2.1                          # Updated
+  9.2.x-feature: 9.2.0                  # No Update
+  9.1.x: 9.1.10                         # Updated
+  9.0.x: 9.0.17                         # Updated
+  8.10.x: 8.8.15                        # No Update
+  8.11.x: 8.9.17                        # No Update
+mas_visualinspection_version:
+  9.2.x: 9.2.1                          # Updated
+  9.2.x-feature: 9.2.0                  # No Update
+  9.1.x: 9.1.19                         # Updated
+  9.0.x: 9.0.22                         # Updated
+  8.10.x: 8.8.4                         # No Update
+  8.11.x: 8.9.21                        # No Update
+mas_facilities_version:
+  9.2.x: 9.2.1                          # Updated
+  9.2.x-feature: 9.2.0                  # No Update
+  9.1.x: 9.1.13                         # Updated
+  9.0.x: ""                             # Not Supported
+  8.10.x: ""                            # Not Supported
+  8.11.x: ""                            # Not Supported
+
+
+# Maximo AI Service
+# ------------------------------------------------------------------------------
+aiservice_version:
+  9.2.x: 9.2.1                          # Updated
+  9.2.x-feature: 9.2.0                  # No Update
+  9.1.x: 9.1.17                         # Updated
+
+aiservice_tenant_version:
+  9.2.x: 9.2.1                          # Updated
+  9.2.x-feature: 9.2.0                  # No Update
+
+
+# Editorial
+# ------------------------------------------------------------------------------
+editorial:
+  whats_new:
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform [v9.0.28](https://www.ibm.com/support/pages/node/7281592), [v9.1.20](https://www.ibm.com/support/pages/node/7281593) and [v9.2.1](https://www.ibm.com/support/pages/node/7281594)
+    - IBM Maximo Manage [v9.0.28](https://www.ibm.com/support/pages/node/7281106),[v9.1.20](https://www.ibm.com/support/pages/node/7281105) and [v9.2.1](https://www.ibm.com/support/pages/node/7276395)
+    - IBM Maximo IoT [v9.0.22](https://www.ibm.com/support/pages/node/7281365) ,[v9.1.13](https://www.ibm.com/support/pages/node/7281366)
+    - IBM Maximo Monitor [v9.0.23](https://www.ibm.com/support/pages/node/7280601),[v9.1.13](https://www.ibm.com/support/pages/node/7280594) and [v9.2.1](https://www.ibm.com/support/pages/node/7280603)
+    - IBM Maximo Optimizer [v9.0.25](https://www.ibm.com/support/pages/node/7276568),[v9.1.14](https://www.ibm.com/support/pages/node/7280908), [v9.2.1](https://www.ibm.com/support/pages/node/7280906)
+    - IBM Maximo Assist/Collaborate [v9.0.19](https://www.ibm.com/support/pages/node/7281391), [v9.1.13](https://www.ibm.com/support/pages/node/7281392)
+    - IBM Maximo Predict [v9.0.17](https://www.ibm.com/support/pages/node/7280608), [v9.1.10](https://www.ibm.com/support/pages/node/7280609) and [v9.2.1](https://www.ibm.com/support/pages/node/7280611)
+    - IBM Maximo Visual Inspection [v9.0.22](https://www.ibm.com/support/pages/node/7281598),[v9.1.19](https://www.ibm.com/support/pages/node/7281597) and [v9.2.1](https://www.ibm.com/support/pages/node/7281599)
+    - IBM Maximo Real Estate and Facilities [v9.1.13](https://www.ibm.com/support/pages/node/7281077) and [v9.2.1](https://www.ibm.com/support/pages/node/7281367)
+    - IBM Maximo AI Service [v9.1.17](https://www.ibm.com/support/pages/node/7280919) and [v9.2.1](https://www.ibm.com/support/pages/node/7280920)
+  known_issues:
+    - title: A known issue exists in the 9.0.x release affecting IBM Maximo Manage customers upgrading from 8.7.x to 9.0.x with the Civil component and Image Stitching deployed; the Image Stitching CR will not recover post-upgrade without manual intervention. To recover, patch the ManageWorkspace CR with kubectl -n mas-{instanceId}-manage patch manageworkspace {instanceId}-{workspaceId} --type merge -p '{"spec":{"components":{"civil":{"imagestitchingpvcname":"imagestitching-pvc-in"}}}}', replacing imagestitching-pvc-in with the value obtained by running kubectl -n mas-{instanceId}-manage get pvc -l app.kubernetes.io/component=imagestitching-api and stripping the {instanceId}-{workspaceId}- prefix from the returned PVC name.

--- a/src/mas/devops/data/catalogs/v9-260805-ppc64le.yaml
+++ b/src/mas/devops/data/catalogs/v9-260805-ppc64le.yaml
@@ -52,17 +52,17 @@ mongo_extras_version_8: 8.0.23
 # Maximo Application Suite
 # -----------------------------------------------------------------------------
 mas_core_version:
-  9.2.x: 9.2.1                          # Updated
+  9.2.x: 9.2.2                          # Updated
   9.2.x-feature: 9.2.0                  # No Update
-  9.1.x: 9.1.20                         # Updated
-  9.0.x: 9.0.28                         # Updated
+  9.1.x: 9.1.20                         # No Update
+  9.0.x: 9.0.28                         # No Update
   8.10.x: ""                            # Not Supported
   8.11.x: ""                            # Not Supported
 mas_manage_version:
-  9.2.x: 9.2.1                          # Updated
+  9.2.x: 9.2.1                          # No Update
   9.2.x-feature: 9.2.0                  # No Update
-  9.1.x: 9.1.20                         # Updated
-  9.0.x: 9.0.28                         # Updated
+  9.1.x: 9.1.20                         # No Update
+  9.0.x: 9.0.28                         # No Update
   8.10.x: ""                            # Not Supported
   8.11.x: ""                            # Not Supported
 
@@ -73,7 +73,4 @@ editorial:
   whats_new:
   - title: '**Security updates and bug fixes**'
     details:
-    - IBM Maximo Application Suite Core Platform [v9.0.28](https://www.ibm.com/support/pages/node/7281592), [v9.1.20](https://www.ibm.com/support/pages/node/7281593) and [v9.2.1](https://www.ibm.com/support/pages/node/7281594)
-    - IBM Maximo Manage [v9.0.28](https://www.ibm.com/support/pages/node/7281106),[v9.1.20](https://www.ibm.com/support/pages/node/7281105) and [v9.2.1](https://www.ibm.com/support/pages/node/7276395)
-  known_issues:
-    - title: A known issue exists in the 9.0.x release affecting IBM Maximo Manage customers upgrading from 8.7.x to 9.0.x with the Civil component and Image Stitching deployed; the Image Stitching CR will not recover post-upgrade without manual intervention. To recover, patch the ManageWorkspace CR with kubectl -n mas-{instanceId}-manage patch manageworkspace {instanceId}-{workspaceId} --type merge -p '{"spec":{"components":{"civil":{"imagestitchingpvcname":"imagestitching-pvc-in"}}}}', replacing imagestitching-pvc-in with the value obtained by running kubectl -n mas-{instanceId}-manage get pvc -l app.kubernetes.io/component=imagestitching-api and stripping the {instanceId}-{workspaceId}- prefix from the returned PVC name.
+    - IBM Maximo Application Suite Core Platform v9.2.2

--- a/src/mas/devops/data/catalogs/v9-260805-ppc64le.yaml
+++ b/src/mas/devops/data/catalogs/v9-260805-ppc64le.yaml
@@ -1,0 +1,79 @@
+---
+# Case bundle configuration for IBM Maximo Operator Catalog 260805 (PPC)
+# -----------------------------------------------------------------------------
+# In the future this won't be necessary as we'll be able to mirror from the
+# catalog itself, but not everything in the catalog supports this yet (including MAS)
+# so we need to use the CASE bundle mirror process still.
+
+catalog_digest: sha256:f007008fbe4bdf379dde5e2ff6f34f993861305e4f8b4726ce964aa5d135fa87
+
+ocp_compatibility:
+- "4.16"
+- "4.17"
+- "4.18"
+- "4.19"
+- "4.20"
+- "4.21"
+
+# Dependencies - Db2u
+# -----------------------------------------------------------------------------
+db2u_version: 7.6.0+20260224.123157.19264        # Operator version 120104.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+
+db2_channel_default: v120104.0                   # Default Channel version for db2u-operator
+
+
+# Dependencies - UDS
+# -----------------------------------------------------------------------------
+uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
+uds_extras_version: 1.5.0                    # No Update
+
+
+# Dependencies - Suite License Service
+# -----------------------------------------------------------------------------
+# https://github.ibm.com/maximoappsuite/ibm-sls/releases
+sls_version: 3.13.0             # No Update
+
+
+# Dependencies - Truststore Manager
+# -----------------------------------------------------------------------------
+# https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases
+tsm_version: 1.7.7              # No Update
+
+
+# Dependencies - MongoDB
+# -----------------------------------------------------------------------------
+mongo_extras_version_default: 8.0.23
+mongo_extras_version_4: 4.4.21
+mongo_extras_version_5: 5.0.23
+mongo_extras_version_6: 6.0.12
+mongo_extras_version_7: 7.0.12
+mongo_extras_version_8: 8.0.23
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  9.2.x: 9.2.1                          # Updated
+  9.2.x-feature: 9.2.0                  # No Update
+  9.1.x: 9.1.20                         # Updated
+  9.0.x: 9.0.28                         # Updated
+  8.10.x: ""                            # Not Supported
+  8.11.x: ""                            # Not Supported
+mas_manage_version:
+  9.2.x: 9.2.1                          # Updated
+  9.2.x-feature: 9.2.0                  # No Update
+  9.1.x: 9.1.20                         # Updated
+  9.0.x: 9.0.28                         # Updated
+  8.10.x: ""                            # Not Supported
+  8.11.x: ""                            # Not Supported
+
+
+# Editorial
+# ------------------------------------------------------------------------------
+editorial:
+  whats_new:
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform [v9.0.28](https://www.ibm.com/support/pages/node/7281592), [v9.1.20](https://www.ibm.com/support/pages/node/7281593) and [v9.2.1](https://www.ibm.com/support/pages/node/7281594)
+    - IBM Maximo Manage [v9.0.28](https://www.ibm.com/support/pages/node/7281106),[v9.1.20](https://www.ibm.com/support/pages/node/7281105) and [v9.2.1](https://www.ibm.com/support/pages/node/7276395)
+  known_issues:
+    - title: A known issue exists in the 9.0.x release affecting IBM Maximo Manage customers upgrading from 8.7.x to 9.0.x with the Civil component and Image Stitching deployed; the Image Stitching CR will not recover post-upgrade without manual intervention. To recover, patch the ManageWorkspace CR with kubectl -n mas-{instanceId}-manage patch manageworkspace {instanceId}-{workspaceId} --type merge -p '{"spec":{"components":{"civil":{"imagestitchingpvcname":"imagestitching-pvc-in"}}}}', replacing imagestitching-pvc-in with the value obtained by running kubectl -n mas-{instanceId}-manage get pvc -l app.kubernetes.io/component=imagestitching-api and stripping the {instanceId}-{workspaceId}- prefix from the returned PVC name.

--- a/src/mas/devops/data/catalogs/v9-260805-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-260805-s390x.yaml
@@ -52,17 +52,17 @@ mongo_extras_version_8: 8.0.23
 # Maximo Application Suite
 # -----------------------------------------------------------------------------
 mas_core_version:
-  9.2.x: 9.2.1                          # Updated
+  9.2.x: 9.2.2                          # Updated
   9.2.x-feature: 9.2.0                  # No Update
-  9.1.x: 9.1.20                         # Updated
-  9.0.x: 9.0.28                         # Updated
+  9.1.x: 9.1.20                         # No Update
+  9.0.x: 9.0.28                         # No Update
   8.10.x: ""                            # Not Supported
   8.11.x: ""                            # Not Supported
 mas_manage_version:
   9.2.x: 9.2.1                          # Updated
   9.2.x-feature: 9.2.0                  # No Update
-  9.1.x: 9.1.20                         # Updated
-  9.0.x: 9.0.28                         # Updated
+  9.1.x: 9.1.20                         # No Update
+  9.0.x: 9.0.28                         # No Update
   8.10.x: ""                            # Not Supported
   8.11.x: ""                            # Not Supported
 
@@ -73,7 +73,4 @@ editorial:
   whats_new:
   - title: '**Security updates and bug fixes**'
     details:
-    - IBM Maximo Application Suite Core Platform [v9.0.28](https://www.ibm.com/support/pages/node/7281592), [v9.1.20](https://www.ibm.com/support/pages/node/7281593) and [v9.2.1](https://www.ibm.com/support/pages/node/7281594)
-    - IBM Maximo Manage [v9.0.28](https://www.ibm.com/support/pages/node/7281106),[v9.1.20](https://www.ibm.com/support/pages/node/7281105) and [v9.2.1](https://www.ibm.com/support/pages/node/7276395)
-  known_issues:
-    - title: A known issue exists in the 9.0.x release affecting IBM Maximo Manage customers upgrading from 8.7.x to 9.0.x with the Civil component and Image Stitching deployed; the Image Stitching CR will not recover post-upgrade without manual intervention. To recover, patch the ManageWorkspace CR with kubectl -n mas-{instanceId}-manage patch manageworkspace {instanceId}-{workspaceId} --type merge -p '{"spec":{"components":{"civil":{"imagestitchingpvcname":"imagestitching-pvc-in"}}}}', replacing imagestitching-pvc-in with the value obtained by running kubectl -n mas-{instanceId}-manage get pvc -l app.kubernetes.io/component=imagestitching-api and stripping the {instanceId}-{workspaceId}- prefix from the returned PVC name.
+    - IBM Maximo Application Suite Core Platform v9.2.2

--- a/src/mas/devops/data/catalogs/v9-260805-s390x.yaml
+++ b/src/mas/devops/data/catalogs/v9-260805-s390x.yaml
@@ -1,0 +1,79 @@
+---
+# Case bundle configuration for IBM Maximo Operator Catalog 260805 (Z)
+# -----------------------------------------------------------------------------
+# In the future this won't be necessary as we'll be able to mirror from the
+# catalog itself, but not everything in the catalog supports this yet (including MAS)
+# so we need to use the CASE bundle mirror process still.
+
+catalog_digest: sha256:18ac825b6758c7cc4e0e4e88dd2c57dd59595bf3a4870b8c59c6d92df63d8a6f
+
+ocp_compatibility:
+- "4.16"
+- "4.17"
+- "4.18"
+- "4.19"
+- "4.20"
+- "4.21"
+
+# Dependencies - Db2u
+# -----------------------------------------------------------------------------
+db2u_version: 7.6.0+20260224.123157.19264        # Operator version 120104.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+
+db2_channel_default: v120104.0                   # Default Channel version for db2u-operator
+
+
+# Dependencies - UDS
+# -----------------------------------------------------------------------------
+uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
+uds_extras_version: 1.5.0                    # No Update
+
+
+# Dependencies - Suite License Service
+# -----------------------------------------------------------------------------
+# https://github.ibm.com/maximoappsuite/ibm-sls/releases
+sls_version: 3.13.0             # No Update
+
+
+# Dependencies - Truststore Manager
+# -----------------------------------------------------------------------------
+# https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases
+tsm_version: 1.7.7              # No Update
+
+
+# Dependencies - MongoDB
+# -----------------------------------------------------------------------------
+mongo_extras_version_default: 8.0.23
+mongo_extras_version_4: 4.4.21
+mongo_extras_version_5: 5.0.23
+mongo_extras_version_6: 6.0.12
+mongo_extras_version_7: 7.0.12
+mongo_extras_version_8: 8.0.23
+
+# Maximo Application Suite
+# -----------------------------------------------------------------------------
+mas_core_version:
+  9.2.x: 9.2.1                          # Updated
+  9.2.x-feature: 9.2.0                  # No Update
+  9.1.x: 9.1.20                         # Updated
+  9.0.x: 9.0.28                         # Updated
+  8.10.x: ""                            # Not Supported
+  8.11.x: ""                            # Not Supported
+mas_manage_version:
+  9.2.x: 9.2.1                          # Updated
+  9.2.x-feature: 9.2.0                  # No Update
+  9.1.x: 9.1.20                         # Updated
+  9.0.x: 9.0.28                         # Updated
+  8.10.x: ""                            # Not Supported
+  8.11.x: ""                            # Not Supported
+
+
+# Editorial
+# ------------------------------------------------------------------------------
+editorial:
+  whats_new:
+  - title: '**Security updates and bug fixes**'
+    details:
+    - IBM Maximo Application Suite Core Platform [v9.0.28](https://www.ibm.com/support/pages/node/7281592), [v9.1.20](https://www.ibm.com/support/pages/node/7281593) and [v9.2.1](https://www.ibm.com/support/pages/node/7281594)
+    - IBM Maximo Manage [v9.0.28](https://www.ibm.com/support/pages/node/7281106),[v9.1.20](https://www.ibm.com/support/pages/node/7281105) and [v9.2.1](https://www.ibm.com/support/pages/node/7276395)
+  known_issues:
+    - title: A known issue exists in the 9.0.x release affecting IBM Maximo Manage customers upgrading from 8.7.x to 9.0.x with the Civil component and Image Stitching deployed; the Image Stitching CR will not recover post-upgrade without manual intervention. To recover, patch the ManageWorkspace CR with kubectl -n mas-{instanceId}-manage patch manageworkspace {instanceId}-{workspaceId} --type merge -p '{"spec":{"components":{"civil":{"imagestitchingpvcname":"imagestitching-pvc-in"}}}}', replacing imagestitching-pvc-in with the value obtained by running kubectl -n mas-{instanceId}-manage get pvc -l app.kubernetes.io/component=imagestitching-api and stripping the {instanceId}-{workspaceId}- prefix from the returned PVC name.

--- a/test/src/test_data.py
+++ b/test/src/test_data.py
@@ -32,7 +32,7 @@ def test_list_catalogs():
 def test_get_newest_catalog_tag():
     catalogTag = getNewestCatalogTag("amd64")
     # Reminder: update this test when adding a new catalog each month!
-    assert catalogTag == "v9-260730-amd64"
+    assert catalogTag == "v9-260805-amd64"
 
 
 def test_get_newest_catalog_tag_fail():


### PR DESCRIPTION
Deliver interim catalog v9-260805-amd64 including MAS Core 9.2.2 release for MetaAgent 1.0.2 update

MetaAgent version 1.0.2 was missed in the July MAS Core 9.2.1 release. To avoid waiting for the next planned release cycle, an interim MAS Core 9.2.2 release is being created to deliver this missing update.

Jira: https://jsw.ibm.com/browse/MASCORE-16035


Catalog pr: https://github.ibm.com/maximoappsuite/ibm-maximo-operator-catalog/pull/1090